### PR TITLE
CDF-18787: Use 2 partitions to list assets by default.

### DIFF
--- a/cognite/neat/core/extractors/rdf_to_assets.py
+++ b/cognite/neat/core/extractors/rdf_to_assets.py
@@ -752,7 +752,7 @@ def categorize_assets(
     client: CogniteClient,
     rdf_assets: dict,
     data_set_id: int,
-    partitions: int = 40,
+    partitions: int = 2,
     stop_on_exception: bool = False,
     return_report: bool = False,
 ) -> Union[tuple[dict, dict], dict]:
@@ -767,7 +767,7 @@ def categorize_assets(
     data_set_id : int
         Dataset id to which assets are to be/are stored
     partitions : int, optional
-        Number of partitions to use when fetching assets from CDF, by default 40
+        Number of partitions to use when fetching assets from CDF, by default 2
     stop_on_exception : bool, optional
         Whether to stop on exception or not, by default False
     return_report : bool, optional


### PR DESCRIPTION
Assets API recommends(insists in the future versions) to use at most 10 partitions to list assets.
But for 99% of use cases even this number is too much and just creates unnecessary concurrent requests spikes.
Example: Mean asset list request latency is about 300ms => ~ 3rps, each request returns up to 1K items. So with 10 partitions, the throughput is 30K assets per second. >1.5M assets per minute. We have quite small number (<20) of projects across all clusters where the full assets set is bigger than 2M.