### PR TITLE
Extended testing

### DIFF
--- a/cognite/neat/core/loader/graph_store.py
+++ b/cognite/neat/core/loader/graph_store.py
@@ -100,6 +100,7 @@ class NeatGraphStore:
             logging.info("Initializing Oxigraph store")
             # Adding support for both in-memory and file-based storage
             oxstore = None
+            self.internal_storage_dir.mkdir(parents=True, exist_ok=True)
             for i in range(4):
                 try:
                     oxstore = pyoxigraph.Store(

--- a/cognite/neat/examples/workflows/fast_graph/workflow.yaml
+++ b/cognite/neat/examples/workflows/fast_graph/workflow.yaml
@@ -272,7 +272,7 @@ steps:
         pos_x: 114
         pos_y: 874
 -   description: Upload CDF labels
-    enabled: false
+    enabled: true
     group_id: null
     id: create_cdf_labels
     label: Upload CDF labels

--- a/tests/api/test_workflows.py
+++ b/tests/api/test_workflows.py
@@ -56,9 +56,9 @@ def test_run_default_workflow(
         # When running this test in GitHub actions, you get permission issues with the default disk_store_dir.
         response = fastapi_client.get("/api/workflow/workflow-definition/fast_graph")
         definition = WorkflowDefinition(**response.json()["definition"])
-        source = next(config for config in definition.configs if config.name == "source_rdf_store.disk_store_dir")
+        source = next(c for c in definition.configs if c.name == "source_rdf_store.disk_store_dir")
         source.value = str(tmp_path / "source")
-        solution = next(filter(lambda c: c.name == "solution_rdf_store.disk_store_dir", definition.configs))
+        solution = next(c for c in definition.configs if c.name == "solution_rdf_store.disk_store_dir")
         solution.value = str(tmp_path / "solution")
         response = fastapi_client.post("/api/workflow/workflow-definition/fast_graph", json=definition.dict())
         assert response.status_code == 200

--- a/tests/api/test_workflows.py
+++ b/tests/api/test_workflows.py
@@ -43,10 +43,13 @@ def test_load_rules(transformation_rules, fastapi_client: TestClient):
     assert len(transformation_rules.properties) == len(rules["properties"])
 
 
-def test_run_default_workflow(cognite_client: CogniteClient, fastapi_client: TestClient, data_regression):
+@pytest.mark.parametrize("workflow_name", ["default", "fast_graph", "sheet2cdf"])
+def test_run_default_workflow(
+    workflow_name: str, cognite_client: CogniteClient, fastapi_client: TestClient, data_regression
+):
     response = fastapi_client.post(
         "/api/workflow/start",
-        json=RunWorkflowRequest(name="default", sync=True, config={}, start_step="Not used").dict(),
+        json=RunWorkflowRequest(name=workflow_name, sync=True, config={}, start_step="Not used").dict(),
     )
 
     assert response.status_code == 200
@@ -56,4 +59,4 @@ def test_run_default_workflow(cognite_client: CogniteClient, fastapi_client: Tes
     for resource_name in ["assets", "relationships", "labels"]:
         memory: MemoryClient = getattr(cognite_client, resource_name)
         data[resource_name] = memory.dump(ordered=True, exclude={"metadata.start_time", "metadata.update_time"})
-    data_regression.check(data, basename="default_workflow")
+    data_regression.check(data, basename=f"{workflow_name}_workflow")

--- a/tests/api/test_workflows.py
+++ b/tests/api/test_workflows.py
@@ -56,10 +56,10 @@ def test_run_default_workflow(
         # When running this test in GitHub actions, you get permission issues with the default disk_store_dir.
         response = fastapi_client.get("/api/workflow/workflow-definition/fast_graph")
         definition = WorkflowDefinition(**response.json()["definition"])
-        disk_store_dir = next(
-            config for config in definition.configs if config.name == "source_rdf_store.disk_store_dir"
-        )
-        disk_store_dir.value = str(tmp_path)
+        source = next(config for config in definition.configs if config.name == "source_rdf_store.disk_store_dir")
+        source.value = str(tmp_path / "source")
+        solution = next(filter(lambda c: c.name == "solution_rdf_store.disk_store_dir", definition.configs))
+        solution.value = str(tmp_path / "solution")
         response = fastapi_client.post("/api/workflow/workflow-definition/fast_graph", json=definition.dict())
         assert response.status_code == 200
 

--- a/tests/api/test_workflows/fast_graph_workflow.yml
+++ b/tests/api/test_workflows/fast_graph_workflow.yml
@@ -1,3 +1,18871 @@
-assets: []
-labels: []
-relationships: []
+assets:
+- data_set_id: 2626756768281823
+  external_id: 02b41435-bd3e-bb4b-9b89-24e3a8983c0f
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 02b41435-bd3e-bb4b-9b89-24e3a8983c0f
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176966a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 02b41435-bd3e-bb4b-9b89-24e3a8983c0f
+    type: Terminal
+  name: T2
+  parent_external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 0345061e-37c9-9a49-b632-2af77bdca3a2
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 0345061e-37c9-9a49-b632-2af77bdca3a2
+    IdentifiedObject.name: KRISTIAN300KV1 BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 0345061e-37c9-9a49-b632-2af77bdca3a2
+    type: Terminal
+  name: KRISTIAN300KV1 BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 0619c12e-abb9-b141-b3a7-e2788d3d375c
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 0619c12e-abb9-b141-b3a7-e2788d3d375c
+    IdentifiedObject.name: KRISTIAN300G1  AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 0619c12e-abb9-b141-b3a7-e2788d3d375c
+    type: Terminal
+  name: KRISTIAN300G1  AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 076da31b-080d-c742-9cb1-134a6ba5b1ed
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 076da31b-080d-c742-9cb1-134a6ba5b1ed
+    IdentifiedObject.name: ARENDAL 300KR1 BD_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 076da31b-080d-c742-9cb1-134a6ba5b1ed
+    type: Terminal
+  name: ARENDAL 300KR1 BD_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 093a3df5-0583-894f-99c9-016d752ff920
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 093a3df5-0583-894f-99c9-016d752ff920
+    IdentifiedObject.name: KRISTIAN300G3  BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 093a3df5-0583-894f-99c9-016d752ff920
+    type: Terminal
+  name: KRISTIAN300G3  BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 0a122f63-f2c6-ca43-be49-76571474d98c
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 0a122f63-f2c6-ca43-be49-76571474d98c
+    IdentifiedObject.name: KRISTIAN300G2  BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 0a122f63-f2c6-ca43-be49-76571474d98c
+    type: Terminal
+  name: KRISTIAN300G2  BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 0b50ae74-92eb-f244-872b-07e629f53494
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 0b50ae74-92eb-f244-872b-07e629f53494
+    IdentifiedObject.name: KRISTIAN300G1  AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 0b50ae74-92eb-f244-872b-07e629f53494
+    type: Terminal
+  name: KRISTIAN300G1  AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 0d7f39d0-5447-fb42-9d4f-3d0775bceef0
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 0d7f39d0-5447-fb42-9d4f-3d0775bceef0
+    IdentifiedObject.name: KRISTIAN300G4  AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 0d7f39d0-5447-fb42-9d4f-3d0775bceef0
+    type: Terminal
+  name: KRISTIAN300G4  AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 0dae5d37-4d01-3645-9e94-607410c5ac34
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 0dae5d37-4d01-3645-9e94-607410c5ac34
+    IdentifiedObject.name: KRISTIAN300L1  BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 0dae5d37-4d01-3645-9e94-607410c5ac34
+    type: Terminal
+  name: KRISTIAN300L1  BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 0ef62251-5e2e-d14a-aa44-396d4a885c4f
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 0ef62251-5e2e-d14a-aa44-396d4a885c4f
+    IdentifiedObject.name: ARENDAL 300SC1 AB_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 0ef62251-5e2e-d14a-aa44-396d4a885c4f
+    type: Terminal
+  name: ARENDAL 300SC1 AB_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 13116d72-3969-1344-91a7-14fb404a00c0
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 13116d72-3969-1344-91a7-14fb404a00c0
+    IdentifiedObject.name: KRISTIAN300FE1 BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 13116d72-3969-1344-91a7-14fb404a00c0
+    type: Terminal
+  name: KRISTIAN300FE1 BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 16659ede-d69f-1d48-bcf2-ebb2ee6c259e
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 16659ede-d69f-1d48-bcf2-ebb2ee6c259e
+    IdentifiedObject.name: KRISTIAN300G4  AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 16659ede-d69f-1d48-bcf2-ebb2ee6c259e
+    type: Terminal
+  name: KRISTIAN300G4  AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 1a6d8d77-f2ca-f043-b475-f7db6304fe3e
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 1a6d8d77-f2ca-f043-b475-f7db6304fe3e
+    IdentifiedObject.name: ARENDAL 420T1  AB_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 1a6d8d77-f2ca-f043-b475-f7db6304fe3e
+    type: Terminal
+  name: ARENDAL 420T1  AB_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 1ef7a41b-2cff-6046-b48f-c60a16fd20b0
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 1ef7a41b-2cff-6046-b48f-c60a16fd20b0
+    IdentifiedObject.name: ARENDAL 300KR1 BB_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 1ef7a41b-2cff-6046-b48f-c60a16fd20b0
+    type: Terminal
+  name: ARENDAL 300KR1 BB_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 22c3512a-fdf2-464c-b1f4-85d173fa2d18
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 22c3512a-fdf2-464c-b1f4-85d173fa2d18
+    IdentifiedObject.name: ARENDAL 300KR2 BD_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 22c3512a-fdf2-464c-b1f4-85d173fa2d18
+    type: Terminal
+  name: ARENDAL 300KR2 BD_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 292835be-c432-734c-8c28-3b8c61c0c077
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 292835be-c432-734c-8c28-3b8c61c0c077
+    IdentifiedObject.name: KRISTIAN300G3  BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 292835be-c432-734c-8c28-3b8c61c0c077
+    type: Terminal
+  name: KRISTIAN300G3  BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2a67a243-6e4a-a84d-8aea-f250399166c9
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2a67a243-6e4a-a84d-8aea-f250399166c9
+    IdentifiedObject.name: KRISTIAN300G1  BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2a67a243-6e4a-a84d-8aea-f250399166c9
+    type: Terminal
+  name: KRISTIAN300G1  BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90156-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90156-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90156-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9015c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9015c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9015c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9015e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9015e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9015e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90162-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90162-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90162-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90166-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90166-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90166-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90168-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90168-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90168-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9016b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9016b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695df-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9016b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9016d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9016d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9016d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9016f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9016f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9016f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90171-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90171-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90171-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90173-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90173-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90173-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90176-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90176-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90176-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90178-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90178-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769604-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90178-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9017c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9017c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9017c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9017e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9017e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769614-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9017e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90182-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90182-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176961e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90182-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90184-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90184-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90184-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90186-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90186-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176962a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90186-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90188-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90188-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769630-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90188-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9018a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9018a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769636-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9018a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9018c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9018c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9018c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9018e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9018e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769642-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9018e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90190-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90190-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769648-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90190-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90192-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90192-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90192-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90194-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90194-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769654-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90194-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90196-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90196-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: KRISTIAN300 BS1 T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90196-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: KRISTIAN300 BS1 T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9019a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9019a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769664-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9019a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9019c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9019c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176966a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9019c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9019e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9019e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: ARENDAL 300 A T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9019e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: ARENDAL 300 A T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901a0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901a0-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769676-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901a0-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901a2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: Some Alias Name Which is not used since name exist
+    IdentifiedObject.mRID: 2dd901a2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176967c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901a2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901a4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: Alias Name
+    IdentifiedObject.mRID: 2dd901a4-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: ''
+    Terminal.Substation: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901a4-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: Alias Name
+  parent_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901a8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901a8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901a8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901aa-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901aa-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901aa-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901ae-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901ae-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901ae-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901b2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901b2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901b2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901b4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901b4-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901b4-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901b8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901b8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901b8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901ba-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901ba-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901ba-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901bc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901bc-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901bc-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901be-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901be-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901be-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901c2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901c2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901c2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901c4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901c4-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696da-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901c4-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901c6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901c6-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901c6-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901c9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901c9-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901c9-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901cc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901cc-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901cc-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901cf-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901cf-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901cf-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901d2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901d2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901d2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901d5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901d5-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901d5-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901d8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901d8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901d8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901db-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901db-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901db-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901de-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901de-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901de-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901e1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901e1-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901e1-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901e4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901e4-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901e4-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901e7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901e7-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901e7-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901ea-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901ea-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901ea-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901ed-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901ed-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901ed-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901f0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901f0-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769604-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901f0-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901f3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901f3-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901f3-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901f6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901f6-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901f6-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901f9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901f9-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901f9-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901fc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901fc-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901fc-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd901ff-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd901ff-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: KRISTIAN300 L1  T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd901ff-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: KRISTIAN300 L1  T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90202-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90202-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: KRISTIAN300 L2  T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90202-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: KRISTIAN300 L2  T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90205-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90205-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769676-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90205-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90208-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90208-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176967c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90208-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9020b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9020b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9020b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9020e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9020e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9020e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90211-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90211-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90211-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90214-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90214-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90214-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90217-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90217-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90217-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9021a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9021a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9021a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9021d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9021d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9021d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90220-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90220-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90220-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90223-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90223-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90223-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90226-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90226-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90226-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90229-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90229-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90229-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9022c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9022c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9022c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9022f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9022f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9022f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90232-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90232-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90232-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90235-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90235-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90235-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90238-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90238-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90238-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9023b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9023b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9023b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9023e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9023e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9023e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90241-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90241-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90241-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90244-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90244-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90244-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90247-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90247-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90247-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9024a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9024a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9024a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9024d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9024d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9024d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90250-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90250-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90250-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90253-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90253-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696da-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90253-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90258-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90258-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90258-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9025b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9025b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9025b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9025e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9025e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9025e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90262-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90262-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90262-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90265-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90265-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90265-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90268-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90268-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90268-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9026b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9026b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9026b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9026e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9026e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9026e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90272-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90272-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695df-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90272-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90276-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90276-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90276-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90279-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90279-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90279-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9027c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9027c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9027c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9027f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9027f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9027f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90282-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90282-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90282-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90285-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90285-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90285-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90288-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90288-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90288-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9028b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9028b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9028b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9028f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9028f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9028f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90292-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90292-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90292-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90295-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90295-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90295-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90298-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90298-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90298-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9029b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9029b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9029b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9029e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9029e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9029e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902a2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902a2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902a2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902a5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902a5-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902a5-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902a8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902a8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902a8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902ab-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902ab-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902ab-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902ae-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902ae-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902ae-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902b1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902b1-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902b1-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902b5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902b5-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769604-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902b5-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902b8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902b8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769604-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902b8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902bc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902bc-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902bc-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902bf-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902bf-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902bf-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902c2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902c2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902c2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902c5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902c5-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902c5-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902c8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902c8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902c8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902cb-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902cb-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902cb-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902cf-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902cf-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902cf-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902d2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902d2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902d2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902d6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902d6-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902d6-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902d9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902d9-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902d9-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902dd-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902dd-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: KRISTIAN300 M1  T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902dd-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: KRISTIAN300 M1  T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902e0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902e0-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: KRISTIAN300 M2  T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902e0-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: KRISTIAN300 M2  T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902e3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902e3-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: KRISTIAN300 M3  T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902e3-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: KRISTIAN300 M3  T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902e6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902e6-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: KRISTIAN300 M4  T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902e6-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: KRISTIAN300 M4  T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902ea-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902ea-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902ea-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902ed-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902ed-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902ed-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902f0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902f0-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902f0-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902f3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902f3-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902f3-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902f7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902f7-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902f7-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902fa-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902fa-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902fa-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd902fd-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd902fd-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd902fd-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90300-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90300-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90300-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90303-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90303-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90303-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90307-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90307-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90307-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9030a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9030a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9030a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9030d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9030d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9030d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90310-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90310-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90310-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90314-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90314-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90314-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90317-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90317-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90317-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9031a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9031a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9031a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9031d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9031d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9031d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90321-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90321-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90321-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90324-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90324-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90324-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90327-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90327-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90327-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9032a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9032a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9032a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9032d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9032d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9032d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90330-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90330-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90330-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90333-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90333-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90333-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90336-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90336-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90336-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90339-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90339-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90339-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9033d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9033d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9033d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90340-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90340-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90340-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90343-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90343-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90343-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90347-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90347-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90347-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9034a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9034a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9034a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9034d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9034d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9034d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90350-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90350-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90350-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90353-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90353-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90353-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90356-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90356-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90356-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90357-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90357-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90357-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90358-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90358-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90358-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9035a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9035a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9035a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9035b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9035b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9035b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9035d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9035d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9035d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9035e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9035e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695df-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9035e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90360-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90360-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90360-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90361-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90361-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695df-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90361-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90363-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90363-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90363-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90364-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90364-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90364-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90366-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90366-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90366-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90367-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90367-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90367-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90369-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90369-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90369-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9036a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9036a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9036a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9036c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9036c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9036c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9036d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9036d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9036d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9036f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9036f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9036f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90370-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90370-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90370-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90372-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90372-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90372-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90373-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90373-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90373-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90375-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90375-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90375-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90376-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90376-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90376-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90378-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90378-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90378-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90379-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90379-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90379-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9037b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9037b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9037b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9037c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9037c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9037c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9037e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9037e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9037e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9037f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9037f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695df-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9037f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90381-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90381-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90381-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90382-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90382-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90382-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90384-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90384-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90384-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90385-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90385-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90385-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90387-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90387-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90387-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90388-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90388-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90388-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9038a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9038a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9038a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9038b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9038b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9038b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9038d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9038d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9038d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9038e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9038e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9038e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90390-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90390-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90390-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90391-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90391-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90391-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90393-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90393-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90393-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90394-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90394-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90394-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90396-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90396-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90396-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90397-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90397-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90397-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90399-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90399-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90399-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9039a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9039a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9039a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9039c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9039c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9039c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9039d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9039d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9039d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9039f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9039f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9039f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903a0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903a0-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903a0-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903a2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903a2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903a2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903a3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903a3-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903a3-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903a5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903a5-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903a5-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903a6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903a6-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903a6-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903a8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903a8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903a8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903a9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903a9-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903a9-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903ab-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903ab-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903ab-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903ac-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903ac-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903ac-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903ae-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903ae-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769604-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903ae-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903af-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903af-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903af-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903b1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903b1-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769604-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903b1-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903b2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903b2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903b2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903b4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903b4-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903b4-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903b5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903b5-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769614-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903b5-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903b7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903b7-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903b7-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903b8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903b8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176961e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903b8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903ba-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903ba-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903ba-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903bb-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903bb-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769654-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903bb-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903be-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903be-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903be-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903c1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903c1-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769654-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903c1-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903c3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903c3-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769614-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903c3-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903c4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903c4-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176961e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903c4-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903c6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903c6-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769614-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903c6-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903c7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903c7-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769630-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903c7-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903c9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903c9-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769614-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903c9-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903ca-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903ca-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903ca-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903cd-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903cd-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769614-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903cd-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903d0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903d0-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903d0-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903d2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903d2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176961e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903d2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903d3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903d3-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769630-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903d3-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903d5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903d5-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176961e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903d5-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903d6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903d6-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769630-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903d6-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903d8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903d8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903d8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903d9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903d9-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903d9-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903db-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903db-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176962a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903db-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903dc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903dc-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769630-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903dc-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903de-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903de-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176962a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903de-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903df-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903df-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769636-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903df-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903e1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903e1-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176962a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903e1-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903e2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903e2-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903e2-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903e4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903e4-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769630-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903e4-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903e5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903e5-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769636-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903e5-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903e7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903e7-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769630-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903e7-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903e8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903e8-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769636-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903e8-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903ea-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903ea-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903ea-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903eb-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903eb-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903eb-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903ed-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903ed-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903ed-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903ee-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903ee-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903ee-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903f0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903f0-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769642-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903f0-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903f1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903f1-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769654-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903f1-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903f3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903f3-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769642-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903f3-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903f4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903f4-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176966a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903f4-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903f6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903f6-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769642-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903f6-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903f7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903f7-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903f7-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903fa-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903fa-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769642-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903fa-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903fd-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903fd-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903fd-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd903ff-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd903ff-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769648-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd903ff-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90400-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90400-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90400-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90402-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90402-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90402-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90403-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90403-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: 300ASKER-ARENDAL T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90403-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: 300ASKER-ARENDAL T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90406-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90406-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90406-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90409-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90409-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: ARENDAL 300 LSC1 T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90409-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: ARENDAL 300 LSC1 T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9040b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9040b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: 300KRISTIAN-STAVANGE_T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9040b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: 300KRISTIAN-STAVANGE_T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9040c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9040c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769664-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9040c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9040e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9040e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: 300KRISTIAN-ARENDAL_T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9040e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: 300KRISTIAN-ARENDAL_T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9040f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9040f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: 300KRISTIAN-ARENDAL T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9040f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: 300KRISTIAN-ARENDAL T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90411-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90411-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: 300KRISTIAN-FEDA_T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90411-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: 300KRISTIAN-FEDA_T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90412-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90412-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176967c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90412-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90414-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90414-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: 300KRISTIAN-KVILLDAL_T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90414-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: 300KRISTIAN-KVILLDAL_T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90415-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90415-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90415-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90417-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90417-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: 300KRISTIAN-ARENDAL T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90417-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: 300KRISTIAN-ARENDAL T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90418-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90418-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769676-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90418-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9041a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9041a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9041a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9041b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9041b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9041b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9041d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9041d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9041d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9041e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9041e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9041e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90420-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90420-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90420-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90421-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90421-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90421-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90423-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90423-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90423-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90424-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90424-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90424-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90426-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90426-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90426-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90427-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90427-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696be-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90427-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90429-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90429-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90429-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9042a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9042a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9042a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9042c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9042c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9042c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9042d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9042d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9042d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9042f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9042f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9042f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90430-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90430-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90430-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90432-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90432-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90432-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90433-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90433-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90433-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90435-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90435-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90435-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90436-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90436-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696da-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90436-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90439-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90439-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90439-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9043d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9043d-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695df-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9043d-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90440-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90440-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90440-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90444-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90444-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90444-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90447-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90447-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90447-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9044b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9044b-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9044b-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9044e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9044e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9044e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90452-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90452-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769604-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90452-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90455-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90455-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90455-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90459-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90459-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f176962a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90459-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9045c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9045c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9045c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90460-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90460-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769642-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90460-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90463-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90463-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90463-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90467-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90467-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769648-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90467-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9046a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9046a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9046a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9046e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9046e-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769654-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9046e-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90471-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90471-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769664-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90471-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90475-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90475-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90475-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90478-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90478-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: ARENDAL T1 T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90478-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: ARENDAL T1 T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9047c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9047c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: ARENDAL T1 T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9047c-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: ARENDAL T1 T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9047f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9047f-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9047f-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90483-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90483-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90483-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd90486-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd90486-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T1
+    Terminal.Substation: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd90486-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T1
+  parent_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9048a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2dd9048a-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: T2
+    Terminal.Substation: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2dd9048a-bdfb-11e5-94fa-c8f73332c8f4
+    type: Terminal
+  name: T2
+  parent_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    IdentifiedObject.name: 'NO'
+    RootCIMNode.node: root-node
+    active: 'true'
+    identifier: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    type: GeographicalRegion
+  name: 'NO'
+  parent_external_id: root-node
+- data_set_id: 2626756768281823
+  external_id: 2e64900b-94a8-6e40-bd63-3e69510c316f
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2e64900b-94a8-6e40-bd63-3e69510c316f
+    IdentifiedObject.name: ARENDAL 300AS1 AB_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2e64900b-94a8-6e40-bd63-3e69510c316f
+    type: Terminal
+  name: ARENDAL 300AS1 AB_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2e98d68c-e0c5-6d47-b392-a1746743ef63
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2e98d68c-e0c5-6d47-b392-a1746743ef63
+    IdentifiedObject.name: KRISTIAN300AR1 BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2e98d68c-e0c5-6d47-b392-a1746743ef63
+    type: Terminal
+  name: KRISTIAN300AR1 BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 2f8c9437-e564-e948-8764-be3494565b1f
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 2f8c9437-e564-e948-8764-be3494565b1f
+    IdentifiedObject.name: KRISTIAN300G2  AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 2f8c9437-e564-e948-8764-be3494565b1f
+    type: Terminal
+  name: KRISTIAN300G2  AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 30ab0123-1669-1242-99ca-610e4bcdc6c5
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 30ab0123-1669-1242-99ca-610e4bcdc6c5
+    IdentifiedObject.name: KRISTIAN300G2  BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 30ab0123-1669-1242-99ca-610e4bcdc6c5
+    type: Terminal
+  name: KRISTIAN300G2  BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 329965e7-b5de-c54f-856a-358c9e1f9c50
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 329965e7-b5de-c54f-856a-358c9e1f9c50
+    IdentifiedObject.name: KRISTIAN300ST1 AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 329965e7-b5de-c54f-856a-358c9e1f9c50
+    type: Terminal
+  name: KRISTIAN300ST1 AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 356c6f11-da4d-3f4d-b3fd-49234106345c
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 356c6f11-da4d-3f4d-b3fd-49234106345c
+    IdentifiedObject.name: ARENDAL 300T1  AB_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 356c6f11-da4d-3f4d-b3fd-49234106345c
+    type: Terminal
+  name: ARENDAL 300T1  AB_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 3718af45-a6ee-fb40-a4c6-f1118c114393
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 3718af45-a6ee-fb40-a4c6-f1118c114393
+    IdentifiedObject.name: KRISTIAN300L1  AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 3718af45-a6ee-fb40-a4c6-f1118c114393
+    type: Terminal
+  name: KRISTIAN300L1  AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 37c82b4c-7441-9946-98bf-7ade99732ecf
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 37c82b4c-7441-9946-98bf-7ade99732ecf
+    IdentifiedObject.name: KRISTIAN300KV1 BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 37c82b4c-7441-9946-98bf-7ade99732ecf
+    type: Terminal
+  name: KRISTIAN300KV1 BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 38b8e08a-112e-b046-8504-efef4beb0c17
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 38b8e08a-112e-b046-8504-efef4beb0c17
+    IdentifiedObject.name: KRISTIAN300L1  AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 38b8e08a-112e-b046-8504-efef4beb0c17
+    type: Terminal
+  name: KRISTIAN300L1  AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 3916ae31-9f3d-af4e-8d87-87d373d8200a
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 3916ae31-9f3d-af4e-8d87-87d373d8200a
+    IdentifiedObject.name: ARENDAL 300KR2 BB_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 3916ae31-9f3d-af4e-8d87-87d373d8200a
+    type: Terminal
+  name: ARENDAL 300KR2 BB_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 40725e5a-33bf-6046-8d11-da19f9c726b4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 40725e5a-33bf-6046-8d11-da19f9c726b4
+    IdentifiedObject.name: KRISTIAN300G2  BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 40725e5a-33bf-6046-8d11-da19f9c726b4
+    type: Terminal
+  name: KRISTIAN300G2  BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 40c8340e-7ccf-d446-8a6b-bffa19ec88e6
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 40c8340e-7ccf-d446-8a6b-bffa19ec88e6
+    IdentifiedObject.name: KRISTIAN300G3  BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 40c8340e-7ccf-d446-8a6b-bffa19ec88e6
+    type: Terminal
+  name: KRISTIAN300G3  BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 4a5b7813-14d3-fa4d-8907-edcdce7dbfd9
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 4a5b7813-14d3-fa4d-8907-edcdce7dbfd9
+    IdentifiedObject.name: KRISTIAN300FE1 AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 4a5b7813-14d3-fa4d-8907-edcdce7dbfd9
+    type: Terminal
+  name: KRISTIAN300FE1 AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 51883d43-111e-f24b-89f7-0573426fa32f
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 51883d43-111e-f24b-89f7-0573426fa32f
+    IdentifiedObject.name: ARENDAL 300KR1 AD_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 51883d43-111e-f24b-89f7-0573426fa32f
+    type: Terminal
+  name: ARENDAL 300KR1 AD_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 5831696b-e9e1-8e4a-a169-0e4e09f15f1f
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 5831696b-e9e1-8e4a-a169-0e4e09f15f1f
+    IdentifiedObject.name: KRISTIAN300FE1 BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 5831696b-e9e1-8e4a-a169-0e4e09f15f1f
+    type: Terminal
+  name: KRISTIAN300FE1 BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 5906b2a0-4ec9-1949-98b8-709380af0060
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 5906b2a0-4ec9-1949-98b8-709380af0060
+    IdentifiedObject.name: ARENDAL 300KR1 AB_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 5906b2a0-4ec9-1949-98b8-709380af0060
+    type: Terminal
+  name: ARENDAL 300KR1 AB_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 5c3fa20d-4748-5e44-b915-481e6d2552cd
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 5c3fa20d-4748-5e44-b915-481e6d2552cd
+    IdentifiedObject.name: KRISTIAN300ST1 AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 5c3fa20d-4748-5e44-b915-481e6d2552cd
+    type: Terminal
+  name: KRISTIAN300ST1 AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 5ddb272d-00bd-d74e-8c96-e2049351c3e4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 5ddb272d-00bd-d74e-8c96-e2049351c3e4
+    IdentifiedObject.name: KRISTIAN300L1  BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 5ddb272d-00bd-d74e-8c96-e2049351c3e4
+    type: Terminal
+  name: KRISTIAN300L1  BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 5ffde614-bc34-384d-923e-e62ac9f3f584
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 5ffde614-bc34-384d-923e-e62ac9f3f584
+    IdentifiedObject.name: KRISTIAN300AR1 AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 5ffde614-bc34-384d-923e-e62ac9f3f584
+    type: Terminal
+  name: KRISTIAN300AR1 AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 669c1d0c-87dd-a943-9316-88308bd36f15
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 669c1d0c-87dd-a943-9316-88308bd36f15
+    IdentifiedObject.name: 420ARENDAL-SANDEFJORD T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 669c1d0c-87dd-a943-9316-88308bd36f15
+    type: Terminal
+  name: 420ARENDAL-SANDEFJORD T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 67bc203e-13e4-534b-94b8-bf19f5b31080
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 67bc203e-13e4-534b-94b8-bf19f5b31080
+    IdentifiedObject.name: KRISTIAN300AR1 BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 67bc203e-13e4-534b-94b8-bf19f5b31080
+    type: Terminal
+  name: KRISTIAN300AR1 BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 67dfc70a-36cf-da4e-b97c-fd1eda9cd8ac
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 67dfc70a-36cf-da4e-b97c-fd1eda9cd8ac
+    IdentifiedObject.name: KRISTIAN300AR1 AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 67dfc70a-36cf-da4e-b97c-fd1eda9cd8ac
+    type: Terminal
+  name: KRISTIAN300AR1 AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 692809cf-1bb4-8642-9b70-ee677f063304
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 692809cf-1bb4-8642-9b70-ee677f063304
+    IdentifiedObject.name: KRISTIAN300AR1 BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 692809cf-1bb4-8642-9b70-ee677f063304
+    type: Terminal
+  name: KRISTIAN300AR1 BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 6abb96f5-a71f-8e41-b563-7c569789d6bd
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 6abb96f5-a71f-8e41-b563-7c569789d6bd
+    IdentifiedObject.name: KRISTIAN300G4  BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 6abb96f5-a71f-8e41-b563-7c569789d6bd
+    type: Terminal
+  name: KRISTIAN300G4  BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 6ac2f3cd-c906-0a4b-ba1b-5942e9c65307
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 6ac2f3cd-c906-0a4b-ba1b-5942e9c65307
+    IdentifiedObject.name: KRISTIAN300L2  BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 6ac2f3cd-c906-0a4b-ba1b-5942e9c65307
+    type: Terminal
+  name: KRISTIAN300L2  BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 6da89f37-cc6f-4e4e-8b20-975295017390
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 6da89f37-cc6f-4e4e-8b20-975295017390
+    IdentifiedObject.name: ARENDAL 300KR2 AB_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 6da89f37-cc6f-4e4e-8b20-975295017390
+    type: Terminal
+  name: ARENDAL 300KR2 AB_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 70f1852f-186d-5e43-98bf-b69f028cfcc5
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 70f1852f-186d-5e43-98bf-b69f028cfcc5
+    IdentifiedObject.name: KRISTIAN300L2  BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 70f1852f-186d-5e43-98bf-b69f028cfcc5
+    type: Terminal
+  name: KRISTIAN300L2  BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 714c775a-246f-e34f-9a6b-667f4b66138c
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 714c775a-246f-e34f-9a6b-667f4b66138c
+    IdentifiedObject.name: KRISTIAN300L2  AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 714c775a-246f-e34f-9a6b-667f4b66138c
+    type: Terminal
+  name: KRISTIAN300L2  AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 71d09d39-a080-5d4f-86f3-7b3185e51b8e
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 71d09d39-a080-5d4f-86f3-7b3185e51b8e
+    IdentifiedObject.name: KRISTIAN300FE1 BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 71d09d39-a080-5d4f-86f3-7b3185e51b8e
+    type: Terminal
+  name: KRISTIAN300FE1 BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 761a49da-2b71-2d4e-877f-3cf7fa86ef63
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 761a49da-2b71-2d4e-877f-3cf7fa86ef63
+    IdentifiedObject.name: ARENDAL 300T1  AB_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 761a49da-2b71-2d4e-877f-3cf7fa86ef63
+    type: Terminal
+  name: ARENDAL 300T1  AB_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 79887cf1-6c94-3f4f-a1f8-7ddef866d55f
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 79887cf1-6c94-3f4f-a1f8-7ddef866d55f
+    IdentifiedObject.name: KRISTIAN300KV1 BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 79887cf1-6c94-3f4f-a1f8-7ddef866d55f
+    type: Terminal
+  name: KRISTIAN300KV1 BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 7af49a35-a119-5443-84be-af343b7761c8
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 7af49a35-a119-5443-84be-af343b7761c8
+    IdentifiedObject.name: KRISTIAN300G1  BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 7af49a35-a119-5443-84be-af343b7761c8
+    type: Terminal
+  name: KRISTIAN300G1  BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 7d101d2b-ce05-9843-ab59-2c3e5e244cbb
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 7d101d2b-ce05-9843-ab59-2c3e5e244cbb
+    IdentifiedObject.name: KRISTIAN300AR1 AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 7d101d2b-ce05-9843-ab59-2c3e5e244cbb
+    type: Terminal
+  name: KRISTIAN300AR1 AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 7f811234-10fe-e34f-a9af-9af61a6dd4c7
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 7f811234-10fe-e34f-a9af-9af61a6dd4c7
+    IdentifiedObject.name: KRISTIAN300FE1 AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 7f811234-10fe-e34f-a9af-9af61a6dd4c7
+    type: Terminal
+  name: KRISTIAN300FE1 AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 84775b5d-95c1-bd46-bb0d-0f74e4c06757
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 84775b5d-95c1-bd46-bb0d-0f74e4c06757
+    IdentifiedObject.name: KRISTIAN300KV1 BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 84775b5d-95c1-bd46-bb0d-0f74e4c06757
+    type: Terminal
+  name: KRISTIAN300KV1 BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 854b40ee-7109-d04c-b4ef-f0665722e451
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 854b40ee-7109-d04c-b4ef-f0665722e451
+    IdentifiedObject.name: KRISTIAN300G3  BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 854b40ee-7109-d04c-b4ef-f0665722e451
+    type: Terminal
+  name: KRISTIAN300G3  BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 8574aebb-23c4-3e4a-bd04-b5651c97d27a
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 8574aebb-23c4-3e4a-bd04-b5651c97d27a
+    IdentifiedObject.name: KRISTIAN300L1  AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 8574aebb-23c4-3e4a-bd04-b5651c97d27a
+    type: Terminal
+  name: KRISTIAN300L1  AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 8a0babd6-6d6f-854b-b65f-4245e65c9e9c
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 8a0babd6-6d6f-854b-b65f-4245e65c9e9c
+    IdentifiedObject.name: ARENDAL 300AS1 BD_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 8a0babd6-6d6f-854b-b65f-4245e65c9e9c
+    type: Terminal
+  name: ARENDAL 300AS1 BD_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 8d35b51b-06bd-7541-b3e6-2ddbbb1204fe
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 8d35b51b-06bd-7541-b3e6-2ddbbb1204fe
+    IdentifiedObject.name: KRISTIAN300L2  BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 8d35b51b-06bd-7541-b3e6-2ddbbb1204fe
+    type: Terminal
+  name: KRISTIAN300L2  BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 8e8e6b0c-ee96-7a4f-9790-c9ae62edafbe
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 8e8e6b0c-ee96-7a4f-9790-c9ae62edafbe
+    IdentifiedObject.name: KRISTIAN300AR1 BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 8e8e6b0c-ee96-7a4f-9790-c9ae62edafbe
+    type: Terminal
+  name: KRISTIAN300AR1 BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 8f8094c3-5c43-1241-9014-6c7a3ae10213
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 8f8094c3-5c43-1241-9014-6c7a3ae10213
+    IdentifiedObject.name: ARENDAL 300 B T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 8f8094c3-5c43-1241-9014-6c7a3ae10213
+    type: Terminal
+  name: ARENDAL 300 B T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 925f3ab7-54ce-b748-887a-fc6ae23bbdc2
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 925f3ab7-54ce-b748-887a-fc6ae23bbdc2
+    IdentifiedObject.name: KRISTIAN300KV1 AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 925f3ab7-54ce-b748-887a-fc6ae23bbdc2
+    type: Terminal
+  name: KRISTIAN300KV1 AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 947636e9-e939-294e-a94b-2090060b74ca
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 947636e9-e939-294e-a94b-2090060b74ca
+    IdentifiedObject.name: KRISTIAN300G1  BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 947636e9-e939-294e-a94b-2090060b74ca
+    type: Terminal
+  name: KRISTIAN300G1  BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 9acd76b4-8d78-2b4b-81d5-e404e244997d
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 9acd76b4-8d78-2b4b-81d5-e404e244997d
+    IdentifiedObject.name: ARENDAL 300KR1 BD_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 9acd76b4-8d78-2b4b-81d5-e404e244997d
+    type: Terminal
+  name: ARENDAL 300KR1 BD_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: 9b49634c-4910-9841-b595-0d0cb0d0d1de
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: 9b49634c-4910-9841-b595-0d0cb0d0d1de
+    IdentifiedObject.name: KRISTIAN300KV1 AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: 9b49634c-4910-9841-b595-0d0cb0d0d1de
+    type: Terminal
+  name: KRISTIAN300KV1 AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: a0ad0036-fbee-6646-b195-3a86614529f2
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: a0ad0036-fbee-6646-b195-3a86614529f2
+    IdentifiedObject.name: KRISTIAN300KV1 AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: a0ad0036-fbee-6646-b195-3a86614529f2
+    type: Terminal
+  name: KRISTIAN300KV1 AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: a2a690ef-b78a-3f46-90c5-5d434e26a64e
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: a2a690ef-b78a-3f46-90c5-5d434e26a64e
+    IdentifiedObject.name: KRISTIAN300G4  BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: a2a690ef-b78a-3f46-90c5-5d434e26a64e
+    type: Terminal
+  name: KRISTIAN300G4  BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: a4bc44aa-25e4-684a-ab2c-c7fc3378d9e5
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: a4bc44aa-25e4-684a-ab2c-c7fc3378d9e5
+    IdentifiedObject.name: KRISTIAN300G4  AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: a4bc44aa-25e4-684a-ab2c-c7fc3378d9e5
+    type: Terminal
+  name: KRISTIAN300G4  AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: a533d3fd-822f-3b40-9030-e18b571cd1ea
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: a533d3fd-822f-3b40-9030-e18b571cd1ea
+    IdentifiedObject.name: ARENDAL 300AS1 BD_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: a533d3fd-822f-3b40-9030-e18b571cd1ea
+    type: Terminal
+  name: ARENDAL 300AS1 BD_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: a749d698-52a2-564e-8c6f-068fe62045fe
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: a749d698-52a2-564e-8c6f-068fe62045fe
+    IdentifiedObject.name: KRISTIAN300AR1 AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: a749d698-52a2-564e-8c6f-068fe62045fe
+    type: Terminal
+  name: KRISTIAN300AR1 AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: a949cafd-39f3-8e4c-bca5-9928b004b4da
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: a949cafd-39f3-8e4c-bca5-9928b004b4da
+    IdentifiedObject.name: ARENDAL 300KR2 AB_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: a949cafd-39f3-8e4c-bca5-9928b004b4da
+    type: Terminal
+  name: ARENDAL 300KR2 AB_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: aadfa134-666a-ae4f-8c09-6f3ae114c3b5
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: aadfa134-666a-ae4f-8c09-6f3ae114c3b5
+    IdentifiedObject.name: ARENDAL 300AS1 AD_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: aadfa134-666a-ae4f-8c09-6f3ae114c3b5
+    type: Terminal
+  name: ARENDAL 300AS1 AD_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: ab88a3a2-a572-3440-be06-757e0225ea42
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: ab88a3a2-a572-3440-be06-757e0225ea42
+    IdentifiedObject.name: ARENDAL 300KR2 BD_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: ab88a3a2-a572-3440-be06-757e0225ea42
+    type: Terminal
+  name: ARENDAL 300KR2 BD_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: ad37e24a-9993-4f45-80ed-49a80b6a85d9
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: ad37e24a-9993-4f45-80ed-49a80b6a85d9
+    IdentifiedObject.name: KRISTIAN300G2  BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: ad37e24a-9993-4f45-80ed-49a80b6a85d9
+    type: Terminal
+  name: KRISTIAN300G2  BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: ad970e05-69d9-5340-9dbd-ce6a9a2e0996
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: ad970e05-69d9-5340-9dbd-ce6a9a2e0996
+    IdentifiedObject.name: KRISTIAN300G1  AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: ad970e05-69d9-5340-9dbd-ce6a9a2e0996
+    type: Terminal
+  name: KRISTIAN300G1  AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: ae68b597-69fb-e14b-a070-67c7dcc1d698
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: ae68b597-69fb-e14b-a070-67c7dcc1d698
+    IdentifiedObject.name: KRISTIAN300L1  AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: ae68b597-69fb-e14b-a070-67c7dcc1d698
+    type: Terminal
+  name: KRISTIAN300L1  AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: b016bc42-5a9f-ec42-b326-e9b9eed9e6d3
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: b016bc42-5a9f-ec42-b326-e9b9eed9e6d3
+    IdentifiedObject.name: KRISTIAN300G3  AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: b016bc42-5a9f-ec42-b326-e9b9eed9e6d3
+    type: Terminal
+  name: KRISTIAN300G3  AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: b3ff19da-83b8-5e40-b38c-38982b748732
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: b3ff19da-83b8-5e40-b38c-38982b748732
+    IdentifiedObject.name: KRISTIAN300G2  AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: b3ff19da-83b8-5e40-b38c-38982b748732
+    type: Terminal
+  name: KRISTIAN300G2  AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: b77c60e8-fe4f-9149-9bc6-c3eb8f899de2
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: b77c60e8-fe4f-9149-9bc6-c3eb8f899de2
+    IdentifiedObject.name: ARENDAL 300KR2 BB_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: b77c60e8-fe4f-9149-9bc6-c3eb8f899de2
+    type: Terminal
+  name: ARENDAL 300KR2 BB_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: bc0f852a-3cc8-e143-8174-f0854a2d38aa
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: bc0f852a-3cc8-e143-8174-f0854a2d38aa
+    IdentifiedObject.name: KRISTIAN300KV1 AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: bc0f852a-3cc8-e143-8174-f0854a2d38aa
+    type: Terminal
+  name: KRISTIAN300KV1 AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: bff806b2-7825-af4c-a34b-be542dbe5ae6
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: bff806b2-7825-af4c-a34b-be542dbe5ae6
+    IdentifiedObject.name: ARENDAL 300AS1 BB_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: bff806b2-7825-af4c-a34b-be542dbe5ae6
+    type: Terminal
+  name: ARENDAL 300AS1 BB_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: c1aa295d-e817-db46-b14e-bee2739fcd9d
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: c1aa295d-e817-db46-b14e-bee2739fcd9d
+    IdentifiedObject.name: KRISTIAN300L1  BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: c1aa295d-e817-db46-b14e-bee2739fcd9d
+    type: Terminal
+  name: KRISTIAN300L1  BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: c1ca1160-be67-9448-a16b-e92a6112e380
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: c1ca1160-be67-9448-a16b-e92a6112e380
+    IdentifiedObject.name: KRISTIAN300G3  AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: c1ca1160-be67-9448-a16b-e92a6112e380
+    type: Terminal
+  name: KRISTIAN300G3  AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: c3458e72-1c7a-a74b-b561-8afe0a3aa2be
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: c3458e72-1c7a-a74b-b561-8afe0a3aa2be
+    IdentifiedObject.name: ARENDAL 300KR2 AD_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: c3458e72-1c7a-a74b-b561-8afe0a3aa2be
+    type: Terminal
+  name: ARENDAL 300KR2 AD_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: c8ac9d5f-d60e-a345-8790-12b86184c31b
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: c8ac9d5f-d60e-a345-8790-12b86184c31b
+    IdentifiedObject.name: KRISTIAN300ST1 BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: c8ac9d5f-d60e-a345-8790-12b86184c31b
+    type: Terminal
+  name: KRISTIAN300ST1 BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: c8f95fee-e9a6-a44b-97ac-23e272a05ecd
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: c8f95fee-e9a6-a44b-97ac-23e272a05ecd
+    IdentifiedObject.name: KRISTIAN300G3  AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: c8f95fee-e9a6-a44b-97ac-23e272a05ecd
+    type: Terminal
+  name: KRISTIAN300G3  AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: c95039b2-aea2-ad4d-b444-c6efc77461e5
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: c95039b2-aea2-ad4d-b444-c6efc77461e5
+    IdentifiedObject.name: KRISTIAN300G4  BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: c95039b2-aea2-ad4d-b444-c6efc77461e5
+    type: Terminal
+  name: KRISTIAN300G4  BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: caa10f15-4591-e241-ac0b-81675acf5687
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: caa10f15-4591-e241-ac0b-81675acf5687
+    IdentifiedObject.name: KRISTIAN300KV1 BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: caa10f15-4591-e241-ac0b-81675acf5687
+    type: Terminal
+  name: KRISTIAN300KV1 BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: cd25f47c-ad0c-f74d-8c0e-fd91a95505b6
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: cd25f47c-ad0c-f74d-8c0e-fd91a95505b6
+    IdentifiedObject.name: KRISTIAN300ST1 BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: cd25f47c-ad0c-f74d-8c0e-fd91a95505b6
+    type: Terminal
+  name: KRISTIAN300ST1 BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: cf654436-a05a-7948-8cc3-f3a288608964
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: cf654436-a05a-7948-8cc3-f3a288608964
+    IdentifiedObject.name: KRISTIAN300L1  BD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: cf654436-a05a-7948-8cc3-f3a288608964
+    type: Terminal
+  name: KRISTIAN300L1  BD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: d288bd96-ae6e-cf46-9775-f38e2699f1ce
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: d288bd96-ae6e-cf46-9775-f38e2699f1ce
+    IdentifiedObject.name: ARENDAL 300KR1 BB_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: d288bd96-ae6e-cf46-9775-f38e2699f1ce
+    type: Terminal
+  name: ARENDAL 300KR1 BB_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: d28bc89e-0592-1440-9721-5cbe124c1f1b
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: d28bc89e-0592-1440-9721-5cbe124c1f1b
+    IdentifiedObject.name: ARENDAL 300SC1 AB_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: d28bc89e-0592-1440-9721-5cbe124c1f1b
+    type: Terminal
+  name: ARENDAL 300SC1 AB_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: d7a472cc-6b91-564d-93b4-0f3c24f2342c
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: d7a472cc-6b91-564d-93b4-0f3c24f2342c
+    IdentifiedObject.name: KRISTIAN300G4  BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: d7a472cc-6b91-564d-93b4-0f3c24f2342c
+    type: Terminal
+  name: KRISTIAN300G4  BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: d92cb2eb-fd81-194c-9e43-618df025d6b4
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: d92cb2eb-fd81-194c-9e43-618df025d6b4
+    IdentifiedObject.name: KRISTIAN300KV1 BB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: d92cb2eb-fd81-194c-9e43-618df025d6b4
+    type: Terminal
+  name: KRISTIAN300KV1 BB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: da4b0f71-a251-f947-be12-2de53a2d272a
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: da4b0f71-a251-f947-be12-2de53a2d272a
+    IdentifiedObject.name: KRISTIAN300ST1 AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: da4b0f71-a251-f947-be12-2de53a2d272a
+    type: Terminal
+  name: KRISTIAN300ST1 AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: dae3bb4b-0a86-9243-99c1-a1d5b163774d
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: dae3bb4b-0a86-9243-99c1-a1d5b163774d
+    IdentifiedObject.name: KRISTIAN300G2  AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: dae3bb4b-0a86-9243-99c1-a1d5b163774d
+    type: Terminal
+  name: KRISTIAN300G2  AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: db724627-9dae-4748-b4e3-2daf627ffa17
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: db724627-9dae-4748-b4e3-2daf627ffa17
+    IdentifiedObject.name: ARENDAL 420T1  AB_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: db724627-9dae-4748-b4e3-2daf627ffa17
+    type: Terminal
+  name: ARENDAL 420T1  AB_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: dc791b3b-fe63-a14b-b144-953748088613
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: dc791b3b-fe63-a14b-b144-953748088613
+    IdentifiedObject.name: ARENDAL 300AS1 AB_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: dc791b3b-fe63-a14b-b144-953748088613
+    type: Terminal
+  name: ARENDAL 300AS1 AB_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: e035c87e-704d-404f-8ea8-91c62e0d7d8a
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: e035c87e-704d-404f-8ea8-91c62e0d7d8a
+    IdentifiedObject.name: KRISTIAN300L2  AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: e035c87e-704d-404f-8ea8-91c62e0d7d8a
+    type: Terminal
+  name: KRISTIAN300L2  AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: e25c03e3-96a7-a64f-b776-a155f009d5f8
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: e25c03e3-96a7-a64f-b776-a155f009d5f8
+    IdentifiedObject.name: KRISTIAN300G2  AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: e25c03e3-96a7-a64f-b776-a155f009d5f8
+    type: Terminal
+  name: KRISTIAN300G2  AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: e2f56599-a78e-494f-8db3-c0b0bdab1d70
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: e2f56599-a78e-494f-8db3-c0b0bdab1d70
+    IdentifiedObject.name: ARENDAL 300KR1 AD_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: e2f56599-a78e-494f-8db3-c0b0bdab1d70
+    type: Terminal
+  name: ARENDAL 300KR1 AD_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: e3d56d8b-5f71-3042-9734-7118977e887c
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: e3d56d8b-5f71-3042-9734-7118977e887c
+    IdentifiedObject.name: KRISTIAN300FE1 AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: e3d56d8b-5f71-3042-9734-7118977e887c
+    type: Terminal
+  name: KRISTIAN300FE1 AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: e3ef93a1-723a-224e-8863-472e4f269633
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: e3ef93a1-723a-224e-8863-472e4f269633
+    IdentifiedObject.name: KRISTIAN300L2  AB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: e3ef93a1-723a-224e-8863-472e4f269633
+    type: Terminal
+  name: KRISTIAN300L2  AB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: e65c4130-3a4d-db42-9020-c9f7c447d473
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: e65c4130-3a4d-db42-9020-c9f7c447d473
+    IdentifiedObject.name: KRISTIAN300G4  AD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: e65c4130-3a4d-db42-9020-c9f7c447d473
+    type: Terminal
+  name: KRISTIAN300G4  AD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: ea014fdb-b96f-2a4b-b1df-d38e846d4941
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: ea014fdb-b96f-2a4b-b1df-d38e846d4941
+    IdentifiedObject.name: KRISTIAN300 B BS T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: ea014fdb-b96f-2a4b-b1df-d38e846d4941
+    type: Terminal
+  name: KRISTIAN300 B BS T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: eaf768b1-3d82-c64d-a1c6-5bd7f9a72751
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: eaf768b1-3d82-c64d-a1c6-5bd7f9a72751
+    IdentifiedObject.name: KRISTIAN300L2  BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: eaf768b1-3d82-c64d-a1c6-5bd7f9a72751
+    type: Terminal
+  name: KRISTIAN300L2  BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: eb8b2a90-9bc8-154f-92dd-3887e3676498
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: eb8b2a90-9bc8-154f-92dd-3887e3676498
+    IdentifiedObject.name: ARENDAL 300AS1 AD_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: eb8b2a90-9bc8-154f-92dd-3887e3676498
+    type: Terminal
+  name: ARENDAL 300AS1 AD_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: eba035f1-7c96-0142-8561-37b28625abf7
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: eba035f1-7c96-0142-8561-37b28625abf7
+    IdentifiedObject.name: ARENDAL 300KR2 AD_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: eba035f1-7c96-0142-8561-37b28625abf7
+    type: Terminal
+  name: ARENDAL 300KR2 AD_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: ecfaf384-4581-4249-8646-b5d31943ad61
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: ecfaf384-4581-4249-8646-b5d31943ad61
+    IdentifiedObject.name: KRISTIAN300FE1 BD_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: ecfaf384-4581-4249-8646-b5d31943ad61
+    type: Terminal
+  name: KRISTIAN300FE1 BD_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: ee4223ab-0538-dc4a-9b79-d463c048bb08
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: ee4223ab-0538-dc4a-9b79-d463c048bb08
+    IdentifiedObject.name: ARENDAL 300AS1 BB_S T2
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: ee4223ab-0538-dc4a-9b79-d463c048bb08
+    type: Terminal
+  name: ARENDAL 300AS1 BB_S T2
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: efe663e2-7518-3044-88d4-209bf597536a
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: efe663e2-7518-3044-88d4-209bf597536a
+    IdentifiedObject.name: KRISTIAN300L2  AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: efe663e2-7518-3044-88d4-209bf597536a
+    type: Terminal
+  name: KRISTIAN300L2  AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f08f910c-300e-8941-aa85-3106d93e3429
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: f08f910c-300e-8941-aa85-3106d93e3429
+    IdentifiedObject.name: KRISTIAN300FE1 AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: f08f910c-300e-8941-aa85-3106d93e3429
+    type: Terminal
+  name: KRISTIAN300FE1 AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: FORSMARK
+    Substation.Region: f17695af-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9025b-bdfb-11e5-94fa-c8f73332c8f4, 2dd90156-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901c9-bdfb-11e5-94fa-c8f73332c8f4, 2dd90360-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9035a-bdfb-11e5-94fa-c8f73332c8f4, 2dd90363-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90357-bdfb-11e5-94fa-c8f73332c8f4, 2dd901cc-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90366-bdfb-11e5-94fa-c8f73332c8f4, 2dd90258-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9035d-bdfb-11e5-94fa-c8f73332c8f4, 2dd9025e-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901c6-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: FORSMARK
+  parent_external_id: f17695af-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695af-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695af-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: SE3 SGR
+    SubGeographicalRegion.Region: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695af-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: SE3 SGR
+  parent_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+- data_set_id: 2626756768281823
+  external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: DANNEBO_HVDC
+    Substation.Region: f17695af-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9015c-bdfb-11e5-94fa-c8f73332c8f4, 2dd90358-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901cf-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: DANNEBO_HVDC
+  parent_external_id: f17695af-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: HJALTA
+    Substation.Region: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9036c-bdfb-11e5-94fa-c8f73332c8f4, 2dd90378-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90372-bdfb-11e5-94fa-c8f73332c8f4, 2dd90369-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9037b-bdfb-11e5-94fa-c8f73332c8f4, 2dd901d2-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9036f-bdfb-11e5-94fa-c8f73332c8f4, 2dd9015e-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90375-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695be-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: HJALTA
+  parent_external_id: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: SE2 SGR
+    SubGeographicalRegion.Region: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: SE2 SGR
+  parent_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: PORJUS
+    Substation.Region: f17695cd-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9035b-bdfb-11e5-94fa-c8f73332c8f4, 2dd90268-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901d5-bdfb-11e5-94fa-c8f73332c8f4, 2dd9026b-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90381-bdfb-11e5-94fa-c8f73332c8f4, 2dd9026e-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90265-bdfb-11e5-94fa-c8f73332c8f4, 2dd90384-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9037e-bdfb-11e5-94fa-c8f73332c8f4, 2dd90387-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9036a-bdfb-11e5-94fa-c8f73332c8f4, 2dd90262-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90162-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: PORJUS
+  parent_external_id: f17695cd-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695cd-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695cd-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: SE1 SGR
+    SubGeographicalRegion.Region: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695cd-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: SE1 SGR
+  parent_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+- data_set_id: 2626756768281823
+  external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: TENHULT
+    Substation.Region: f17695af-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90166-bdfb-11e5-94fa-c8f73332c8f4, 2dd9038d-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90373-bdfb-11e5-94fa-c8f73332c8f4, 2dd90370-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9036d-bdfb-11e5-94fa-c8f73332c8f4, 2dd9038a-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90390-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: TENHULT
+  parent_external_id: f17695af-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: HOGASEN
+    Substation.Region: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90393-bdfb-11e5-94fa-c8f73332c8f4, 2dd90168-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90439-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: HOGASEN
+  parent_external_id: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695df-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: JARPSTROMMEN
+    Substation.Region: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9035e-bdfb-11e5-94fa-c8f73332c8f4, 2dd90361-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9043d-bdfb-11e5-94fa-c8f73332c8f4, 2dd9016b-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9037f-bdfb-11e5-94fa-c8f73332c8f4, 2dd90272-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695df-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: JARPSTROMMEN
+  parent_external_id: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: GRUNDFORS
+    Substation.Region: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90376-bdfb-11e5-94fa-c8f73332c8f4, 2dd90382-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9016d-bdfb-11e5-94fa-c8f73332c8f4, 2dd90276-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90285-bdfb-11e5-94fa-c8f73332c8f4, 2dd90279-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90282-bdfb-11e5-94fa-c8f73332c8f4, 2dd901d8-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90396-bdfb-11e5-94fa-c8f73332c8f4, 2dd9028b-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90444-bdfb-11e5-94fa-c8f73332c8f4, 2dd9027c-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9027f-bdfb-11e5-94fa-c8f73332c8f4, 2dd90288-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: GRUNDFORS
+  parent_external_id: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: OSKARSHAMN
+    Substation.Region: f17695af-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9038b-bdfb-11e5-94fa-c8f73332c8f4, 2dd90364-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90292-bdfb-11e5-94fa-c8f73332c8f4, 2dd9016f-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90298-bdfb-11e5-94fa-c8f73332c8f4, 2dd9029e-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9028f-bdfb-11e5-94fa-c8f73332c8f4, 2dd90399-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901db-bdfb-11e5-94fa-c8f73332c8f4, 2dd901de-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90295-bdfb-11e5-94fa-c8f73332c8f4, 2dd9029b-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9039c-bdfb-11e5-94fa-c8f73332c8f4, 2dd90367-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: OSKARSHAMN
+  parent_external_id: f17695af-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: RINGHALS
+    Substation.Region: f17695af-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9038e-bdfb-11e5-94fa-c8f73332c8f4, 2dd902ab-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901e1-bdfb-11e5-94fa-c8f73332c8f4, 2dd902a5-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90447-bdfb-11e5-94fa-c8f73332c8f4, 2dd903a5-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9037c-bdfb-11e5-94fa-c8f73332c8f4, 2dd902ae-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9039f-bdfb-11e5-94fa-c8f73332c8f4, 2dd901e4-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd902b1-bdfb-11e5-94fa-c8f73332c8f4, 2dd903a2-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90379-bdfb-11e5-94fa-c8f73332c8f4, 2dd901e7-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd902a2-bdfb-11e5-94fa-c8f73332c8f4, 2dd903a8-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90171-bdfb-11e5-94fa-c8f73332c8f4, 2dd902a8-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901ea-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: RINGHALS
+  parent_external_id: f17695af-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: STENKU_HVDC
+    Substation.Region: f17695af-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9044b-bdfb-11e5-94fa-c8f73332c8f4, 2dd901ed-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90173-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: STENKU_HVDC
+  parent_external_id: f17695af-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: AJAURE
+    Substation.Region: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903ab-bdfb-11e5-94fa-c8f73332c8f4, 2dd90440-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90176-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: AJAURE
+  parent_external_id: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769604-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: TRETTEN
+    Substation.Region: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90452-bdfb-11e5-94fa-c8f73332c8f4, 2dd902b8-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903b1-bdfb-11e5-94fa-c8f73332c8f4, 2dd901f0-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd902b5-bdfb-11e5-94fa-c8f73332c8f4, 2dd903ae-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90178-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769604-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: TRETTEN
+  parent_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: NO1 SGR
+    SubGeographicalRegion.Region: lazarevac, 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: NO1 SGR
+  parent_external_id: lazarevac
+- data_set_id: 2626756768281823
+  external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: HALDEN
+    Substation.Region: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903b7-bdfb-11e5-94fa-c8f73332c8f4, 2dd9017c-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903ba-bdfb-11e5-94fa-c8f73332c8f4, 2dd903b4-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903a3-bdfb-11e5-94fa-c8f73332c8f4, 2dd903be-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9044e-bdfb-11e5-94fa-c8f73332c8f4, 2dd903a0-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f176960e-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: HALDEN
+  parent_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769614-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: DAGALI
+    Substation.Region: f1769619-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903c3-bdfb-11e5-94fa-c8f73332c8f4, 2dd903cd-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9017e-bdfb-11e5-94fa-c8f73332c8f4, 2dd903b5-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903c9-bdfb-11e5-94fa-c8f73332c8f4, 2dd903c6-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769614-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: DAGALI
+  parent_external_id: f1769619-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769619-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769619-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: NO5 SGR
+    SubGeographicalRegion.Region: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769619-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: NO5 SGR
+  parent_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+- data_set_id: 2626756768281823
+  external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176961e-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: KONGSBERG
+    Substation.Region: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903b8-bdfb-11e5-94fa-c8f73332c8f4, 2dd903d2-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903d5-bdfb-11e5-94fa-c8f73332c8f4, 2dd90182-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903c4-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f176961e-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: KONGSBERG
+  parent_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: SIMA
+    Substation.Region: f1769619-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903d8-bdfb-11e5-94fa-c8f73332c8f4, 2dd901f3-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd902bc-bdfb-11e5-94fa-c8f73332c8f4, 2dd90455-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd902cb-bdfb-11e5-94fa-c8f73332c8f4, 2dd902c5-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd902c8-bdfb-11e5-94fa-c8f73332c8f4, 2dd90184-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd902bf-bdfb-11e5-94fa-c8f73332c8f4, 2dd902c2-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769624-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: SIMA
+  parent_external_id: f1769619-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176962a-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: AURLAND
+    Substation.Region: f1769619-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903db-bdfb-11e5-94fa-c8f73332c8f4, 2dd903de-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90459-bdfb-11e5-94fa-c8f73332c8f4, 2dd903e1-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90186-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f176962a-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: AURLAND
+  parent_external_id: f1769619-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769630-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: GEILO
+    Substation.Region: f1769619-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903d3-bdfb-11e5-94fa-c8f73332c8f4, 2dd903e7-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903c7-bdfb-11e5-94fa-c8f73332c8f4, 2dd90188-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903e4-bdfb-11e5-94fa-c8f73332c8f4, 2dd903d6-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903dc-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769630-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: GEILO
+  parent_external_id: f1769619-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769636-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: EIDFJORD
+    Substation.Region: f1769619-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903e8-bdfb-11e5-94fa-c8f73332c8f4, 2dd903e5-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903df-bdfb-11e5-94fa-c8f73332c8f4, 2dd9018a-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769636-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: EIDFJORD
+  parent_external_id: f1769619-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: OSLO
+    Substation.Region: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd901f6-bdfb-11e5-94fa-c8f73332c8f4, 2dd903ea-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9018c-bdfb-11e5-94fa-c8f73332c8f4, 2dd902d2-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90463-bdfb-11e5-94fa-c8f73332c8f4, 2dd903ed-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9045c-bdfb-11e5-94fa-c8f73332c8f4, 2dd902cf-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f176963c-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: OSLO
+  parent_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769642-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: SYLLING
+    Substation.Region: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90460-bdfb-11e5-94fa-c8f73332c8f4, 2dd903f0-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903f6-bdfb-11e5-94fa-c8f73332c8f4, 2dd903f3-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903fa-bdfb-11e5-94fa-c8f73332c8f4, 2dd9018e-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769642-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: SYLLING
+  parent_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769648-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: SYSLE
+    Substation.Region: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903ff-bdfb-11e5-94fa-c8f73332c8f4, 2dd90467-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90190-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769648-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: SYSLE
+  parent_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: ASKER
+    Substation.Region: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9046a-bdfb-11e5-94fa-c8f73332c8f4, 2dd902d6-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903af-bdfb-11e5-94fa-c8f73332c8f4, 2dd90192-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90406-bdfb-11e5-94fa-c8f73332c8f4, 2dd901fc-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903eb-bdfb-11e5-94fa-c8f73332c8f4, 2dd90402-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd902d9-bdfb-11e5-94fa-c8f73332c8f4, 2dd901f9-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f176964e-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: ASKER
+  parent_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769654-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: SKIEN
+    Substation.Region: f1769609-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903f1-bdfb-11e5-94fa-c8f73332c8f4, 2dd90194-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9046e-bdfb-11e5-94fa-c8f73332c8f4, 2dd903bb-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903c1-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769654-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: SKIEN
+  parent_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: KRISTIANSAND
+    Substation.Region: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: f723530d-ae1e-df4f-9c7f-21e42da147d6, 84775b5d-95c1-bd46-bb0d-0f74e4c06757,
+      5c3fa20d-4748-5e44-b915-481e6d2552cd, 0619c12e-abb9-b141-b3a7-e2788d3d375c,
+      e65c4130-3a4d-db42-9020-c9f7c447d473, 2e98d68c-e0c5-6d47-b392-a1746743ef63,
+      947636e9-e939-294e-a94b-2090060b74ca, 5ffde614-bc34-384d-923e-e62ac9f3f584,
+      0dae5d37-4d01-3645-9e94-607410c5ac34, 67bc203e-13e4-534b-94b8-bf19f5b31080,
+      30ab0123-1669-1242-99ca-610e4bcdc6c5, 8d35b51b-06bd-7541-b3e6-2ddbbb1204fe,
+      8e8e6b0c-ee96-7a4f-9790-c9ae62edafbe, 5ddb272d-00bd-d74e-8c96-e2049351c3e4,
+      ad970e05-69d9-5340-9dbd-ce6a9a2e0996, 0345061e-37c9-9a49-b632-2af77bdca3a2,
+      2a67a243-6e4a-a84d-8aea-f250399166c9, 6abb96f5-a71f-8e41-b563-7c569789d6bd,
+      da4b0f71-a251-f947-be12-2de53a2d272a, 6ac2f3cd-c906-0a4b-ba1b-5942e9c65307,
+      7d101d2b-ce05-9843-ab59-2c3e5e244cbb, f710cc4a-50dd-e443-8ac7-4c56b70041e8,
+      329965e7-b5de-c54f-856a-358c9e1f9c50, 37c82b4c-7441-9946-98bf-7ade99732ecf,
+      2dd90202-bdfb-11e5-94fa-c8f73332c8f4, 70f1852f-186d-5e43-98bf-b69f028cfcc5,
+      d92cb2eb-fd81-194c-9e43-618df025d6b4, c1ca1160-be67-9448-a16b-e92a6112e380,
+      2dd902e6-bdfb-11e5-94fa-c8f73332c8f4, 925f3ab7-54ce-b748-887a-fc6ae23bbdc2,
+      38b8e08a-112e-b046-8504-efef4beb0c17, a749d698-52a2-564e-8c6f-068fe62045fe,
+      e035c87e-704d-404f-8ea8-91c62e0d7d8a, 2f8c9437-e564-e948-8764-be3494565b1f,
+      cd25f47c-ad0c-f74d-8c0e-fd91a95505b6, 0b50ae74-92eb-f244-872b-07e629f53494,
+      692809cf-1bb4-8642-9b70-ee677f063304, f9e8d6d1-76e1-6c4d-a640-e128ecfa723e,
+      0a122f63-f2c6-ca43-be49-76571474d98c, c8f95fee-e9a6-a44b-97ac-23e272a05ecd,
+      e3d56d8b-5f71-3042-9734-7118977e887c, 40c8340e-7ccf-d446-8a6b-bffa19ec88e6,
+      2dd90196-bdfb-11e5-94fa-c8f73332c8f4, 0d7f39d0-5447-fb42-9d4f-3d0775bceef0,
+      efe663e2-7518-3044-88d4-209bf597536a, 3718af45-a6ee-fb40-a4c6-f1118c114393,
+      7f811234-10fe-e34f-a9af-9af61a6dd4c7, 2dd902dd-bdfb-11e5-94fa-c8f73332c8f4,
+      caa10f15-4591-e241-ac0b-81675acf5687, f08f910c-300e-8941-aa85-3106d93e3429,
+      2dd90414-bdfb-11e5-94fa-c8f73332c8f4, ad37e24a-9993-4f45-80ed-49a80b6a85d9,
+      16659ede-d69f-1d48-bcf2-ebb2ee6c259e, e25c03e3-96a7-a64f-b776-a155f009d5f8,
+      a4bc44aa-25e4-684a-ab2c-c7fc3378d9e5, ea014fdb-b96f-2a4b-b1df-d38e846d4941,
+      2dd9040e-bdfb-11e5-94fa-c8f73332c8f4, 714c775a-246f-e34f-9a6b-667f4b66138c,
+      292835be-c432-734c-8c28-3b8c61c0c077, eaf768b1-3d82-c64d-a1c6-5bd7f9a72751,
+      c1aa295d-e817-db46-b14e-bee2739fcd9d, 8574aebb-23c4-3e4a-bd04-b5651c97d27a,
+      2dd90411-bdfb-11e5-94fa-c8f73332c8f4, 854b40ee-7109-d04c-b4ef-f0665722e451,
+      4a5b7813-14d3-fa4d-8907-edcdce7dbfd9, 2dd902e3-bdfb-11e5-94fa-c8f73332c8f4,
+      ae68b597-69fb-e14b-a070-67c7dcc1d698, c95039b2-aea2-ad4d-b444-c6efc77461e5,
+      2dd902e0-bdfb-11e5-94fa-c8f73332c8f4, 7af49a35-a119-5443-84be-af343b7761c8,
+      a2a690ef-b78a-3f46-90c5-5d434e26a64e, f4dba262-3ff3-9f41-961d-7fbe1f8a0cd7,
+      b016bc42-5a9f-ec42-b326-e9b9eed9e6d3, 093a3df5-0583-894f-99c9-016d752ff920,
+      e3ef93a1-723a-224e-8863-472e4f269633, 2dd9040b-bdfb-11e5-94fa-c8f73332c8f4,
+      d7a472cc-6b91-564d-93b4-0f3c24f2342c, cf654436-a05a-7948-8cc3-f3a288608964,
+      13116d72-3969-1344-91a7-14fb404a00c0, a0ad0036-fbee-6646-b195-3a86614529f2,
+      2dd901ff-bdfb-11e5-94fa-c8f73332c8f4, bc0f852a-3cc8-e143-8174-f0854a2d38aa,
+      40725e5a-33bf-6046-8d11-da19f9c726b4, b3ff19da-83b8-5e40-b38c-38982b748732,
+      c8ac9d5f-d60e-a345-8790-12b86184c31b, dae3bb4b-0a86-9243-99c1-a1d5b163774d,
+      9b49634c-4910-9841-b595-0d0cb0d0d1de, ecfaf384-4581-4249-8646-b5d31943ad61,
+      5831696b-e9e1-8e4a-a169-0e4e09f15f1f, 67dfc70a-36cf-da4e-b97c-fd1eda9cd8ac,
+      79887cf1-6c94-3f4f-a1f8-7ddef866d55f, 71d09d39-a080-5d4f-86f3-7b3185e51b8e
+    active: 'true'
+    identifier: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: KRISTIANSAND
+  parent_external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: NO2 SGR
+    SubGeographicalRegion.Region: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: NO2 SGR
+  parent_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+- data_set_id: 2626756768281823
+  external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769664-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: STAVANGER
+    Substation.Region: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9040c-bdfb-11e5-94fa-c8f73332c8f4, 2dd90471-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9019a-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769664-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: STAVANGER
+  parent_external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176966a-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: SANDEFJORD
+    Substation.Region: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903f4-bdfb-11e5-94fa-c8f73332c8f4, 2dd9019c-bdfb-11e5-94fa-c8f73332c8f4,
+      02b41435-bd3e-bb4b-9b89-24e3a8983c0f
+    active: 'true'
+    identifier: f176966a-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: SANDEFJORD
+  parent_external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: ARENDAL
+    Substation.Region: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: ee4223ab-0538-dc4a-9b79-d463c048bb08, e2f56599-a78e-494f-8db3-c0b0bdab1d70,
+      3916ae31-9f3d-af4e-8d87-87d373d8200a, 51883d43-111e-f24b-89f7-0573426fa32f,
+      ab88a3a2-a572-3440-be06-757e0225ea42, bff806b2-7825-af4c-a34b-be542dbe5ae6,
+      fe798f30-0725-e94e-8142-c06ca7701b14, 076da31b-080d-c742-9cb1-134a6ba5b1ed,
+      a949cafd-39f3-8e4c-bca5-9928b004b4da, d28bc89e-0592-1440-9721-5cbe124c1f1b,
+      2dd9019e-bdfb-11e5-94fa-c8f73332c8f4, 2dd9040f-bdfb-11e5-94fa-c8f73332c8f4,
+      8f8094c3-5c43-1241-9014-6c7a3ae10213, d288bd96-ae6e-cf46-9775-f38e2699f1ce,
+      2dd90478-bdfb-11e5-94fa-c8f73332c8f4, 9acd76b4-8d78-2b4b-81d5-e404e244997d,
+      b77c60e8-fe4f-9149-9bc6-c3eb8f899de2, 2e64900b-94a8-6e40-bd63-3e69510c316f,
+      6da89f37-cc6f-4e4e-8b20-975295017390, db724627-9dae-4748-b4e3-2daf627ffa17,
+      2dd90409-bdfb-11e5-94fa-c8f73332c8f4, 356c6f11-da4d-3f4d-b3fd-49234106345c,
+      8a0babd6-6d6f-854b-b65f-4245e65c9e9c, 2dd90403-bdfb-11e5-94fa-c8f73332c8f4,
+      c3458e72-1c7a-a74b-b561-8afe0a3aa2be, 22c3512a-fdf2-464c-b1f4-85d173fa2d18,
+      669c1d0c-87dd-a943-9316-88308bd36f15, 5906b2a0-4ec9-1949-98b8-709380af0060,
+      2dd90417-bdfb-11e5-94fa-c8f73332c8f4, 761a49da-2b71-2d4e-877f-3cf7fa86ef63,
+      eba035f1-7c96-0142-8561-37b28625abf7, 1a6d8d77-f2ca-f043-b475-f7db6304fe3e,
+      0ef62251-5e2e-d14a-aa44-396d4a885c4f, 1ef7a41b-2cff-6046-b48f-c60a16fd20b0,
+      dc791b3b-fe63-a14b-b144-953748088613, 2dd9047c-bdfb-11e5-94fa-c8f73332c8f4,
+      a533d3fd-822f-3b40-9030-e18b571cd1ea, eb8b2a90-9bc8-154f-92dd-3887e3676498,
+      aadfa134-666a-ae4f-8c09-6f3ae114c3b5
+    active: 'true'
+    identifier: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: ARENDAL
+  parent_external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769676-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: KRISTIA_HVDC
+    Substation.Region: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd901a0-bdfb-11e5-94fa-c8f73332c8f4, 2dd90418-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90205-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769676-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: KRISTIA_HVDC
+  parent_external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176967c-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: FEDA_HVDC
+    Substation.Region: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd901a2-bdfb-11e5-94fa-c8f73332c8f4, 2dd90208-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90412-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f176967c-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: FEDA_HVDC
+  parent_external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: KVILLDAL
+    Substation.Region: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9041a-bdfb-11e5-94fa-c8f73332c8f4, 2dd901a4-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90415-bdfb-11e5-94fa-c8f73332c8f4, 2dd902ea-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd902f3-bdfb-11e5-94fa-c8f73332c8f4, 2dd902f0-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903ee-bdfb-11e5-94fa-c8f73332c8f4, 2dd902ed-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9047f-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769682-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: KVILLDAL
+  parent_external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: HAGAFOSS
+    Substation.Region: f1769619-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd903fd-bdfb-11e5-94fa-c8f73332c8f4, 2dd903d0-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90483-bdfb-11e5-94fa-c8f73332c8f4, 2dd903f7-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903e2-bdfb-11e5-94fa-c8f73332c8f4, 2dd90475-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90400-bdfb-11e5-94fa-c8f73332c8f4, terminal-without-name-property, 2dd903ca-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: HAGAFOSS
+  parent_external_id: f1769619-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: BLAFALLI
+    Substation.Region: f176965f-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90303-bdfb-11e5-94fa-c8f73332c8f4, 2dd902fd-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9020b-bdfb-11e5-94fa-c8f73332c8f4, 2dd902fa-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901a8-bdfb-11e5-94fa-c8f73332c8f4, 2dd9020e-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd903d9-bdfb-11e5-94fa-c8f73332c8f4, 2dd902f7-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9041b-bdfb-11e5-94fa-c8f73332c8f4, 2dd90300-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f176968e-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: BLAFALLI
+  parent_external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: TRONDHEIM
+    Substation.Region: f1769699-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd9041d-bdfb-11e5-94fa-c8f73332c8f4, 2dd90211-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9030a-bdfb-11e5-94fa-c8f73332c8f4, 2dd90214-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90217-bdfb-11e5-94fa-c8f73332c8f4, 2dd90420-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901aa-bdfb-11e5-94fa-c8f73332c8f4, 2dd90310-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9030d-bdfb-11e5-94fa-c8f73332c8f4, 2dd903b2-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90307-bdfb-11e5-94fa-c8f73332c8f4, 2dd90394-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769694-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: TRONDHEIM
+  parent_external_id: f1769699-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f1769699-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f1769699-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: NO3 SGR
+    SubGeographicalRegion.Region: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f1769699-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: NO3 SGR
+  parent_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: MO
+    Substation.Region: f17696a3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90314-bdfb-11e5-94fa-c8f73332c8f4, 2dd9031d-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901ae-bdfb-11e5-94fa-c8f73332c8f4, 2dd9031a-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9041e-bdfb-11e5-94fa-c8f73332c8f4, 2dd903ac-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90317-bdfb-11e5-94fa-c8f73332c8f4, 2dd90486-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9021a-bdfb-11e5-94fa-c8f73332c8f4, 2dd90421-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f176969e-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: MO
+  parent_external_id: f17696a3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17696a3-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696a3-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: NO4 SGR
+    SubGeographicalRegion.Region: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696a3-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: NO4 SGR
+  parent_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+- data_set_id: 2626756768281823
+  external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: NARVIK
+    Substation.Region: f17696a3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90385-bdfb-11e5-94fa-c8f73332c8f4, 2dd90220-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901b2-bdfb-11e5-94fa-c8f73332c8f4, 2dd9048a-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9021d-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: NARVIK
+  parent_external_id: f17696a3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: HELSINKI
+    Substation.Region: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90339-bdfb-11e5-94fa-c8f73332c8f4, 2dd9032a-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90336-bdfb-11e5-94fa-c8f73332c8f4, 2dd90324-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9032d-bdfb-11e5-94fa-c8f73332c8f4, 2dd9042f-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9042c-bdfb-11e5-94fa-c8f73332c8f4, 2dd90321-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90333-bdfb-11e5-94fa-c8f73332c8f4, 2dd90327-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90429-bdfb-11e5-94fa-c8f73332c8f4, 2dd9022f-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90226-bdfb-11e5-94fa-c8f73332c8f4, 2dd90330-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90423-bdfb-11e5-94fa-c8f73332c8f4, 2dd90232-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90229-bdfb-11e5-94fa-c8f73332c8f4, 2dd9022c-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901b4-bdfb-11e5-94fa-c8f73332c8f4, 2dd90426-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90223-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: HELSINKI
+  parent_external_id: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: FI1 SGR
+    SubGeographicalRegion.Region: ''
+    active: 'true'
+    identifier: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: FI1 SGR
+  parent_external_id: orphanage
+- data_set_id: 2626756768281823
+  external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: VYBORG_HVDC
+    Substation.Region: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90235-bdfb-11e5-94fa-c8f73332c8f4, 2dd901b8-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90424-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: VYBORG_HVDC
+  parent_external_id: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696be-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: ESTLINK_HVDC
+    Substation.Region: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90238-bdfb-11e5-94fa-c8f73332c8f4, 2dd901ba-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90427-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696be-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: ESTLINK_HVDC
+  parent_external_id: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: OULU
+    Substation.Region: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd901bc-bdfb-11e5-94fa-c8f73332c8f4, 2dd90388-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90343-bdfb-11e5-94fa-c8f73332c8f4, 2dd9023e-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90430-bdfb-11e5-94fa-c8f73332c8f4, 2dd9042a-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9023b-bdfb-11e5-94fa-c8f73332c8f4, 2dd90397-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90340-bdfb-11e5-94fa-c8f73332c8f4, 2dd9042d-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90241-bdfb-11e5-94fa-c8f73332c8f4, 2dd9033d-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: OULU
+  parent_external_id: f17696b3-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: MALMO
+    Substation.Region: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90432-bdfb-11e5-94fa-c8f73332c8f4, 2dd903a6-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90244-bdfb-11e5-94fa-c8f73332c8f4, 2dd90353-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90391-bdfb-11e5-94fa-c8f73332c8f4, 2dd9034d-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9034a-bdfb-11e5-94fa-c8f73332c8f4, 2dd9024d-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9039a-bdfb-11e5-94fa-c8f73332c8f4, 2dd90350-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd901be-bdfb-11e5-94fa-c8f73332c8f4, 2dd903a9-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90435-bdfb-11e5-94fa-c8f73332c8f4, 2dd90247-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90356-bdfb-11e5-94fa-c8f73332c8f4, 2dd90347-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd9024a-bdfb-11e5-94fa-c8f73332c8f4, 2dd9039d-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: MALMO
+  parent_external_id: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: SubGeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: SE4 SGR
+    SubGeographicalRegion.Region: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+    type: SubGeographicalRegion
+  name: SE4 SGR
+  parent_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+- data_set_id: 2626756768281823
+  external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: ARRIE_HVDC
+    Substation.Region: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd901c2-bdfb-11e5-94fa-c8f73332c8f4, 2dd90250-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90433-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: ARRIE_HVDC
+  parent_external_id: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: f17696da-9aeb-11e5-91da-b8763fd99c5f
+    IdentifiedObject.name: KARLSH_HVDC
+    Substation.Region: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+    Substation.Terminal: 2dd90436-bdfb-11e5-94fa-c8f73332c8f4, 2dd901c4-bdfb-11e5-94fa-c8f73332c8f4,
+      2dd90253-bdfb-11e5-94fa-c8f73332c8f4
+    active: 'true'
+    identifier: f17696da-9aeb-11e5-91da-b8763fd99c5f
+    type: Substation
+  name: KARLSH_HVDC
+  parent_external_id: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f4dba262-3ff3-9f41-961d-7fbe1f8a0cd7
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: f4dba262-3ff3-9f41-961d-7fbe1f8a0cd7
+    IdentifiedObject.name: KRISTIAN300G1  AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: f4dba262-3ff3-9f41-961d-7fbe1f8a0cd7
+    type: Terminal
+  name: KRISTIAN300G1  AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f710cc4a-50dd-e443-8ac7-4c56b70041e8
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: f710cc4a-50dd-e443-8ac7-4c56b70041e8
+    IdentifiedObject.name: KRISTIAN300ST1 AB_S T2
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: f710cc4a-50dd-e443-8ac7-4c56b70041e8
+    type: Terminal
+  name: KRISTIAN300ST1 AB_S T2
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f723530d-ae1e-df4f-9c7f-21e42da147d6
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: f723530d-ae1e-df4f-9c7f-21e42da147d6
+    IdentifiedObject.name: KRISTIAN300G1  BB_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: f723530d-ae1e-df4f-9c7f-21e42da147d6
+    type: Terminal
+  name: KRISTIAN300G1  BB_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: f9e8d6d1-76e1-6c4d-a640-e128ecfa723e
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: f9e8d6d1-76e1-6c4d-a640-e128ecfa723e
+    IdentifiedObject.name: KRISTIAN300G3  AD_S T1
+    Terminal.Substation: f176965a-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: f9e8d6d1-76e1-6c4d-a640-e128ecfa723e
+    type: Terminal
+  name: KRISTIAN300G3  AD_S T1
+  parent_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: fe798f30-0725-e94e-8142-c06ca7701b14
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: fe798f30-0725-e94e-8142-c06ca7701b14
+    IdentifiedObject.name: ARENDAL 300KR1 AB_S T1
+    Terminal.Substation: f1769670-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: fe798f30-0725-e94e-8142-c06ca7701b14
+    type: Terminal
+  name: ARENDAL 300KR1 AB_S T1
+  parent_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+- data_set_id: 2626756768281823
+  external_id: lazarevac
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.mRID: lazarevac
+    IdentifiedObject.name: LA
+    RootCIMNode.node: ''
+    active: 'true'
+    identifier: lazarevac
+    type: GeographicalRegion
+  name: LA
+  parent_external_id: orphanage
+- data_set_id: 2626756768281823
+  external_id: orphanage
+  labels:
+  - externalId: Orphanage
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.description: Used to store all assets which parent does not exist
+    IdentifiedObject.mRID: ''
+    IdentifiedObject.name: Orphanage
+    active: 'true'
+    cdfResourceType: Asset
+    identifier: orphanage
+    type: Orphanage
+  name: Orphanage
+- data_set_id: 2626756768281823
+  external_id: root-node
+  labels:
+  - externalId: RootCIMNode
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.description: Used as root asset for all CIM objects
+    IdentifiedObject.mRID: ''
+    IdentifiedObject.name: Root CIM Node
+    active: 'true'
+    cdfResourceType: Asset
+    identifier: root-node
+    type: RootCIMNode
+  name: Root CIM Node
+- data_set_id: 2626756768281823
+  external_id: terminal-without-name-property
+  labels:
+  - externalId: Terminal
+  - externalId: non-historic
+  metadata:
+    IdentifiedObject.aliasName: ''
+    IdentifiedObject.mRID: terminal-without-name-property
+    IdentifiedObject.name: ''
+    Terminal.Substation: f1769688-9aeb-11e5-91da-b8763fd99c5f
+    active: 'true'
+    identifier: terminal-without-name-property
+    type: Terminal
+  name: terminal-without-name-property
+  parent_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+labels:
+- data_set_id: 2626756768281823
+  external_id: Analog
+  name: Analog
+- data_set_id: 2626756768281823
+  external_id: GeographicalRegion
+  name: GeographicalRegion
+- data_set_id: 2626756768281823
+  external_id: IdentifiedObject.aliasName
+  name: IdentifiedObject.aliasName
+- data_set_id: 2626756768281823
+  external_id: IdentifiedObject.mRID
+  name: IdentifiedObject.mRID
+- data_set_id: 2626756768281823
+  external_id: IdentifiedObject.name
+  name: IdentifiedObject.name
+- data_set_id: 2626756768281823
+  external_id: Orphanage
+  name: Orphanage
+- data_set_id: 2626756768281823
+  external_id: RootCIMNode
+  name: RootCIMNode
+- data_set_id: 2626756768281823
+  external_id: RootCIMNode.node
+  name: RootCIMNode.node
+- data_set_id: 2626756768281823
+  external_id: SubGeographicalRegion
+  name: SubGeographicalRegion
+- data_set_id: 2626756768281823
+  external_id: SubGeographicalRegion.Region
+  name: SubGeographicalRegion.Region
+- data_set_id: 2626756768281823
+  external_id: Substation
+  name: Substation
+- data_set_id: 2626756768281823
+  external_id: Substation.Region
+  name: Substation.Region
+- data_set_id: 2626756768281823
+  external_id: Substation.Terminal
+  name: Substation.Terminal
+- data_set_id: 2626756768281823
+  external_id: Terminal
+  name: Terminal
+- data_set_id: 2626756768281823
+  external_id: Terminal.Substation
+  name: Terminal.Substation
+- data_set_id: 2626756768281823
+  external_id: belongsTo
+  name: belongsTo
+- data_set_id: 2626756768281823
+  external_id: connectsTo
+  name: connectsTo
+- data_set_id: 2626756768281823
+  external_id: historic
+  name: historic
+- data_set_id: 2626756768281823
+  external_id: non-historic
+  name: non-historic
+relationships:
+- data_set_id: 2626756768281823
+  external_id: 02b41435-bd3e-bb4b-9b89-24e3a8983c0f:f176966a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 02b41435-bd3e-bb4b-9b89-24e3a8983c0f
+  source_type: Asset
+  target_external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 0345061e-37c9-9a49-b632-2af77bdca3a2:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 0345061e-37c9-9a49-b632-2af77bdca3a2
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 0619c12e-abb9-b141-b3a7-e2788d3d375c:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 0619c12e-abb9-b141-b3a7-e2788d3d375c
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 076da31b-080d-c742-9cb1-134a6ba5b1ed:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 076da31b-080d-c742-9cb1-134a6ba5b1ed
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 093a3df5-0583-894f-99c9-016d752ff920:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 093a3df5-0583-894f-99c9-016d752ff920
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 0a122f63-f2c6-ca43-be49-76571474d98c:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 0a122f63-f2c6-ca43-be49-76571474d98c
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 0b50ae74-92eb-f244-872b-07e629f53494:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 0b50ae74-92eb-f244-872b-07e629f53494
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 0d7f39d0-5447-fb42-9d4f-3d0775bceef0:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 0d7f39d0-5447-fb42-9d4f-3d0775bceef0
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 0dae5d37-4d01-3645-9e94-607410c5ac34:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 0dae5d37-4d01-3645-9e94-607410c5ac34
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 0ef62251-5e2e-d14a-aa44-396d4a885c4f:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 0ef62251-5e2e-d14a-aa44-396d4a885c4f
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 13116d72-3969-1344-91a7-14fb404a00c0:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 13116d72-3969-1344-91a7-14fb404a00c0
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 16659ede-d69f-1d48-bcf2-ebb2ee6c259e:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 16659ede-d69f-1d48-bcf2-ebb2ee6c259e
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 1a6d8d77-f2ca-f043-b475-f7db6304fe3e:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 1a6d8d77-f2ca-f043-b475-f7db6304fe3e
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 1ef7a41b-2cff-6046-b48f-c60a16fd20b0:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 1ef7a41b-2cff-6046-b48f-c60a16fd20b0
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 22c3512a-fdf2-464c-b1f4-85d173fa2d18:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 22c3512a-fdf2-464c-b1f4-85d173fa2d18
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 292835be-c432-734c-8c28-3b8c61c0c077:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 292835be-c432-734c-8c28-3b8c61c0c077
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2a67a243-6e4a-a84d-8aea-f250399166c9:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2a67a243-6e4a-a84d-8aea-f250399166c9
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90156-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90156-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9015c-bdfb-11e5-94fa-c8f73332c8f4:f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9015c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9015e-bdfb-11e5-94fa-c8f73332c8f4:f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9015e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90162-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90162-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90166-bdfb-11e5-94fa-c8f73332c8f4:f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90166-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90168-bdfb-11e5-94fa-c8f73332c8f4:f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90168-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9016b-bdfb-11e5-94fa-c8f73332c8f4:f17695df-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9016b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9016d-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9016d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9016f-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9016f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90171-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90171-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90173-bdfb-11e5-94fa-c8f73332c8f4:f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90173-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90176-bdfb-11e5-94fa-c8f73332c8f4:f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90176-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90178-bdfb-11e5-94fa-c8f73332c8f4:f1769604-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90178-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9017c-bdfb-11e5-94fa-c8f73332c8f4:f176960e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9017c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9017e-bdfb-11e5-94fa-c8f73332c8f4:f1769614-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9017e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90182-bdfb-11e5-94fa-c8f73332c8f4:f176961e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90182-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90184-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90184-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90186-bdfb-11e5-94fa-c8f73332c8f4:f176962a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90186-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90188-bdfb-11e5-94fa-c8f73332c8f4:f1769630-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90188-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9018a-bdfb-11e5-94fa-c8f73332c8f4:f1769636-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9018a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9018c-bdfb-11e5-94fa-c8f73332c8f4:f176963c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9018c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9018e-bdfb-11e5-94fa-c8f73332c8f4:f1769642-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9018e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90190-bdfb-11e5-94fa-c8f73332c8f4:f1769648-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90190-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90192-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90192-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90194-bdfb-11e5-94fa-c8f73332c8f4:f1769654-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90194-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90196-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90196-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9019a-bdfb-11e5-94fa-c8f73332c8f4:f1769664-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9019a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9019c-bdfb-11e5-94fa-c8f73332c8f4:f176966a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9019c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9019e-bdfb-11e5-94fa-c8f73332c8f4:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9019e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901a0-bdfb-11e5-94fa-c8f73332c8f4:f1769676-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901a0-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901a2-bdfb-11e5-94fa-c8f73332c8f4:f176967c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901a2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901a4-bdfb-11e5-94fa-c8f73332c8f4:f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901a4-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901a8-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901a8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901aa-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901aa-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901ae-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901ae-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901b2-bdfb-11e5-94fa-c8f73332c8f4:f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901b2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901b4-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901b4-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901b8-bdfb-11e5-94fa-c8f73332c8f4:f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901b8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901ba-bdfb-11e5-94fa-c8f73332c8f4:f17696be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901ba-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901bc-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901bc-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901be-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901be-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901c2-bdfb-11e5-94fa-c8f73332c8f4:f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901c2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901c4-bdfb-11e5-94fa-c8f73332c8f4:f17696da-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901c4-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901c6-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901c6-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901c9-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901c9-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901cc-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901cc-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901cf-bdfb-11e5-94fa-c8f73332c8f4:f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901cf-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901d2-bdfb-11e5-94fa-c8f73332c8f4:f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901d2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901d5-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901d5-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901d8-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901d8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901db-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901db-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901de-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901de-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901e1-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901e1-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901e4-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901e4-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901e7-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901e7-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901ea-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901ea-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901ed-bdfb-11e5-94fa-c8f73332c8f4:f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901ed-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901f0-bdfb-11e5-94fa-c8f73332c8f4:f1769604-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901f0-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901f3-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901f3-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901f6-bdfb-11e5-94fa-c8f73332c8f4:f176963c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901f6-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901f9-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901f9-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901fc-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901fc-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd901ff-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd901ff-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90202-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90202-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90205-bdfb-11e5-94fa-c8f73332c8f4:f1769676-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90205-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90208-bdfb-11e5-94fa-c8f73332c8f4:f176967c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90208-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9020b-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9020b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9020e-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9020e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90211-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90211-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90214-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90214-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90217-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90217-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9021a-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9021a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9021d-bdfb-11e5-94fa-c8f73332c8f4:f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9021d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90220-bdfb-11e5-94fa-c8f73332c8f4:f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90220-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90223-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90223-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90226-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90226-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90229-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90229-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9022c-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9022c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9022f-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9022f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90232-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90232-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90235-bdfb-11e5-94fa-c8f73332c8f4:f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90235-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90238-bdfb-11e5-94fa-c8f73332c8f4:f17696be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90238-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9023b-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9023b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9023e-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9023e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90241-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90241-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90244-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90244-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90247-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90247-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9024a-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9024a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9024d-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9024d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90250-bdfb-11e5-94fa-c8f73332c8f4:f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90250-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90253-bdfb-11e5-94fa-c8f73332c8f4:f17696da-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90253-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90258-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90258-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9025b-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9025b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9025e-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9025e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90262-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90262-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90265-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90265-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90268-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90268-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9026b-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9026b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9026e-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9026e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90272-bdfb-11e5-94fa-c8f73332c8f4:f17695df-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90272-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90276-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90276-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90279-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90279-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9027c-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9027c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9027f-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9027f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90282-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90282-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90285-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90285-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90288-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90288-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9028b-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9028b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9028f-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9028f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90292-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90292-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90295-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90295-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90298-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90298-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9029b-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9029b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9029e-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9029e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902a2-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902a2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902a5-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902a5-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902a8-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902a8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902ab-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902ab-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902ae-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902ae-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902b1-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902b1-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902b5-bdfb-11e5-94fa-c8f73332c8f4:f1769604-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902b5-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902b8-bdfb-11e5-94fa-c8f73332c8f4:f1769604-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902b8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902bc-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902bc-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902bf-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902bf-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902c2-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902c2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902c5-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902c5-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902c8-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902c8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902cb-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902cb-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902cf-bdfb-11e5-94fa-c8f73332c8f4:f176963c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902cf-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902d2-bdfb-11e5-94fa-c8f73332c8f4:f176963c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902d2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902d6-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902d6-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902d9-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902d9-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902dd-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902dd-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902e0-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902e0-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902e3-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902e3-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902e6-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902e6-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902ea-bdfb-11e5-94fa-c8f73332c8f4:f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902ea-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902ed-bdfb-11e5-94fa-c8f73332c8f4:f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902ed-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902f0-bdfb-11e5-94fa-c8f73332c8f4:f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902f0-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902f3-bdfb-11e5-94fa-c8f73332c8f4:f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902f3-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902f7-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902f7-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902fa-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902fa-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd902fd-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd902fd-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90300-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90300-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90303-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90303-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90307-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90307-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9030a-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9030a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9030d-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9030d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90310-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90310-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90314-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90314-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90317-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90317-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9031a-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9031a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9031d-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9031d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90321-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90321-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90324-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90324-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90327-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90327-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9032a-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9032a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9032d-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9032d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90330-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90330-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90333-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90333-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90336-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90336-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90339-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90339-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9033d-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9033d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90340-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90340-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90343-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90343-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90347-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90347-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9034a-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9034a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9034d-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9034d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90350-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90350-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90353-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90353-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90356-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90356-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90357-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90357-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90358-bdfb-11e5-94fa-c8f73332c8f4:f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90358-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9035a-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9035a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9035b-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9035b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9035d-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9035d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9035e-bdfb-11e5-94fa-c8f73332c8f4:f17695df-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9035e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90360-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90360-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90361-bdfb-11e5-94fa-c8f73332c8f4:f17695df-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90361-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90363-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90363-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90364-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90364-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90366-bdfb-11e5-94fa-c8f73332c8f4:f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90366-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90367-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90367-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90369-bdfb-11e5-94fa-c8f73332c8f4:f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90369-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9036a-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9036a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9036c-bdfb-11e5-94fa-c8f73332c8f4:f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9036c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9036d-bdfb-11e5-94fa-c8f73332c8f4:f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9036d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9036f-bdfb-11e5-94fa-c8f73332c8f4:f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9036f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90370-bdfb-11e5-94fa-c8f73332c8f4:f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90370-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90372-bdfb-11e5-94fa-c8f73332c8f4:f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90372-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90373-bdfb-11e5-94fa-c8f73332c8f4:f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90373-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90375-bdfb-11e5-94fa-c8f73332c8f4:f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90375-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90376-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90376-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90378-bdfb-11e5-94fa-c8f73332c8f4:f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90378-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90379-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90379-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9037b-bdfb-11e5-94fa-c8f73332c8f4:f17695be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9037b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9037c-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9037c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9037e-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9037e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9037f-bdfb-11e5-94fa-c8f73332c8f4:f17695df-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9037f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90381-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90381-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90382-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90382-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90384-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90384-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90385-bdfb-11e5-94fa-c8f73332c8f4:f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90385-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90387-bdfb-11e5-94fa-c8f73332c8f4:f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90387-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90388-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90388-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9038a-bdfb-11e5-94fa-c8f73332c8f4:f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9038a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9038b-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9038b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9038d-bdfb-11e5-94fa-c8f73332c8f4:f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9038d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9038e-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9038e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90390-bdfb-11e5-94fa-c8f73332c8f4:f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90390-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90391-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90391-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90393-bdfb-11e5-94fa-c8f73332c8f4:f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90393-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90394-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90394-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90396-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90396-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90397-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90397-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90399-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90399-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9039a-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9039a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9039c-bdfb-11e5-94fa-c8f73332c8f4:f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9039c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9039d-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9039d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9039f-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9039f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903a0-bdfb-11e5-94fa-c8f73332c8f4:f176960e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903a0-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903a2-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903a2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903a3-bdfb-11e5-94fa-c8f73332c8f4:f176960e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903a3-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903a5-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903a5-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903a6-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903a6-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903a8-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903a8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903a9-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903a9-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903ab-bdfb-11e5-94fa-c8f73332c8f4:f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903ab-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903ac-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903ac-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903ae-bdfb-11e5-94fa-c8f73332c8f4:f1769604-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903ae-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903af-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903af-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903b1-bdfb-11e5-94fa-c8f73332c8f4:f1769604-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903b1-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903b2-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903b2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903b4-bdfb-11e5-94fa-c8f73332c8f4:f176960e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903b4-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903b5-bdfb-11e5-94fa-c8f73332c8f4:f1769614-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903b5-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903b7-bdfb-11e5-94fa-c8f73332c8f4:f176960e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903b7-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903b8-bdfb-11e5-94fa-c8f73332c8f4:f176961e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903b8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903ba-bdfb-11e5-94fa-c8f73332c8f4:f176960e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903ba-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903bb-bdfb-11e5-94fa-c8f73332c8f4:f1769654-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903bb-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903be-bdfb-11e5-94fa-c8f73332c8f4:f176960e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903be-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903c1-bdfb-11e5-94fa-c8f73332c8f4:f1769654-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903c1-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903c3-bdfb-11e5-94fa-c8f73332c8f4:f1769614-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903c3-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903c4-bdfb-11e5-94fa-c8f73332c8f4:f176961e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903c4-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903c6-bdfb-11e5-94fa-c8f73332c8f4:f1769614-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903c6-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903c7-bdfb-11e5-94fa-c8f73332c8f4:f1769630-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903c7-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903c9-bdfb-11e5-94fa-c8f73332c8f4:f1769614-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903c9-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903ca-bdfb-11e5-94fa-c8f73332c8f4:f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903ca-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903cd-bdfb-11e5-94fa-c8f73332c8f4:f1769614-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903cd-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903d0-bdfb-11e5-94fa-c8f73332c8f4:f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903d0-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903d2-bdfb-11e5-94fa-c8f73332c8f4:f176961e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903d2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903d3-bdfb-11e5-94fa-c8f73332c8f4:f1769630-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903d3-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903d5-bdfb-11e5-94fa-c8f73332c8f4:f176961e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903d5-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903d6-bdfb-11e5-94fa-c8f73332c8f4:f1769630-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903d6-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903d8-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903d8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903d9-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903d9-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903db-bdfb-11e5-94fa-c8f73332c8f4:f176962a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903db-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903dc-bdfb-11e5-94fa-c8f73332c8f4:f1769630-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903dc-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903de-bdfb-11e5-94fa-c8f73332c8f4:f176962a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903de-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903df-bdfb-11e5-94fa-c8f73332c8f4:f1769636-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903df-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903e1-bdfb-11e5-94fa-c8f73332c8f4:f176962a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903e1-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903e2-bdfb-11e5-94fa-c8f73332c8f4:f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903e2-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903e4-bdfb-11e5-94fa-c8f73332c8f4:f1769630-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903e4-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903e5-bdfb-11e5-94fa-c8f73332c8f4:f1769636-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903e5-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903e7-bdfb-11e5-94fa-c8f73332c8f4:f1769630-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903e7-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903e8-bdfb-11e5-94fa-c8f73332c8f4:f1769636-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903e8-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903ea-bdfb-11e5-94fa-c8f73332c8f4:f176963c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903ea-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903eb-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903eb-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903ed-bdfb-11e5-94fa-c8f73332c8f4:f176963c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903ed-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903ee-bdfb-11e5-94fa-c8f73332c8f4:f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903ee-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903f0-bdfb-11e5-94fa-c8f73332c8f4:f1769642-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903f0-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903f1-bdfb-11e5-94fa-c8f73332c8f4:f1769654-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903f1-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903f3-bdfb-11e5-94fa-c8f73332c8f4:f1769642-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903f3-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903f4-bdfb-11e5-94fa-c8f73332c8f4:f176966a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903f4-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903f6-bdfb-11e5-94fa-c8f73332c8f4:f1769642-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903f6-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903f7-bdfb-11e5-94fa-c8f73332c8f4:f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903f7-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903fa-bdfb-11e5-94fa-c8f73332c8f4:f1769642-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903fa-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903fd-bdfb-11e5-94fa-c8f73332c8f4:f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903fd-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd903ff-bdfb-11e5-94fa-c8f73332c8f4:f1769648-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd903ff-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90400-bdfb-11e5-94fa-c8f73332c8f4:f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90400-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90402-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90402-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90403-bdfb-11e5-94fa-c8f73332c8f4:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90403-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90406-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90406-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90409-bdfb-11e5-94fa-c8f73332c8f4:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90409-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9040b-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9040b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9040c-bdfb-11e5-94fa-c8f73332c8f4:f1769664-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9040c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9040e-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9040e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9040f-bdfb-11e5-94fa-c8f73332c8f4:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9040f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90411-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90411-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90412-bdfb-11e5-94fa-c8f73332c8f4:f176967c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90412-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90414-bdfb-11e5-94fa-c8f73332c8f4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90414-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90415-bdfb-11e5-94fa-c8f73332c8f4:f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90415-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90417-bdfb-11e5-94fa-c8f73332c8f4:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90417-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90418-bdfb-11e5-94fa-c8f73332c8f4:f1769676-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90418-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9041a-bdfb-11e5-94fa-c8f73332c8f4:f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9041a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9041b-bdfb-11e5-94fa-c8f73332c8f4:f176968e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9041b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9041d-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9041d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9041e-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9041e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90420-bdfb-11e5-94fa-c8f73332c8f4:f1769694-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90420-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90421-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90421-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90423-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90423-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90424-bdfb-11e5-94fa-c8f73332c8f4:f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90424-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90426-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90426-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90427-bdfb-11e5-94fa-c8f73332c8f4:f17696be-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90427-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90429-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90429-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9042a-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9042a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9042c-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9042c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9042d-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9042d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9042f-bdfb-11e5-94fa-c8f73332c8f4:f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9042f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90430-bdfb-11e5-94fa-c8f73332c8f4:f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90430-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90432-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90432-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90433-bdfb-11e5-94fa-c8f73332c8f4:f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90433-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90435-bdfb-11e5-94fa-c8f73332c8f4:f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90435-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90436-bdfb-11e5-94fa-c8f73332c8f4:f17696da-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90436-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90439-bdfb-11e5-94fa-c8f73332c8f4:f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90439-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9043d-bdfb-11e5-94fa-c8f73332c8f4:f17695df-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9043d-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90440-bdfb-11e5-94fa-c8f73332c8f4:f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90440-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90444-bdfb-11e5-94fa-c8f73332c8f4:f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90444-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90447-bdfb-11e5-94fa-c8f73332c8f4:f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90447-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9044b-bdfb-11e5-94fa-c8f73332c8f4:f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9044b-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9044e-bdfb-11e5-94fa-c8f73332c8f4:f176960e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9044e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90452-bdfb-11e5-94fa-c8f73332c8f4:f1769604-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90452-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90455-bdfb-11e5-94fa-c8f73332c8f4:f1769624-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90455-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90459-bdfb-11e5-94fa-c8f73332c8f4:f176962a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90459-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9045c-bdfb-11e5-94fa-c8f73332c8f4:f176963c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9045c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90460-bdfb-11e5-94fa-c8f73332c8f4:f1769642-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90460-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90463-bdfb-11e5-94fa-c8f73332c8f4:f176963c-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90463-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90467-bdfb-11e5-94fa-c8f73332c8f4:f1769648-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90467-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9046a-bdfb-11e5-94fa-c8f73332c8f4:f176964e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9046a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9046e-bdfb-11e5-94fa-c8f73332c8f4:f1769654-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9046e-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90471-bdfb-11e5-94fa-c8f73332c8f4:f1769664-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90471-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90475-bdfb-11e5-94fa-c8f73332c8f4:f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90475-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90478-bdfb-11e5-94fa-c8f73332c8f4:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90478-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9047c-bdfb-11e5-94fa-c8f73332c8f4:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9047c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9047f-bdfb-11e5-94fa-c8f73332c8f4:f1769682-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9047f-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90483-bdfb-11e5-94fa-c8f73332c8f4:f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90483-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd90486-bdfb-11e5-94fa-c8f73332c8f4:f176969e-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd90486-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9048a-bdfb-11e5-94fa-c8f73332c8f4:f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9048a-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4:root-node
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: RootCIMNode
+  - externalId: RootCIMNode.node
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  source_type: Asset
+  target_external_id: root-node
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2e64900b-94a8-6e40-bd63-3e69510c316f:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2e64900b-94a8-6e40-bd63-3e69510c316f
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2e98d68c-e0c5-6d47-b392-a1746743ef63:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2e98d68c-e0c5-6d47-b392-a1746743ef63
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 2f8c9437-e564-e948-8764-be3494565b1f:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 2f8c9437-e564-e948-8764-be3494565b1f
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 30ab0123-1669-1242-99ca-610e4bcdc6c5:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 30ab0123-1669-1242-99ca-610e4bcdc6c5
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 329965e7-b5de-c54f-856a-358c9e1f9c50:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 329965e7-b5de-c54f-856a-358c9e1f9c50
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 356c6f11-da4d-3f4d-b3fd-49234106345c:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 356c6f11-da4d-3f4d-b3fd-49234106345c
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 3718af45-a6ee-fb40-a4c6-f1118c114393:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 3718af45-a6ee-fb40-a4c6-f1118c114393
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 37c82b4c-7441-9946-98bf-7ade99732ecf:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 37c82b4c-7441-9946-98bf-7ade99732ecf
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 38b8e08a-112e-b046-8504-efef4beb0c17:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 38b8e08a-112e-b046-8504-efef4beb0c17
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 3916ae31-9f3d-af4e-8d87-87d373d8200a:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 3916ae31-9f3d-af4e-8d87-87d373d8200a
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 40725e5a-33bf-6046-8d11-da19f9c726b4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 40725e5a-33bf-6046-8d11-da19f9c726b4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 40c8340e-7ccf-d446-8a6b-bffa19ec88e6:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 40c8340e-7ccf-d446-8a6b-bffa19ec88e6
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 4a5b7813-14d3-fa4d-8907-edcdce7dbfd9:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 4a5b7813-14d3-fa4d-8907-edcdce7dbfd9
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 51883d43-111e-f24b-89f7-0573426fa32f:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 51883d43-111e-f24b-89f7-0573426fa32f
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 5831696b-e9e1-8e4a-a169-0e4e09f15f1f:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 5831696b-e9e1-8e4a-a169-0e4e09f15f1f
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 5906b2a0-4ec9-1949-98b8-709380af0060:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 5906b2a0-4ec9-1949-98b8-709380af0060
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 5c3fa20d-4748-5e44-b915-481e6d2552cd:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 5c3fa20d-4748-5e44-b915-481e6d2552cd
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 5ddb272d-00bd-d74e-8c96-e2049351c3e4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 5ddb272d-00bd-d74e-8c96-e2049351c3e4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 5ffde614-bc34-384d-923e-e62ac9f3f584:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 5ffde614-bc34-384d-923e-e62ac9f3f584
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 669c1d0c-87dd-a943-9316-88308bd36f15:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 669c1d0c-87dd-a943-9316-88308bd36f15
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 67bc203e-13e4-534b-94b8-bf19f5b31080:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 67bc203e-13e4-534b-94b8-bf19f5b31080
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 67dfc70a-36cf-da4e-b97c-fd1eda9cd8ac:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 67dfc70a-36cf-da4e-b97c-fd1eda9cd8ac
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 692809cf-1bb4-8642-9b70-ee677f063304:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 692809cf-1bb4-8642-9b70-ee677f063304
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 6abb96f5-a71f-8e41-b563-7c569789d6bd:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 6abb96f5-a71f-8e41-b563-7c569789d6bd
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 6ac2f3cd-c906-0a4b-ba1b-5942e9c65307:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 6ac2f3cd-c906-0a4b-ba1b-5942e9c65307
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 6da89f37-cc6f-4e4e-8b20-975295017390:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 6da89f37-cc6f-4e4e-8b20-975295017390
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 70f1852f-186d-5e43-98bf-b69f028cfcc5:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 70f1852f-186d-5e43-98bf-b69f028cfcc5
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 714c775a-246f-e34f-9a6b-667f4b66138c:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 714c775a-246f-e34f-9a6b-667f4b66138c
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 71d09d39-a080-5d4f-86f3-7b3185e51b8e:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 71d09d39-a080-5d4f-86f3-7b3185e51b8e
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 761a49da-2b71-2d4e-877f-3cf7fa86ef63:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 761a49da-2b71-2d4e-877f-3cf7fa86ef63
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 79887cf1-6c94-3f4f-a1f8-7ddef866d55f:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 79887cf1-6c94-3f4f-a1f8-7ddef866d55f
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 7af49a35-a119-5443-84be-af343b7761c8:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 7af49a35-a119-5443-84be-af343b7761c8
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 7d101d2b-ce05-9843-ab59-2c3e5e244cbb:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 7d101d2b-ce05-9843-ab59-2c3e5e244cbb
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 7f811234-10fe-e34f-a9af-9af61a6dd4c7:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 7f811234-10fe-e34f-a9af-9af61a6dd4c7
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 84775b5d-95c1-bd46-bb0d-0f74e4c06757:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 84775b5d-95c1-bd46-bb0d-0f74e4c06757
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 854b40ee-7109-d04c-b4ef-f0665722e451:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 854b40ee-7109-d04c-b4ef-f0665722e451
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 8574aebb-23c4-3e4a-bd04-b5651c97d27a:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 8574aebb-23c4-3e4a-bd04-b5651c97d27a
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 8a0babd6-6d6f-854b-b65f-4245e65c9e9c:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 8a0babd6-6d6f-854b-b65f-4245e65c9e9c
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 8d35b51b-06bd-7541-b3e6-2ddbbb1204fe:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 8d35b51b-06bd-7541-b3e6-2ddbbb1204fe
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 8e8e6b0c-ee96-7a4f-9790-c9ae62edafbe:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 8e8e6b0c-ee96-7a4f-9790-c9ae62edafbe
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 8f8094c3-5c43-1241-9014-6c7a3ae10213:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 8f8094c3-5c43-1241-9014-6c7a3ae10213
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 925f3ab7-54ce-b748-887a-fc6ae23bbdc2:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 925f3ab7-54ce-b748-887a-fc6ae23bbdc2
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 947636e9-e939-294e-a94b-2090060b74ca:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 947636e9-e939-294e-a94b-2090060b74ca
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 9acd76b4-8d78-2b4b-81d5-e404e244997d:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 9acd76b4-8d78-2b4b-81d5-e404e244997d
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: 9b49634c-4910-9841-b595-0d0cb0d0d1de:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: 9b49634c-4910-9841-b595-0d0cb0d0d1de
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: a0ad0036-fbee-6646-b195-3a86614529f2:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: a0ad0036-fbee-6646-b195-3a86614529f2
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: a2a690ef-b78a-3f46-90c5-5d434e26a64e:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: a2a690ef-b78a-3f46-90c5-5d434e26a64e
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: a4bc44aa-25e4-684a-ab2c-c7fc3378d9e5:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: a4bc44aa-25e4-684a-ab2c-c7fc3378d9e5
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: a533d3fd-822f-3b40-9030-e18b571cd1ea:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: a533d3fd-822f-3b40-9030-e18b571cd1ea
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: a749d698-52a2-564e-8c6f-068fe62045fe:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: a749d698-52a2-564e-8c6f-068fe62045fe
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: a949cafd-39f3-8e4c-bca5-9928b004b4da:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: a949cafd-39f3-8e4c-bca5-9928b004b4da
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: aadfa134-666a-ae4f-8c09-6f3ae114c3b5:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: aadfa134-666a-ae4f-8c09-6f3ae114c3b5
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: ab88a3a2-a572-3440-be06-757e0225ea42:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: ab88a3a2-a572-3440-be06-757e0225ea42
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: ad37e24a-9993-4f45-80ed-49a80b6a85d9:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: ad37e24a-9993-4f45-80ed-49a80b6a85d9
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: ad970e05-69d9-5340-9dbd-ce6a9a2e0996:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: ad970e05-69d9-5340-9dbd-ce6a9a2e0996
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: ae68b597-69fb-e14b-a070-67c7dcc1d698:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: ae68b597-69fb-e14b-a070-67c7dcc1d698
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: b016bc42-5a9f-ec42-b326-e9b9eed9e6d3:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: b016bc42-5a9f-ec42-b326-e9b9eed9e6d3
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: b3ff19da-83b8-5e40-b38c-38982b748732:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: b3ff19da-83b8-5e40-b38c-38982b748732
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: b77c60e8-fe4f-9149-9bc6-c3eb8f899de2:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: b77c60e8-fe4f-9149-9bc6-c3eb8f899de2
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: bc0f852a-3cc8-e143-8174-f0854a2d38aa:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: bc0f852a-3cc8-e143-8174-f0854a2d38aa
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: bff806b2-7825-af4c-a34b-be542dbe5ae6:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: bff806b2-7825-af4c-a34b-be542dbe5ae6
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: c1aa295d-e817-db46-b14e-bee2739fcd9d:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: c1aa295d-e817-db46-b14e-bee2739fcd9d
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: c1ca1160-be67-9448-a16b-e92a6112e380:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: c1ca1160-be67-9448-a16b-e92a6112e380
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: c3458e72-1c7a-a74b-b561-8afe0a3aa2be:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: c3458e72-1c7a-a74b-b561-8afe0a3aa2be
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: c8ac9d5f-d60e-a345-8790-12b86184c31b:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: c8ac9d5f-d60e-a345-8790-12b86184c31b
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: c8f95fee-e9a6-a44b-97ac-23e272a05ecd:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: c8f95fee-e9a6-a44b-97ac-23e272a05ecd
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: c95039b2-aea2-ad4d-b444-c6efc77461e5:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: c95039b2-aea2-ad4d-b444-c6efc77461e5
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: caa10f15-4591-e241-ac0b-81675acf5687:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: caa10f15-4591-e241-ac0b-81675acf5687
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: cd25f47c-ad0c-f74d-8c0e-fd91a95505b6:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: cd25f47c-ad0c-f74d-8c0e-fd91a95505b6
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: cf654436-a05a-7948-8cc3-f3a288608964:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: cf654436-a05a-7948-8cc3-f3a288608964
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: d288bd96-ae6e-cf46-9775-f38e2699f1ce:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: d288bd96-ae6e-cf46-9775-f38e2699f1ce
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: d28bc89e-0592-1440-9721-5cbe124c1f1b:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: d28bc89e-0592-1440-9721-5cbe124c1f1b
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: d7a472cc-6b91-564d-93b4-0f3c24f2342c:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: d7a472cc-6b91-564d-93b4-0f3c24f2342c
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: d92cb2eb-fd81-194c-9e43-618df025d6b4:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: d92cb2eb-fd81-194c-9e43-618df025d6b4
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: da4b0f71-a251-f947-be12-2de53a2d272a:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: da4b0f71-a251-f947-be12-2de53a2d272a
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: dae3bb4b-0a86-9243-99c1-a1d5b163774d:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: dae3bb4b-0a86-9243-99c1-a1d5b163774d
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: db724627-9dae-4748-b4e3-2daf627ffa17:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: db724627-9dae-4748-b4e3-2daf627ffa17
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: dc791b3b-fe63-a14b-b144-953748088613:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: dc791b3b-fe63-a14b-b144-953748088613
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: e035c87e-704d-404f-8ea8-91c62e0d7d8a:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: e035c87e-704d-404f-8ea8-91c62e0d7d8a
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: e25c03e3-96a7-a64f-b776-a155f009d5f8:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: e25c03e3-96a7-a64f-b776-a155f009d5f8
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: e2f56599-a78e-494f-8db3-c0b0bdab1d70:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: e2f56599-a78e-494f-8db3-c0b0bdab1d70
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: e3d56d8b-5f71-3042-9734-7118977e887c:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: e3d56d8b-5f71-3042-9734-7118977e887c
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: e3ef93a1-723a-224e-8863-472e4f269633:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: e3ef93a1-723a-224e-8863-472e4f269633
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: e65c4130-3a4d-db42-9020-c9f7c447d473:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: e65c4130-3a4d-db42-9020-c9f7c447d473
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: ea014fdb-b96f-2a4b-b1df-d38e846d4941:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: ea014fdb-b96f-2a4b-b1df-d38e846d4941
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: eaf768b1-3d82-c64d-a1c6-5bd7f9a72751:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: eaf768b1-3d82-c64d-a1c6-5bd7f9a72751
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: eb8b2a90-9bc8-154f-92dd-3887e3676498:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: eb8b2a90-9bc8-154f-92dd-3887e3676498
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: eba035f1-7c96-0142-8561-37b28625abf7:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: eba035f1-7c96-0142-8561-37b28625abf7
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: ecfaf384-4581-4249-8646-b5d31943ad61:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: ecfaf384-4581-4249-8646-b5d31943ad61
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: ee4223ab-0538-dc4a-9b79-d463c048bb08:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: ee4223ab-0538-dc4a-9b79-d463c048bb08
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: efe663e2-7518-3044-88d4-209bf597536a:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: efe663e2-7518-3044-88d4-209bf597536a
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f08f910c-300e-8941-aa85-3106d93e3429:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f08f910c-300e-8941-aa85-3106d93e3429
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd90156-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90156-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd901c6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901c6-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd901c9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901c9-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd901cc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901cc-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd90258-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90258-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd9025b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9025b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd9025e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9025e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd90357-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90357-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd9035a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9035a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd9035d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9035d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd90360-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90360-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd90363-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90363-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f:2dd90366-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695aa-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90366-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695af-9aeb-11e5-91da-b8763fd99c5f:2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f17695af-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f:2dd9015c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9015c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f:2dd901cf-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901cf-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f:2dd90358-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695b8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90358-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f:2dd9015e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9015e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f:2dd901d2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901d2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f:2dd90369-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90369-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f:2dd9036c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9036c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f:2dd9036f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9036f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f:2dd90372-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90372-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f:2dd90375-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90375-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f:2dd90378-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90378-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f:2dd9037b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9037b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c3-9aeb-11e5-91da-b8763fd99c5f:2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f17695c3-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd90162-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90162-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd901d5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901d5-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd90262-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90262-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd90265-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90265-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd90268-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90268-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd9026b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9026b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd9026e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9026e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd9035b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9035b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd9036a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9036a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd9037e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9037e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd90381-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90381-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd90384-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90384-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f:2dd90387-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695c8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90387-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695cd-9aeb-11e5-91da-b8763fd99c5f:2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f17695cd-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f:2dd90166-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90166-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f:2dd9036d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9036d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f:2dd90370-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90370-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f:2dd90373-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90373-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f:2dd9038a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9038a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f:2dd9038d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9038d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f:2dd90390-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d2-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90390-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f:2dd90168-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90168-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f:2dd90393-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90393-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f:2dd90439-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695d8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90439-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f:2dd9016b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9016b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f:2dd90272-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90272-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f:2dd9035e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9035e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f:2dd90361-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90361-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f:2dd9037f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9037f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f:2dd9043d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695df-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9043d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd9016d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9016d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd901d8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901d8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd90276-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90276-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd90279-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90279-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd9027c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9027c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd9027f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9027f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd90282-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90282-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd90285-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90285-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd90288-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90288-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd9028b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9028b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd90376-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90376-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd90382-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90382-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd90396-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90396-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f:2dd90444-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695e5-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90444-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd9016f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9016f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd901db-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901db-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd901de-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901de-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd9028f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9028f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd90292-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90292-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd90295-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90295-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd90298-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90298-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd9029b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9029b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd9029e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9029e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd90364-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90364-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd90367-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90367-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd9038b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9038b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd90399-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90399-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f:2dd9039c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695eb-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9039c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd90171-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90171-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd901e1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901e1-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd901e4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901e4-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd901e7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901e7-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd901ea-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901ea-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd902a2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902a2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd902a5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902a5-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd902a8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902a8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd902ab-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902ab-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd902ae-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902ae-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd902b1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902b1-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd90379-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90379-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd9037c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9037c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd9038e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9038e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd9039f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9039f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd903a2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903a2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd903a5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903a5-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd903a8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903a8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f:2dd90447-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f1-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90447-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f:2dd90173-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90173-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f:2dd901ed-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901ed-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f:2dd9044b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695f7-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9044b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f:2dd90176-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90176-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f:2dd903ab-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903ab-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f:2dd90440-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17695fe-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90440-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f:2dd90178-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90178-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f:2dd901f0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901f0-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f:2dd902b5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902b5-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f:2dd902b8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902b8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f:2dd903ae-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903ae-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f:2dd903b1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903b1-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f:2dd90452-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769604-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90452-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f:2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f:lazarevac
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f1769609-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: lazarevac
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f:2dd9017c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9017c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f:2dd903a0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903a0-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f:2dd903a3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903a3-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f:2dd903b4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903b4-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f:2dd903b7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903b7-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f:2dd903ba-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903ba-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f:2dd903be-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903be-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f:2dd9044e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176960e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9044e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f:2dd9017e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9017e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f:2dd903b5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903b5-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f:2dd903c3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903c3-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f:2dd903c6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903c6-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f:2dd903c9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903c9-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f:2dd903cd-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769614-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903cd-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769619-9aeb-11e5-91da-b8763fd99c5f:2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f1769619-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f:2dd90182-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90182-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f:2dd903b8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903b8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f:2dd903c4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903c4-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f:2dd903d2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903d2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f:2dd903d5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176961e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903d5-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd90184-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90184-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd901f3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901f3-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd902bc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902bc-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd902bf-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902bf-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd902c2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902c2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd902c5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902c5-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd902c8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902c8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd902cb-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902cb-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd903d8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903d8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f:2dd90455-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769624-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90455-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f:2dd90186-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90186-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f:2dd903db-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903db-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f:2dd903de-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903de-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f:2dd903e1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903e1-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f:2dd90459-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176962a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90459-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f:2dd90188-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90188-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f:2dd903c7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903c7-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f:2dd903d3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903d3-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f:2dd903d6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903d6-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f:2dd903dc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903dc-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f:2dd903e4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903e4-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f:2dd903e7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769630-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903e7-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f:2dd9018a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9018a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f:2dd903df-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903df-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f:2dd903e5-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903e5-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f:2dd903e8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769636-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903e8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f:2dd9018c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9018c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f:2dd901f6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901f6-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f:2dd902cf-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902cf-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f:2dd902d2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902d2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f:2dd903ea-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903ea-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f:2dd903ed-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903ed-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f:2dd9045c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9045c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f:2dd90463-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176963c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90463-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f:2dd9018e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9018e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f:2dd903f0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903f0-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f:2dd903f3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903f3-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f:2dd903f6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903f6-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f:2dd903fa-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903fa-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f:2dd90460-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769642-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90460-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f:2dd90190-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90190-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f:2dd903ff-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903ff-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f:2dd90467-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769648-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90467-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd90192-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90192-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd901f9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901f9-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd901fc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901fc-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd902d6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902d6-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd902d9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902d9-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd903af-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903af-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd903eb-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903eb-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd90402-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90402-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd90406-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90406-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f:2dd9046a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176964e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9046a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f:2dd90194-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90194-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f:2dd903bb-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903bb-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f:2dd903c1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903c1-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f:2dd903f1-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903f1-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f:2dd9046e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769654-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9046e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:0345061e-37c9-9a49-b632-2af77bdca3a2
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 0345061e-37c9-9a49-b632-2af77bdca3a2
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:0619c12e-abb9-b141-b3a7-e2788d3d375c
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 0619c12e-abb9-b141-b3a7-e2788d3d375c
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:093a3df5-0583-894f-99c9-016d752ff920
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 093a3df5-0583-894f-99c9-016d752ff920
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:0a122f63-f2c6-ca43-be49-76571474d98c
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 0a122f63-f2c6-ca43-be49-76571474d98c
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:0b50ae74-92eb-f244-872b-07e629f53494
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 0b50ae74-92eb-f244-872b-07e629f53494
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:0d7f39d0-5447-fb42-9d4f-3d0775bceef0
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 0d7f39d0-5447-fb42-9d4f-3d0775bceef0
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:0dae5d37-4d01-3645-9e94-607410c5ac34
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 0dae5d37-4d01-3645-9e94-607410c5ac34
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:13116d72-3969-1344-91a7-14fb404a00c0
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 13116d72-3969-1344-91a7-14fb404a00c0
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:16659ede-d69f-1d48-bcf2-ebb2ee6c259e
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 16659ede-d69f-1d48-bcf2-ebb2ee6c259e
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:292835be-c432-734c-8c28-3b8c61c0c077
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 292835be-c432-734c-8c28-3b8c61c0c077
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2a67a243-6e4a-a84d-8aea-f250399166c9
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2a67a243-6e4a-a84d-8aea-f250399166c9
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd90196-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90196-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd901ff-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901ff-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd90202-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90202-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd902dd-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902dd-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd902e0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902e0-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd902e3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902e3-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd902e6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902e6-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd9040b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9040b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd9040e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9040e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd90411-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90411-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2dd90414-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90414-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2e98d68c-e0c5-6d47-b392-a1746743ef63
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2e98d68c-e0c5-6d47-b392-a1746743ef63
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:2f8c9437-e564-e948-8764-be3494565b1f
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2f8c9437-e564-e948-8764-be3494565b1f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:30ab0123-1669-1242-99ca-610e4bcdc6c5
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 30ab0123-1669-1242-99ca-610e4bcdc6c5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:329965e7-b5de-c54f-856a-358c9e1f9c50
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 329965e7-b5de-c54f-856a-358c9e1f9c50
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:3718af45-a6ee-fb40-a4c6-f1118c114393
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 3718af45-a6ee-fb40-a4c6-f1118c114393
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:37c82b4c-7441-9946-98bf-7ade99732ecf
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 37c82b4c-7441-9946-98bf-7ade99732ecf
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:38b8e08a-112e-b046-8504-efef4beb0c17
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 38b8e08a-112e-b046-8504-efef4beb0c17
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:40725e5a-33bf-6046-8d11-da19f9c726b4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 40725e5a-33bf-6046-8d11-da19f9c726b4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:40c8340e-7ccf-d446-8a6b-bffa19ec88e6
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 40c8340e-7ccf-d446-8a6b-bffa19ec88e6
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:4a5b7813-14d3-fa4d-8907-edcdce7dbfd9
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 4a5b7813-14d3-fa4d-8907-edcdce7dbfd9
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:5831696b-e9e1-8e4a-a169-0e4e09f15f1f
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 5831696b-e9e1-8e4a-a169-0e4e09f15f1f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:5c3fa20d-4748-5e44-b915-481e6d2552cd
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 5c3fa20d-4748-5e44-b915-481e6d2552cd
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:5ddb272d-00bd-d74e-8c96-e2049351c3e4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 5ddb272d-00bd-d74e-8c96-e2049351c3e4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:5ffde614-bc34-384d-923e-e62ac9f3f584
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 5ffde614-bc34-384d-923e-e62ac9f3f584
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:67bc203e-13e4-534b-94b8-bf19f5b31080
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 67bc203e-13e4-534b-94b8-bf19f5b31080
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:67dfc70a-36cf-da4e-b97c-fd1eda9cd8ac
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 67dfc70a-36cf-da4e-b97c-fd1eda9cd8ac
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:692809cf-1bb4-8642-9b70-ee677f063304
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 692809cf-1bb4-8642-9b70-ee677f063304
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:6abb96f5-a71f-8e41-b563-7c569789d6bd
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 6abb96f5-a71f-8e41-b563-7c569789d6bd
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:6ac2f3cd-c906-0a4b-ba1b-5942e9c65307
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 6ac2f3cd-c906-0a4b-ba1b-5942e9c65307
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:70f1852f-186d-5e43-98bf-b69f028cfcc5
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 70f1852f-186d-5e43-98bf-b69f028cfcc5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:714c775a-246f-e34f-9a6b-667f4b66138c
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 714c775a-246f-e34f-9a6b-667f4b66138c
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:71d09d39-a080-5d4f-86f3-7b3185e51b8e
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 71d09d39-a080-5d4f-86f3-7b3185e51b8e
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:79887cf1-6c94-3f4f-a1f8-7ddef866d55f
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 79887cf1-6c94-3f4f-a1f8-7ddef866d55f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:7af49a35-a119-5443-84be-af343b7761c8
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 7af49a35-a119-5443-84be-af343b7761c8
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:7d101d2b-ce05-9843-ab59-2c3e5e244cbb
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 7d101d2b-ce05-9843-ab59-2c3e5e244cbb
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:7f811234-10fe-e34f-a9af-9af61a6dd4c7
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 7f811234-10fe-e34f-a9af-9af61a6dd4c7
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:84775b5d-95c1-bd46-bb0d-0f74e4c06757
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 84775b5d-95c1-bd46-bb0d-0f74e4c06757
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:854b40ee-7109-d04c-b4ef-f0665722e451
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 854b40ee-7109-d04c-b4ef-f0665722e451
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:8574aebb-23c4-3e4a-bd04-b5651c97d27a
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 8574aebb-23c4-3e4a-bd04-b5651c97d27a
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:8d35b51b-06bd-7541-b3e6-2ddbbb1204fe
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 8d35b51b-06bd-7541-b3e6-2ddbbb1204fe
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:8e8e6b0c-ee96-7a4f-9790-c9ae62edafbe
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 8e8e6b0c-ee96-7a4f-9790-c9ae62edafbe
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:925f3ab7-54ce-b748-887a-fc6ae23bbdc2
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 925f3ab7-54ce-b748-887a-fc6ae23bbdc2
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:947636e9-e939-294e-a94b-2090060b74ca
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 947636e9-e939-294e-a94b-2090060b74ca
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:9b49634c-4910-9841-b595-0d0cb0d0d1de
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 9b49634c-4910-9841-b595-0d0cb0d0d1de
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:a0ad0036-fbee-6646-b195-3a86614529f2
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: a0ad0036-fbee-6646-b195-3a86614529f2
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:a2a690ef-b78a-3f46-90c5-5d434e26a64e
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: a2a690ef-b78a-3f46-90c5-5d434e26a64e
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:a4bc44aa-25e4-684a-ab2c-c7fc3378d9e5
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: a4bc44aa-25e4-684a-ab2c-c7fc3378d9e5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:a749d698-52a2-564e-8c6f-068fe62045fe
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: a749d698-52a2-564e-8c6f-068fe62045fe
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:ad37e24a-9993-4f45-80ed-49a80b6a85d9
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: ad37e24a-9993-4f45-80ed-49a80b6a85d9
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:ad970e05-69d9-5340-9dbd-ce6a9a2e0996
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: ad970e05-69d9-5340-9dbd-ce6a9a2e0996
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:ae68b597-69fb-e14b-a070-67c7dcc1d698
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: ae68b597-69fb-e14b-a070-67c7dcc1d698
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:b016bc42-5a9f-ec42-b326-e9b9eed9e6d3
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: b016bc42-5a9f-ec42-b326-e9b9eed9e6d3
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:b3ff19da-83b8-5e40-b38c-38982b748732
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: b3ff19da-83b8-5e40-b38c-38982b748732
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:bc0f852a-3cc8-e143-8174-f0854a2d38aa
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: bc0f852a-3cc8-e143-8174-f0854a2d38aa
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:c1aa295d-e817-db46-b14e-bee2739fcd9d
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: c1aa295d-e817-db46-b14e-bee2739fcd9d
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:c1ca1160-be67-9448-a16b-e92a6112e380
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: c1ca1160-be67-9448-a16b-e92a6112e380
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:c8ac9d5f-d60e-a345-8790-12b86184c31b
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: c8ac9d5f-d60e-a345-8790-12b86184c31b
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:c8f95fee-e9a6-a44b-97ac-23e272a05ecd
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: c8f95fee-e9a6-a44b-97ac-23e272a05ecd
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:c95039b2-aea2-ad4d-b444-c6efc77461e5
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: c95039b2-aea2-ad4d-b444-c6efc77461e5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:caa10f15-4591-e241-ac0b-81675acf5687
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: caa10f15-4591-e241-ac0b-81675acf5687
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:cd25f47c-ad0c-f74d-8c0e-fd91a95505b6
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: cd25f47c-ad0c-f74d-8c0e-fd91a95505b6
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:cf654436-a05a-7948-8cc3-f3a288608964
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: cf654436-a05a-7948-8cc3-f3a288608964
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:d7a472cc-6b91-564d-93b4-0f3c24f2342c
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: d7a472cc-6b91-564d-93b4-0f3c24f2342c
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:d92cb2eb-fd81-194c-9e43-618df025d6b4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: d92cb2eb-fd81-194c-9e43-618df025d6b4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:da4b0f71-a251-f947-be12-2de53a2d272a
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: da4b0f71-a251-f947-be12-2de53a2d272a
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:dae3bb4b-0a86-9243-99c1-a1d5b163774d
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: dae3bb4b-0a86-9243-99c1-a1d5b163774d
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:e035c87e-704d-404f-8ea8-91c62e0d7d8a
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: e035c87e-704d-404f-8ea8-91c62e0d7d8a
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:e25c03e3-96a7-a64f-b776-a155f009d5f8
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: e25c03e3-96a7-a64f-b776-a155f009d5f8
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:e3d56d8b-5f71-3042-9734-7118977e887c
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: e3d56d8b-5f71-3042-9734-7118977e887c
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:e3ef93a1-723a-224e-8863-472e4f269633
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: e3ef93a1-723a-224e-8863-472e4f269633
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:e65c4130-3a4d-db42-9020-c9f7c447d473
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: e65c4130-3a4d-db42-9020-c9f7c447d473
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:ea014fdb-b96f-2a4b-b1df-d38e846d4941
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: ea014fdb-b96f-2a4b-b1df-d38e846d4941
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:eaf768b1-3d82-c64d-a1c6-5bd7f9a72751
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: eaf768b1-3d82-c64d-a1c6-5bd7f9a72751
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:ecfaf384-4581-4249-8646-b5d31943ad61
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: ecfaf384-4581-4249-8646-b5d31943ad61
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:efe663e2-7518-3044-88d4-209bf597536a
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: efe663e2-7518-3044-88d4-209bf597536a
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:f08f910c-300e-8941-aa85-3106d93e3429
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: f08f910c-300e-8941-aa85-3106d93e3429
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:f4dba262-3ff3-9f41-961d-7fbe1f8a0cd7
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: f4dba262-3ff3-9f41-961d-7fbe1f8a0cd7
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:f710cc4a-50dd-e443-8ac7-4c56b70041e8
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: f710cc4a-50dd-e443-8ac7-4c56b70041e8
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:f723530d-ae1e-df4f-9c7f-21e42da147d6
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: f723530d-ae1e-df4f-9c7f-21e42da147d6
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f:f9e8d6d1-76e1-6c4d-a640-e128ecfa723e
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: f9e8d6d1-76e1-6c4d-a640-e128ecfa723e
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f:2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f176965f-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f:2dd9019a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9019a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f:2dd9040c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9040c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f:2dd90471-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769664-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90471-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f:02b41435-bd3e-bb4b-9b89-24e3a8983c0f
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 02b41435-bd3e-bb4b-9b89-24e3a8983c0f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f:2dd9019c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9019c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f:2dd903f4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176966a-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903f4-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:076da31b-080d-c742-9cb1-134a6ba5b1ed
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 076da31b-080d-c742-9cb1-134a6ba5b1ed
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:0ef62251-5e2e-d14a-aa44-396d4a885c4f
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 0ef62251-5e2e-d14a-aa44-396d4a885c4f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:1a6d8d77-f2ca-f043-b475-f7db6304fe3e
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 1a6d8d77-f2ca-f043-b475-f7db6304fe3e
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:1ef7a41b-2cff-6046-b48f-c60a16fd20b0
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 1ef7a41b-2cff-6046-b48f-c60a16fd20b0
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:22c3512a-fdf2-464c-b1f4-85d173fa2d18
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 22c3512a-fdf2-464c-b1f4-85d173fa2d18
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:2dd9019e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9019e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:2dd90403-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90403-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:2dd90409-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90409-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:2dd9040f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9040f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:2dd90417-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90417-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:2dd90478-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90478-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:2dd9047c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9047c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:2e64900b-94a8-6e40-bd63-3e69510c316f
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2e64900b-94a8-6e40-bd63-3e69510c316f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:356c6f11-da4d-3f4d-b3fd-49234106345c
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 356c6f11-da4d-3f4d-b3fd-49234106345c
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:3916ae31-9f3d-af4e-8d87-87d373d8200a
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 3916ae31-9f3d-af4e-8d87-87d373d8200a
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:51883d43-111e-f24b-89f7-0573426fa32f
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 51883d43-111e-f24b-89f7-0573426fa32f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:5906b2a0-4ec9-1949-98b8-709380af0060
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 5906b2a0-4ec9-1949-98b8-709380af0060
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:669c1d0c-87dd-a943-9316-88308bd36f15
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 669c1d0c-87dd-a943-9316-88308bd36f15
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:6da89f37-cc6f-4e4e-8b20-975295017390
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 6da89f37-cc6f-4e4e-8b20-975295017390
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:761a49da-2b71-2d4e-877f-3cf7fa86ef63
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 761a49da-2b71-2d4e-877f-3cf7fa86ef63
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:8a0babd6-6d6f-854b-b65f-4245e65c9e9c
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 8a0babd6-6d6f-854b-b65f-4245e65c9e9c
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:8f8094c3-5c43-1241-9014-6c7a3ae10213
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 8f8094c3-5c43-1241-9014-6c7a3ae10213
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:9acd76b4-8d78-2b4b-81d5-e404e244997d
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 9acd76b4-8d78-2b4b-81d5-e404e244997d
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:a533d3fd-822f-3b40-9030-e18b571cd1ea
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: a533d3fd-822f-3b40-9030-e18b571cd1ea
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:a949cafd-39f3-8e4c-bca5-9928b004b4da
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: a949cafd-39f3-8e4c-bca5-9928b004b4da
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:aadfa134-666a-ae4f-8c09-6f3ae114c3b5
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: aadfa134-666a-ae4f-8c09-6f3ae114c3b5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:ab88a3a2-a572-3440-be06-757e0225ea42
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: ab88a3a2-a572-3440-be06-757e0225ea42
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:b77c60e8-fe4f-9149-9bc6-c3eb8f899de2
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: b77c60e8-fe4f-9149-9bc6-c3eb8f899de2
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:bff806b2-7825-af4c-a34b-be542dbe5ae6
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: bff806b2-7825-af4c-a34b-be542dbe5ae6
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:c3458e72-1c7a-a74b-b561-8afe0a3aa2be
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: c3458e72-1c7a-a74b-b561-8afe0a3aa2be
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:d288bd96-ae6e-cf46-9775-f38e2699f1ce
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: d288bd96-ae6e-cf46-9775-f38e2699f1ce
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:d28bc89e-0592-1440-9721-5cbe124c1f1b
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: d28bc89e-0592-1440-9721-5cbe124c1f1b
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:db724627-9dae-4748-b4e3-2daf627ffa17
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: db724627-9dae-4748-b4e3-2daf627ffa17
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:dc791b3b-fe63-a14b-b144-953748088613
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: dc791b3b-fe63-a14b-b144-953748088613
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:e2f56599-a78e-494f-8db3-c0b0bdab1d70
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: e2f56599-a78e-494f-8db3-c0b0bdab1d70
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:eb8b2a90-9bc8-154f-92dd-3887e3676498
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: eb8b2a90-9bc8-154f-92dd-3887e3676498
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:eba035f1-7c96-0142-8561-37b28625abf7
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: eba035f1-7c96-0142-8561-37b28625abf7
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:ee4223ab-0538-dc4a-9b79-d463c048bb08
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: ee4223ab-0538-dc4a-9b79-d463c048bb08
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f:fe798f30-0725-e94e-8142-c06ca7701b14
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: fe798f30-0725-e94e-8142-c06ca7701b14
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f:2dd901a0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901a0-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f:2dd90205-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90205-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f:2dd90418-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769676-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90418-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f:2dd901a2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901a2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f:2dd90208-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90208-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f:2dd90412-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176967c-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90412-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f:2dd901a4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901a4-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f:2dd902ea-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902ea-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f:2dd902ed-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902ed-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f:2dd902f0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902f0-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f:2dd902f3-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902f3-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f:2dd903ee-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903ee-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f:2dd90415-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90415-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f:2dd9041a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9041a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f:2dd9047f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769682-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9047f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f:2dd903ca-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903ca-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f:2dd903d0-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903d0-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f:2dd903e2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903e2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f:2dd903f7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903f7-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f:2dd903fd-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903fd-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f:2dd90400-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90400-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f:2dd90475-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90475-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f:2dd90483-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90483-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f:terminal-without-name-property
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: terminal-without-name-property
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd901a8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901a8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd9020b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9020b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd9020e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9020e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd902f7-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902f7-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd902fa-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902fa-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd902fd-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd902fd-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd90300-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90300-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd90303-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90303-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd903d9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903d9-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f:2dd9041b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176968e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9041b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd901aa-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901aa-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd90211-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90211-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd90214-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90214-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd90217-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90217-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd90307-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90307-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd9030a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9030a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd9030d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9030d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd90310-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90310-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd90394-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90394-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd903b2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903b2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd9041d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9041d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f:2dd90420-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f1769694-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90420-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f1769699-9aeb-11e5-91da-b8763fd99c5f:2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f1769699-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd901ae-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901ae-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd9021a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9021a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd90314-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90314-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd90317-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90317-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd9031a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9031a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd9031d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9031d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd903ac-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903ac-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd9041e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9041e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd90421-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90421-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f:2dd90486-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f176969e-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90486-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696a3-9aeb-11e5-91da-b8763fd99c5f:2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f17696a3-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f:2dd901b2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901b2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f:2dd9021d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9021d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f:2dd90220-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90220-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f:2dd90385-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90385-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f:2dd9048a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696a8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd901b4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901b4-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90223-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90223-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90226-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90226-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90229-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90229-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd9022c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9022c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd9022f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9022f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90232-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90232-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90321-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90321-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90324-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90324-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90327-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90327-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd9032a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9032a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd9032d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9032d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90330-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90330-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90333-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90333-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90336-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90336-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90339-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90339-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90423-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90423-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90426-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90426-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd90429-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90429-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd9042c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9042c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f:2dd9042f-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ae-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9042f-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f:2dd901b8-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901b8-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f:2dd90235-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90235-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f:2dd90424-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696b8-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90424-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f:2dd901ba-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901ba-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f:2dd90238-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90238-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f:2dd90427-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696be-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90427-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd901bc-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901bc-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd9023b-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9023b-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd9023e-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9023e-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd90241-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90241-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd9033d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9033d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd90340-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90340-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd90343-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90343-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd90388-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90388-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd90397-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90397-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd9042a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9042a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd9042d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9042d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f:2dd90430-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696c4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90430-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd901be-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901be-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd90244-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90244-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd90247-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90247-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd9024a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9024a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd9024d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9024d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd90347-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90347-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd9034a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9034a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd9034d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9034d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd90350-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90350-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd90353-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90353-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd90356-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90356-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd90391-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90391-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd9039a-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9039a-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd9039d-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9039d-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd903a6-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903a6-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd903a9-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd903a9-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd90432-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90432-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f:2dd90435-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696ca-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90435-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696cf-9aeb-11e5-91da-b8763fd99c5f:2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: GeographicalRegion
+  - externalId: SubGeographicalRegion
+  - externalId: SubGeographicalRegion.Region
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f17696cf-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd9048c-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f:2dd901c2-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901c2-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f:2dd90250-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90250-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f:2dd90433-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696d4-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90433-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f:2dd901c4-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd901c4-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f:2dd90253-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90253-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f:2dd90436-bdfb-11e5-94fa-c8f73332c8f4
+  labels:
+  - externalId: Substation
+  - externalId: Substation.Terminal
+  - externalId: Terminal
+  - externalId: connectsTo
+  - externalId: non-historic
+  source_external_id: f17696da-9aeb-11e5-91da-b8763fd99c5f
+  source_type: Asset
+  target_external_id: 2dd90436-bdfb-11e5-94fa-c8f73332c8f4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f4dba262-3ff3-9f41-961d-7fbe1f8a0cd7:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f4dba262-3ff3-9f41-961d-7fbe1f8a0cd7
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f710cc4a-50dd-e443-8ac7-4c56b70041e8:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f710cc4a-50dd-e443-8ac7-4c56b70041e8
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f723530d-ae1e-df4f-9c7f-21e42da147d6:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f723530d-ae1e-df4f-9c7f-21e42da147d6
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: f9e8d6d1-76e1-6c4d-a640-e128ecfa723e:f176965a-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: f9e8d6d1-76e1-6c4d-a640-e128ecfa723e
+  source_type: Asset
+  target_external_id: f176965a-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: fe798f30-0725-e94e-8142-c06ca7701b14:f1769670-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: fe798f30-0725-e94e-8142-c06ca7701b14
+  source_type: Asset
+  target_external_id: f1769670-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: terminal-without-name-property:f1769688-9aeb-11e5-91da-b8763fd99c5f
+  labels:
+  - externalId: Substation
+  - externalId: Terminal
+  - externalId: Terminal.Substation
+  - externalId: belongsTo
+  - externalId: non-historic
+  source_external_id: terminal-without-name-property
+  source_type: Asset
+  target_external_id: f1769688-9aeb-11e5-91da-b8763fd99c5f
+  target_type: Asset

--- a/tests/api/test_workflows/fast_graph_workflow.yml
+++ b/tests/api/test_workflows/fast_graph_workflow.yml
@@ -1,0 +1,3 @@
+assets: []
+labels: []
+relationships: []

--- a/tests/api/test_workflows/sheet2cdf_workflow.yml
+++ b/tests/api/test_workflows/sheet2cdf_workflow.yml
@@ -1,0 +1,469 @@
+assets:
+- data_set_id: 2626756768281823
+  external_id: playground_NO1.NO2
+  labels:
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    identifier: NO1.NO2
+    priceArea: Nordics.Norway.NO1, Nordics.Norway.NO2
+    type: PriceAreaConnection
+  name: NO1 to NO2
+- data_set_id: 2626756768281823
+  external_id: playground_NO1.NO3
+  labels:
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    identifier: NO1.NO3
+    priceArea: Nordics.Norway.NO1, Nordics.Norway.NO3
+    type: PriceAreaConnection
+  name: NO1 to NO3
+- data_set_id: 2626756768281823
+  external_id: playground_NO1.NO5
+  labels:
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    identifier: NO1.NO5
+    priceArea: Nordics.Norway.NO1, Nordics.Norway.NO5
+    type: PriceAreaConnection
+  name: NO1 to NO5
+- data_set_id: 2626756768281823
+  external_id: playground_NO2.NO5
+  labels:
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    identifier: NO2.NO5
+    priceArea: Nordics.Norway.NO2, Nordics.Norway.NO5
+    type: PriceAreaConnection
+  name: NO2 to NO5
+- data_set_id: 2626756768281823
+  external_id: playground_NO3.NO4
+  labels:
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    identifier: NO3.NO4
+    priceArea: Nordics.Norway.NO3, Nordics.Norway.NO4
+    type: PriceAreaConnection
+  name: NO3 to NO4
+- data_set_id: 2626756768281823
+  external_id: playground_NO3.NO5
+  labels:
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    identifier: NO3.NO5
+    priceArea: Nordics.Norway.NO3, Nordics.Norway.NO5
+    type: PriceAreaConnection
+  name: NO3 to NO5
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics
+  labels:
+  - externalId: CountryGroup
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    identifier: Nordics
+    type: CountryGroup
+  name: Nordics
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway
+  labels:
+  - externalId: Country
+  - externalId: non-historic
+  metadata:
+    TSO: Statnett
+    active: 'true'
+    countryGroup: Nordics
+    identifier: Nordics.Norway
+    type: Country
+  name: Norway
+  parent_external_id: playground_Nordics
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO1
+  labels:
+  - externalId: PriceArea
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    country: Nordics.Norway
+    identifier: Nordics.Norway.NO1
+    priceAreaConnection: NO1.NO2, NO1.NO5, NO1.NO3
+    type: PriceArea
+  name: NO1
+  parent_external_id: playground_Nordics.Norway
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO2
+  labels:
+  - externalId: PriceArea
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    country: Nordics.Norway
+    identifier: Nordics.Norway.NO2
+    priceAreaConnection: NO1.NO2, NO2.NO5
+    type: PriceArea
+  name: NO2
+  parent_external_id: playground_Nordics.Norway
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO3
+  labels:
+  - externalId: PriceArea
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    country: Nordics.Norway
+    identifier: Nordics.Norway.NO3
+    priceAreaConnection: NO1.NO3, NO3.NO4, NO3.NO5
+    type: PriceArea
+  name: NO3
+  parent_external_id: playground_Nordics.Norway
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO4
+  labels:
+  - externalId: PriceArea
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    country: Nordics.Norway
+    identifier: Nordics.Norway.NO4
+    priceAreaConnection: NO3.NO4
+    type: PriceArea
+  name: NO4
+  parent_external_id: playground_Nordics.Norway
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    country: Nordics.Norway
+    identifier: Nordics.Norway.NO5
+    priceAreaConnection: NO1.NO5, NO2.NO5, NO3.NO5
+    type: PriceArea
+  name: NO5
+  parent_external_id: playground_Nordics.Norway
+- data_set_id: 2626756768281823
+  description: Used to store all assets which parent does not exist
+  external_id: playground_orphanage
+  labels:
+  - externalId: Orphanage
+  - externalId: non-historic
+  metadata:
+    active: 'true'
+    cdfResourceType: Asset
+    identifier: orphanage
+    type: Orphanage
+  name: Orphanage
+labels:
+- data_set_id: 2626756768281823
+  external_id: Country
+  name: Country
+- data_set_id: 2626756768281823
+  external_id: CountryGroup
+  name: CountryGroup
+- data_set_id: 2626756768281823
+  external_id: PriceArea
+  name: PriceArea
+- data_set_id: 2626756768281823
+  external_id: PriceAreaConnection
+  name: PriceAreaConnection
+- data_set_id: 2626756768281823
+  external_id: TSO
+  name: TSO
+- data_set_id: 2626756768281823
+  external_id: country
+  name: country
+- data_set_id: 2626756768281823
+  external_id: countryGroup
+  name: countryGroup
+- data_set_id: 2626756768281823
+  external_id: historic
+  name: historic
+- data_set_id: 2626756768281823
+  external_id: name
+  name: name
+- data_set_id: 2626756768281823
+  external_id: non-historic
+  name: non-historic
+- data_set_id: 2626756768281823
+  external_id: priceArea
+  name: priceArea
+- data_set_id: 2626756768281823
+  external_id: priceAreaConnection
+  name: priceAreaConnection
+relationships:
+- data_set_id: 2626756768281823
+  external_id: playground_NO1.NO2:playground_Nordics.Norway.NO1
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO1.NO2
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO1
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO1.NO2:playground_Nordics.Norway.NO2
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO1.NO2
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO2
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO1.NO3:playground_Nordics.Norway.NO1
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO1.NO3
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO1
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO1.NO3:playground_Nordics.Norway.NO3
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO1.NO3
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO3
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO1.NO5:playground_Nordics.Norway.NO1
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO1.NO5
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO1
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO1.NO5:playground_Nordics.Norway.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO1.NO5
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO2.NO5:playground_Nordics.Norway.NO2
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO2.NO5
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO2
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO2.NO5:playground_Nordics.Norway.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO2.NO5
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO3.NO4:playground_Nordics.Norway.NO3
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO3.NO4
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO3
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO3.NO4:playground_Nordics.Norway.NO4
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO3.NO4
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO3.NO5:playground_Nordics.Norway.NO3
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO3.NO5
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO3
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_NO3.NO5:playground_Nordics.Norway.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceArea
+  source_external_id: playground_NO3.NO5
+  source_type: Asset
+  target_external_id: playground_Nordics.Norway.NO5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO1:playground_NO1.NO2
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO1
+  source_type: Asset
+  target_external_id: playground_NO1.NO2
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO1:playground_NO1.NO3
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO1
+  source_type: Asset
+  target_external_id: playground_NO1.NO3
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO1:playground_NO1.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO1
+  source_type: Asset
+  target_external_id: playground_NO1.NO5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO2:playground_NO1.NO2
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO2
+  source_type: Asset
+  target_external_id: playground_NO1.NO2
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO2:playground_NO2.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO2
+  source_type: Asset
+  target_external_id: playground_NO2.NO5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO3:playground_NO1.NO3
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO3
+  source_type: Asset
+  target_external_id: playground_NO1.NO3
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO3:playground_NO3.NO4
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO3
+  source_type: Asset
+  target_external_id: playground_NO3.NO4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO3:playground_NO3.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO3
+  source_type: Asset
+  target_external_id: playground_NO3.NO5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO4:playground_NO3.NO4
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO4
+  source_type: Asset
+  target_external_id: playground_NO3.NO4
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO5:playground_NO1.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO5
+  source_type: Asset
+  target_external_id: playground_NO1.NO5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO5:playground_NO2.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO5
+  source_type: Asset
+  target_external_id: playground_NO2.NO5
+  target_type: Asset
+- data_set_id: 2626756768281823
+  external_id: playground_Nordics.Norway.NO5:playground_NO3.NO5
+  labels:
+  - externalId: PriceArea
+  - externalId: PriceAreaConnection
+  - externalId: non-historic
+  - externalId: priceAreaConnection
+  source_external_id: playground_Nordics.Norway.NO5
+  source_type: Asset
+  target_external_id: playground_NO3.NO5
+  target_type: Asset

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,10 +1,29 @@
+import re
 import tomllib
 
 from cognite import neat
-from tests.config import PYPROJECT_TOML
+from tests.config import PYPROJECT_TOML, ROOT
+
+
+def _extract_version_from_file(filename, search_pattern, error_message):
+    changelog = (ROOT / filename).read_text()
+    if not (changelog_version_result := re.search(search_pattern, changelog)):
+        raise ValueError(error_message)
+    return changelog_version_result.groups()[0]
 
 
 def test_consistent_version_variables():
     pyproject = tomllib.loads(PYPROJECT_TOML.read_text())
+    pyproject_toml = pyproject["tool"]["poetry"]["version"]
 
-    assert neat.__version__ == pyproject["tool"]["poetry"]["version"], "Inconsistent version variables"
+    changelog_version = _extract_version_from_file(
+        "CHANGELOG.md",
+        r"\[(\d+\.\d+\.\d+)\]",
+        "Failed to obtain changelog version",
+    )
+    docker_version = _extract_version_from_file(
+        "Makefile",
+        r'version="(\d+\.\d+\.\d+)"',
+        "Failed to obtain docker version",
+    )
+    assert neat.__version__ == changelog_version == pyproject_toml == docker_version, "Inconsistent version variables"


### PR DESCRIPTION
No need to bump, only additional testing. 

* Check all versions match, including changelog and makefile.
* Approval test of `fast_graph` and `sheet2cdf`.

Wait with merging, the `fast_graph` workflow fails:
```
2023-05-12 17:09:05.540 ERROR    Step configuring_stores failed with error : Traceback (most recent call last):
  File "C:\Users\MyUser\neat\cognite\neat\core\workflow\base.py", line 214, in run_step
    new_flow_message = method(flow_message)
                       ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\MyUser\neat\tests\api\data\workflows\fast_graph\workflow.py", line 88, in step_configuring_stores
    self.source_graph.init_graph(
  File "C:\Users\MyUser\neat\cognite\neat\core\loader\graph_store.py", line 115, in init_graph
    raise e
  File "C:\Users\MyUser\neat\cognite\neat\core\loader\graph_store.py", line 105, in init_graph
    oxstore = pyoxigraph.Store(
              ^^^^^^^^^^^^^^^^^
OSError: IO error: No such file or directory: Failed to create a directory: \app\data\source-graph: The system cannot find the path specified.


Traceback (most recent call last):
  File "C:\Users\MyUser\neat\cognite\neat\core\workflow\base.py", line 214, in run_step
    new_flow_message = method(flow_message)
                       ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\MyUser\neat\tests\api\data\workflows\fast_graph\workflow.py", line 88, in step_configuring_stores
    self.source_graph.init_graph(
  File "C:\Users\MyUser\neat\cognite\neat\core\loader\graph_store.py", line 115, in init_graph
    raise e
  File "C:\Users\MyUser\neat\cognite\neat\core\loader\graph_store.py", line 105, in init_graph
    oxstore = pyoxigraph.Store(
              ^^^^^^^^^^^^^^^^^
OSError: IO error: No such file or directory: Failed to create a directory: \app\data\source-graph: The system cannot find the path specified.

2023-05-12 17:09:05.541 ERROR    Workflow fast_graph is not running , step load_source_graph is skipped
2023-05-12 17:09:05.541 ERROR    Workflow fast_graph is not running , step run_transformation is skipped
2023-05-12 17:09:05.541 INFO     Workflow completed in 0.520285500009777 seconds
2023-05-12 17:09:05.542 INFO     HTTP Request: POST http://testserver/api/workflow/start "HTTP/1.1 200 OK"
```