### PR TITLE
Update docker-builder-publisher.yaml

### DIFF
--- a/.github/workflows/docker-builder-publisher.yaml
+++ b/.github/workflows/docker-builder-publisher.yaml
@@ -38,6 +38,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: cognite/neat:latest, cognite/neat:${{ github.ref_name }}


### PR DESCRIPTION
Removed  linux/arm/v7 platform from github actions to speed up builds.