### PR TITLE
Adding more ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,10 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.278
+    rev: v0.0.284
     hooks:
       -   id: ruff
           args:
-            - --fix
             - --exit-non-zero-on-fix
-            - --line-length=120
 
   - repo: https://github.com/psf/black
     rev: 23.3.0

--- a/cognite/neat/app/api/asgi/metrics.py
+++ b/cognite/neat/app/api/asgi/metrics.py
@@ -1,5 +1,4 @@
 from prometheus_client import Counter, make_asgi_app
 
-
 counter = Counter("started_workflows", "Description of counter")
 prometheus_app = make_asgi_app()

--- a/cognite/neat/app/api/configuration.py
+++ b/cognite/neat/app/api/configuration.py
@@ -1,13 +1,11 @@
 import logging
 import os
-
 from pathlib import Path
+
 from fastapi import FastAPI
 
-from cognite.client import CogniteClient
-
-
 from cognite import neat
+from cognite.client import CogniteClient
 from cognite.neat.app.api.data_classes.configuration import Config, configure_logging
 from cognite.neat.config import copy_examples_to_directory
 from cognite.neat.constants import PACKAGE_DIRECTORY
@@ -15,7 +13,6 @@ from cognite.neat.utils.utils import get_cognite_client_from_config
 from cognite.neat.workflows.cdf_store import CdfStore
 from cognite.neat.workflows.manager import WorkflowManager
 from cognite.neat.workflows.triggers import TriggerManager
-
 
 UI_PATH = PACKAGE_DIRECTORY / "app" / "ui" / "neat-app" / "build"
 

--- a/cognite/neat/app/api/configuration.py
+++ b/cognite/neat/app/api/configuration.py
@@ -2,10 +2,10 @@ import logging
 import os
 from pathlib import Path
 
+from cognite.client import CogniteClient
 from fastapi import FastAPI
 
 from cognite import neat
-from cognite.client import CogniteClient
 from cognite.neat.app.api.data_classes.configuration import Config, configure_logging
 from cognite.neat.config import copy_examples_to_directory
 from cognite.neat.constants import PACKAGE_DIRECTORY

--- a/cognite/neat/app/api/context_manager/manager.py
+++ b/cognite/neat/app/api/context_manager/manager.py
@@ -1,5 +1,5 @@
-from contextlib import asynccontextmanager
 import logging
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 

--- a/cognite/neat/app/api/data_classes/configuration.py
+++ b/cognite/neat/app/api/data_classes/configuration.py
@@ -3,8 +3,7 @@ import logging
 import os
 from enum import StrEnum
 from pathlib import Path
-
-from typing import Literal, Optional, Self
+from typing import Literal, Self
 
 import yaml
 from pydantic import BaseModel, Field
@@ -42,7 +41,7 @@ class Config(BaseModel):
     workflows_store_type: RulesStoreType = WorkflowsStoreType.FILE
     data_store_path: Path = Field(default_factory=lambda: Path.cwd() / "data")
 
-    workflow_downloader_filter: Optional[list[str]] = Field(
+    workflow_downloader_filter: list[str] | None = Field(
         description="List of workflow names+tags to filter on when downloading workflows from CDF. "
         "Example name:workflow_name=version,tag:tag_name",
         default=None,

--- a/cognite/neat/app/api/explorer.py
+++ b/cognite/neat/app/api/explorer.py
@@ -1,16 +1,14 @@
+import pkg_resources
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
-import pkg_resources
-
 
 from cognite import neat
+from cognite.neat.app.api.asgi.metrics import prometheus_app
 from cognite.neat.app.api.configuration import UI_PATH, neat_app
 from cognite.neat.app.api.context_manager import lifespan
-from cognite.neat.app.api.asgi.metrics import prometheus_app
-from cognite.neat.app.api.routers import configuration, crud, metrics, workflows, rules, data_exploration
-
+from cognite.neat.app.api.routers import configuration, crud, data_exploration, metrics, rules, workflows
 
 app = FastAPI(title="Neat", lifespan=lifespan)
 

--- a/cognite/neat/app/api/routers/configuration.py
+++ b/cognite/neat/app/api/routers/configuration.py
@@ -1,9 +1,10 @@
 import logging
 import os
 from pathlib import Path
-from fastapi import APIRouter
-from cognite.neat.app.api.configuration import Config, neat_app
 
+from fastapi import APIRouter
+
+from cognite.neat.app.api.configuration import Config, neat_app
 
 router = APIRouter()
 

--- a/cognite/neat/app/api/routers/crud.py
+++ b/cognite/neat/app/api/routers/crud.py
@@ -2,26 +2,26 @@
 
 
 import logging
-import os
 import shutil
-from fastapi import APIRouter, UploadFile
-from cognite.neat.workflows.model import FlowMessage, WorkflowConfigItem
 
-from cognite.neat.workflows.utils import get_file_hash
+from fastapi import APIRouter, UploadFile
+
 from cognite.neat.app.api.configuration import neat_app
+from cognite.neat.workflows.model import FlowMessage, WorkflowConfigItem
+from cognite.neat.workflows.utils import get_file_hash
 
 router = APIRouter()
 
 
 @router.get("/api/cdf/neat-resources")
-def get_neat_resources(resource_type: str = None):
+def get_neat_resources(resource_type: str | None = None):
     result = neat_app.cdf_store.get_list_of_resources_from_cdf(resource_type=resource_type)
     logging.debug(f"Got {len(result)} resources")
     return {"result": result}
 
 
 @router.post("/api/cdf/init-neat-resources")
-def init_neat_cdf_resources(resource_type: str = None):
+def init_neat_cdf_resources(resource_type: str | None = None):
     neat_app.cdf_store.init_cdf_resources(resource_type=resource_type)
     return {"result": "ok"}
 
@@ -37,8 +37,8 @@ async def file_upload_handler(files: list[UploadFile], workflow_name: str, file_
             f"Uploading file : {file.filename} , workflow : {workflow_name} , step_id {step_id} , action : {action}"
         )
         # save file to disk
-        full_path = os.path.join(upload_dir, file.filename)
-        with open(full_path, "wb") as buffer:
+        full_path = upload_dir / file.filename
+        with full_path.open("wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
         file_name = file.filename
         file_version = get_file_hash(full_path)

--- a/cognite/neat/app/api/routers/data_exploration.py
+++ b/cognite/neat/app/api/routers/data_exploration.py
@@ -1,17 +1,16 @@
 import logging
 import time
 import traceback
-from fastapi import APIRouter
+
 import rdflib
+from fastapi import APIRouter
 
-from cognite.neat.graph.transformations import query_generator
-
-from cognite.neat.app.api.configuration import neat_app, cache_store
-from cognite.neat.app.api.data_classes.rest import NodesAndEdgesRequest, QueryRequest, RuleRequest
 from cognite.neat.app.api.asgi.metrics import counter
+from cognite.neat.app.api.configuration import cache_store, neat_app
+from cognite.neat.app.api.data_classes.rest import NodesAndEdgesRequest, QueryRequest, RuleRequest
 from cognite.neat.app.api.utils.data_mapping import rdf_result_to_api_response
 from cognite.neat.app.api.utils.query_templates import query_templates
-
+from cognite.neat.graph.transformations import query_generator
 
 router = APIRouter()
 

--- a/cognite/neat/app/api/routers/rules.py
+++ b/cognite/neat/app/api/routers/rules.py
@@ -1,12 +1,11 @@
 import logging
 from pathlib import Path
+
 from fastapi import APIRouter
 
+from cognite.neat.app.api.configuration import neat_app
 from cognite.neat.rules.parser import parse_rules_from_excel_file
 from cognite.neat.workflows.utils import get_file_hash
-
-from cognite.neat.app.api.configuration import neat_app
-
 
 router = APIRouter()
 

--- a/cognite/neat/app/api/routers/workflows.py
+++ b/cognite/neat/app/api/routers/workflows.py
@@ -1,8 +1,9 @@
 import logging
 from pathlib import Path
-from fastapi import APIRouter
-from fastapi import HTTPException
+
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
+
 from cognite.neat.app.api.configuration import neat_app
 from cognite.neat.app.api.data_classes.rest import DownloadFromCdfRequest, RunWorkflowRequest, UploadToCdfRequest
 from cognite.neat.workflows import WorkflowFullStateReport

--- a/cognite/neat/app/monitoring/metrics.py
+++ b/cognite/neat/app/monitoring/metrics.py
@@ -1,8 +1,7 @@
 from collections.abc import Iterable
 
-from prometheus_client import REGISTRY, Counter, Gauge, Metric
-
 from cognite.client import CogniteClient
+from prometheus_client import REGISTRY, Counter, Gauge, Metric
 
 
 class NeatMetricsCollector:

--- a/cognite/neat/app/monitoring/metrics.py
+++ b/cognite/neat/app/monitoring/metrics.py
@@ -1,7 +1,8 @@
-from typing import Iterable
+from collections.abc import Iterable
+
+from prometheus_client import REGISTRY, Counter, Gauge, Metric
 
 from cognite.client import CogniteClient
-from prometheus_client import REGISTRY, Counter, Gauge, Metric
 
 
 class NeatMetricsCollector:
@@ -10,7 +11,11 @@ class NeatMetricsCollector:
         self.metrics: dict[str, Gauge | Counter] = {}
 
     def register_metric(
-        self, metric_name: str, metric_description: str = "", m_type: str = "gauge", metric_labels: list[str] = None
+        self,
+        metric_name: str,
+        metric_description: str = "",
+        m_type: str = "gauge",
+        metric_labels: list[str] | None = None,
     ) -> Gauge | Counter:
         """Register metric in prometheus"""
         metric_labels = [] if metric_labels is None else metric_labels
@@ -30,14 +35,18 @@ class NeatMetricsCollector:
             self.metrics[metric_name] = metric
             return metric
 
-    def get(self, metric_name: str, labels: dict[str, str] = None) -> Gauge | Counter:
+    def get(self, metric_name: str, labels: dict[str, str] | None = None) -> Gauge | Counter:
         """Return metric by name"""
         labels = {} if labels is None else labels
         metric_name = f"neat_workflow_{self.name}_{metric_name}"
         return self.metrics.get(metric_name).labels(**labels)
 
     def report_metric_value(
-        self, metric_name: str, metric_description: str = "", m_type: str = "gauge", labels: dict[str, str] = None
+        self,
+        metric_name: str,
+        metric_description: str = "",
+        m_type: str = "gauge",
+        labels: dict[str, str] | None = None,
     ) -> Gauge | Counter:
         metric = self.register_metric(metric_name, metric_description, m_type, [k for k, v in labels.items()])
         return metric.labels(**labels)

--- a/cognite/neat/config.py
+++ b/cognite/neat/config.py
@@ -1,7 +1,7 @@
 import shutil
 from pathlib import Path
 
-from cognite.neat.constants import EXAMPLE_RULES, EXAMPLE_GRAPHS, EXAMPLE_WORKFLOWS
+from cognite.neat.constants import EXAMPLE_GRAPHS, EXAMPLE_RULES, EXAMPLE_WORKFLOWS
 
 
 def copy_examples_to_directory(target_data_dir: Path):

--- a/cognite/neat/constants.py
+++ b/cognite/neat/constants.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from rdflib import Namespace
-from cognite import neat
 
+from rdflib import Namespace
+
+from cognite import neat
 
 PACKAGE_DIRECTORY = Path(neat.__file__).parent
 
@@ -12,10 +13,6 @@ EXAMPLE_WORKFLOWS = PACKAGE_DIRECTORY / "workflows" / "examples"
 
 
 PREFIXES = {
-    # "rdf": Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#"), # noqa
-    # "rdfs": Namespace("http://www.w3.org/2000/01/rdf-schema#"),# noqa
-    # "owl": Namespace("http://www.w3.org/2002/07/owl#"),# noqa
-    # "sh": Namespace("http://www.w3.org/ns/shacl#"),
     "dct": Namespace("http://purl.org/dc/terms/"),
     "skos": Namespace("http://www.w3.org/2004/02/skos/core#"),
     "pav": Namespace("http://purl.org/pav/"),

--- a/cognite/neat/exceptions.py
+++ b/cognite/neat/exceptions.py
@@ -1,4 +1,5 @@
 from warnings import WarningMessage
+
 from pydantic_core import ErrorDetails, PydanticCustomError
 
 

--- a/cognite/neat/graph/extractors/graph_sheet_to_graph.py
+++ b/cognite/neat/graph/extractors/graph_sheet_to_graph.py
@@ -1,13 +1,13 @@
 import logging
-from pathlib import Path
 import warnings
+from pathlib import Path
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from openpyxl import Workbook, load_workbook
 from rdflib import RDF, XSD, Literal, Namespace
 
-from cognite.neat.rules.analysis import to_class_property_pairs, get_defined_classes
+from cognite.neat.rules.analysis import get_defined_classes, to_class_property_pairs
 from cognite.neat.rules.models import TransformationRules
 
 
@@ -15,7 +15,7 @@ def extract_graph_from_sheet(
     filepath: Path,
     transformation_rule: TransformationRules,
     separator: str = ",",
-    namespace: str = None,
+    namespace: str | None = None,
 ) -> list[tuple]:
     """Converts a graph capturing sheet to rdf triples
 
@@ -42,7 +42,7 @@ def sheet2triples(
     graph_capturing_sheet: dict[str, pd.DataFrame],
     transformation_rule: TransformationRules,
     separator: str = ",",
-    namespace: str = None,
+    namespace: str | None = None,
 ) -> list[tuple]:
     """Converts a graph capturing sheet to rdf triples
 

--- a/cognite/neat/graph/extractors/mocks/graph.py
+++ b/cognite/neat/graph/extractors/mocks/graph.py
@@ -153,7 +153,7 @@ def _traverse(hierarchy: dict, graph: dict, names: str) -> dict:
     return hierarchy
 
 
-def _prettify_generation_order(generation_order: dict, depth: dict = None, start=-1) -> dict:
+def _prettify_generation_order(generation_order: dict, depth: dict | None = None, start=-1) -> dict:
     """Prettifies generation order dictionary for easier consumption."""
     depth = depth or {}
     for key, value in generation_order.items():

--- a/cognite/neat/graph/loaders/__init__.py
+++ b/cognite/neat/graph/loaders/__init__.py
@@ -1,6 +1,7 @@
 from cognite.neat.graph.loaders.core.labels import upload_labels
-from .core.rdf_to_assets import rdf2assets, upload_assets, categorize_assets
-from .core.rdf_to_relationships import rdf2relationships, categorize_relationships, upload_relationships
+
+from .core.rdf_to_assets import categorize_assets, rdf2assets, upload_assets
+from .core.rdf_to_relationships import categorize_relationships, rdf2relationships, upload_relationships
 
 __all__ = [
     "rdf2relationships",

--- a/cognite/neat/graph/loaders/core/labels.py
+++ b/cognite/neat/graph/loaders/core/labels.py
@@ -3,7 +3,6 @@ import traceback
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import LabelDefinition
-
 from cognite.neat.rules.exporter.core import get_labels
 from cognite.neat.rules.models import TransformationRules
 
@@ -11,7 +10,7 @@ from cognite.neat.rules.models import TransformationRules
 def upload_labels(
     client: CogniteClient,
     transformation_rules: TransformationRules,
-    extra_labels: list = None,
+    extra_labels: list | None = None,
     stop_on_exception: bool = False,
 ):
     """Upload labels to CDF

--- a/cognite/neat/graph/loaders/core/labels.py
+++ b/cognite/neat/graph/loaders/core/labels.py
@@ -3,6 +3,7 @@ import traceback
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import LabelDefinition
+
 from cognite.neat.rules.exporter.core import get_labels
 from cognite.neat.rules.models import TransformationRules
 

--- a/cognite/neat/graph/loaders/core/models.py
+++ b/cognite/neat/graph/loaders/core/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import ClassVar, List, Optional
+from typing import ClassVar
 
 from pydantic import BaseModel, ConfigDict, root_validator, validator
 from rdflib import Namespace
@@ -12,9 +12,9 @@ from cognite.neat.rules.models import METADATA_VALUE_MAX_LENGTH
 class AssetClassMapping(BaseModel):
     external_id: str
     name: str
-    parent_external_id: Optional[str] = None
-    description: Optional[str] = None
-    metadata: Optional[dict] = {}
+    parent_external_id: str | None = None
+    description: str | None = None
+    metadata: dict | None = {}
 
     @root_validator(pre=True)
     def create_metadata(cls, values: dict):
@@ -33,13 +33,13 @@ class AssetTemplate(BaseModel):
     """This class is used to validate, repair and wrangle rdf asset dictionary according to the
     expected format of cognite sdk Asset dataclass."""
 
-    external_id_prefix: Optional[str] = None  # convenience field to add prefix to external_ids
+    external_id_prefix: str | None = None  # convenience field to add prefix to external_ids
     external_id: str
-    name: Optional[str] = None
-    parent_external_id: Optional[str] = None
-    metadata: Optional[dict] = {}
-    description: Optional[str] = None
-    data_set_id: Optional[int] = None
+    name: str | None = None
+    parent_external_id: str | None = None
+    metadata: dict | None = {}
+    description: str | None = None
+    data_set_id: int | None = None
 
     @root_validator(pre=True)
     def preprocess_fields(cls, values: dict):
@@ -119,10 +119,10 @@ class RelationshipDefinition(BaseModel):
     source_class: str
     target_class: str
     property_: str
-    labels: Optional[List[str]] = None
+    labels: list[str] | None = None
     target_type: str = "Asset"
     source_type: str = "Asset"
-    relationship_external_id_rule: Optional[str] = None
+    relationship_external_id_rule: str | None = None
 
 
 class RelationshipDefinitions(BaseModel):

--- a/cognite/neat/graph/loaders/core/rdf_to_assets.py
+++ b/cognite/neat/graph/loaders/core/rdf_to_assets.py
@@ -8,13 +8,13 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
+from cognite.client import CogniteClient
+from cognite.client.data_classes import Asset, AssetHierarchy, AssetList
+from cognite.client.exceptions import CogniteDuplicatedError
 from deepdiff import DeepDiff
 from rdflib import Graph, Namespace
 from rdflib.term import URIRef
 
-from cognite.client import CogniteClient
-from cognite.client.data_classes import Asset, AssetHierarchy, AssetList
-from cognite.client.exceptions import CogniteDuplicatedError
 from cognite.neat.graph.loaders.core.models import AssetTemplate
 from cognite.neat.graph.stores import NeatGraphStore
 from cognite.neat.rules.models import Property, TransformationRules

--- a/cognite/neat/graph/loaders/core/rdf_to_assets.py
+++ b/cognite/neat/graph/loaders/core/rdf_to_assets.py
@@ -2,19 +2,19 @@ import logging
 import warnings
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, fields
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Self, Tuple, Union, overload
+from datetime import UTC, datetime
+from typing import Any, Self, overload
 from warnings import warn
 
 import numpy as np
 import pandas as pd
-from cognite.client import CogniteClient
-from cognite.client.data_classes import Asset, AssetHierarchy, AssetList
-from cognite.client.exceptions import CogniteDuplicatedError
 from deepdiff import DeepDiff
 from rdflib import Graph, Namespace
 from rdflib.term import URIRef
 
+from cognite.client import CogniteClient
+from cognite.client.data_classes import Asset, AssetHierarchy, AssetList
+from cognite.client.exceptions import CogniteDuplicatedError
 from cognite.neat.graph.loaders.core.models import AssetTemplate
 from cognite.neat.graph.stores import NeatGraphStore
 from cognite.neat.rules.models import Property, TransformationRules
@@ -56,7 +56,7 @@ class NeatMetadataKeys:
         return {field.default: getattr(self, field.name) for field in fields(self)}
 
 
-def _get_class_instance_ids(graph: Graph, class_: str, namespace: Namespace, limit: int = -1) -> List[URIRef]:
+def _get_class_instance_ids(graph: Graph, class_: str, namespace: Namespace, limit: int = -1) -> list[URIRef]:
     """Get instances ids for a given class
 
     Parameters
@@ -83,7 +83,7 @@ def _get_class_instance_ids(graph: Graph, class_: str, namespace: Namespace, lim
     return [res[0] for res in list(graph.query(query_statement))]
 
 
-def _get_class_instance(graph: Graph, instance: URIRef) -> List[tuple]:
+def _get_class_instance(graph: Graph, instance: URIRef) -> list[tuple]:
     """Get instance by means of tuples containing property-value pairs
 
     Returns
@@ -103,7 +103,7 @@ def _get_class_instance(graph: Graph, instance: URIRef) -> List[tuple]:
     return result
 
 
-def _get_class_property_pairs(transformation_rules: TransformationRules) -> dict[List[Property]]:
+def _get_class_property_pairs(transformation_rules: TransformationRules) -> dict[list[Property]]:
     """Define classes in terms of their properties
 
     Parameters
@@ -171,7 +171,7 @@ def _define_asset_class_mapping(transformation_rules: TransformationRules) -> di
     return asset_class_mapping
 
 
-def _remap_class_properties(class_instance: dict, asset_class_mapping: dict) -> Tuple[dict, set, set]:
+def _remap_class_properties(class_instance: dict, asset_class_mapping: dict) -> tuple[dict, set, set]:
     """Remaps original class instance properties to asset properties (e.g., external_id, name, description, metadata)
 
     Parameters
@@ -213,8 +213,8 @@ def _class2asset_instance(
     asset_class_mapping: dict,
     data_set_id: int,
     meta_keys: NeatMetadataKeys,
-    orphanage_asset_external_id: str = None,
-    external_id_prefix: str = None,
+    orphanage_asset_external_id: str | None = None,
+    external_id_prefix: str | None = None,
     fallback_property: str = NeatMetadataKeys.identifier,
     empty_name_default: str = "Missing Name",
     add_missing_metadata: bool = True,
@@ -419,7 +419,6 @@ def rdf2assets(
             response_df = graph_store.query_to_dataframe(query)
         except Exception as e:
             logging.error(f"Error while loading instances of class <{class_ns}> into cache. Reason: {e}")
-            # traceback.print_exc()
             if stop_on_exception:
                 raise e
             continue
@@ -448,7 +447,7 @@ def rdf2assets(
 
                 # adding labels and timestamps
                 asset["labels"] = [asset["metadata"][meta_keys.type], "non-historic"]
-                now = str(datetime.now(timezone.utc))
+                now = str(datetime.now(UTC))
                 asset["metadata"][meta_keys.start_time] = now
                 asset["metadata"][meta_keys.update_time] = now
                 asset["metadata"] = {meta_keys_aliases.get(k, k): v for k, v in asset["metadata"].items()}
@@ -486,8 +485,8 @@ def rdf2asset_dictionary(
     transformation_rules: TransformationRules,
     stop_on_exception: bool = False,
     use_orphanage: bool = True,
-) -> Dict[str, Asset]:
-    warn("'rdf2asset_dictionary' is deprecated, please use 'rdf2assets' instead!")
+) -> dict[str, Asset]:
+    warn("'rdf2asset_dictionary' is deprecated, please use 'rdf2assets' instead!", stacklevel=2)
     logging.warning("'rdf2asset_dictionary' is deprecated, please use 'rdf2assets' instead!")
     return rdf2assets(graph_store, transformation_rules, stop_on_exception, use_orphanage)
 
@@ -536,7 +535,7 @@ def _asset2dict(asset: Asset) -> dict:
     }
 
 
-def _flatten_labels(labels: List[Dict[str, str]]) -> set[str]:
+def _flatten_labels(labels: list[dict[str, str]]) -> set[str]:
     """Flatten labels"""
     result = set()
     if labels is None:
@@ -556,7 +555,7 @@ def _is_historic(labels) -> bool:
 
 def _categorize_cdf_assets(
     client: CogniteClient, data_set_id: int, partitions: int
-) -> Tuple[Optional[pd.DataFrame], dict[str, set]]:
+) -> tuple[pd.DataFrame | None, dict[str, set]]:
     """Categorize CDF assets
 
     Parameters
@@ -733,8 +732,8 @@ def _assets_to_update(
             try:
                 asset.metadata[meta_keys.start_time] = cdf_asset[external_id]["metadata"][meta_keys.start_time]
             except KeyError:
-                asset.metadata[meta_keys.start_time] = str(datetime.now(timezone.utc))
-            asset.metadata[meta_keys.update_time] = str(datetime.now(timezone.utc))
+                asset.metadata[meta_keys.start_time] = str(datetime.now(UTC))
+            asset.metadata[meta_keys.update_time] = str(datetime.now(UTC))
             assets.append(asset)
 
             report[external_id] = dict(diffing_result)
@@ -775,7 +774,7 @@ def _assets_to_resurrect(
         cdf_asset = cdf_asset_subset[external_id]
 
         asset = Asset(**rdf_assets[external_id])
-        now = str(datetime.now(timezone.utc))
+        now = str(datetime.now(UTC))
         try:
             asset.metadata[meta_keys.start_time] = cdf_asset[external_id]["metadata"][meta_keys.start_time]
         except KeyError:
@@ -803,7 +802,7 @@ def _assets_to_decommission(cdf_assets, asset_ids, meta_keys: NeatMetadataKeys) 
     for external_id in asset_ids:
         cdf_asset = cdf_asset_subset[external_id]
 
-        now = str(datetime.now(timezone.utc))
+        now = str(datetime.now(UTC))
         cdf_asset["metadata"][meta_keys.update_time] = now
         cdf_asset["metadata"].pop(meta_keys.resurrection_time, None)
         cdf_asset["metadata"][meta_keys.end_time] = now
@@ -828,7 +827,7 @@ def categorize_assets(
     stop_on_exception: bool = False,
     return_report: bool = False,
     meta_keys: NeatMetadataKeys | None = None,
-) -> Union[tuple[dict, dict], dict]:
+) -> tuple[dict, dict] | dict:
     """Categorize assets on those that are to be created, updated and decommissioned
 
     Parameters
@@ -950,7 +949,7 @@ def _micro_batch_push(
 
 def upload_assets(
     client: CogniteClient,
-    categorized_assets: Dict[str, Sequence[Asset]],
+    categorized_assets: dict[str, Sequence[Asset]],
     batch_size: int = 5000,
     max_retries: int = 1,
     retry_delay: int = 3,

--- a/cognite/neat/graph/loaders/core/rdf_to_relationships.py
+++ b/cognite/neat/graph/loaders/core/rdf_to_relationships.py
@@ -3,10 +3,10 @@ import warnings
 from warnings import warn
 
 import pandas as pd
-
 from cognite.client import CogniteClient
 from cognite.client.data_classes import LabelFilter, Relationship, RelationshipUpdate
 from cognite.client.exceptions import CogniteDuplicatedError
+
 from cognite.neat.graph.loaders.core.models import RelationshipDefinition, RelationshipDefinitions
 from cognite.neat.graph.loaders.core.rdf_to_assets import _categorize_cdf_assets
 from cognite.neat.graph.stores import NeatGraphStore

--- a/cognite/neat/graph/loaders/validator.py
+++ b/cognite/neat/graph/loaders/validator.py
@@ -3,12 +3,11 @@ as well App Data Model (RDF)
 """
 
 import logging
-from typing import List, Tuple
 
 from cognite.client.data_classes import Asset
 
 
-def _find_circular_reference_path(asset: Asset, assets: dict[str, Asset], max_hierarchy_depth: int = 10000) -> List:
+def _find_circular_reference_path(asset: Asset, assets: dict[str, Asset], max_hierarchy_depth: int = 10000) -> list:
     original_external_id = asset.get("external_id")
     circle = [original_external_id]
     ref = assets.get(asset.get("parent_external_id"))
@@ -38,7 +37,7 @@ def _find_circular_reference_path(asset: Asset, assets: dict[str, Asset], max_hi
         return []
 
 
-def validate_asset_hierarchy(assets: dict[str, Asset]) -> Tuple[List[str], List[List[str]]]:
+def validate_asset_hierarchy(assets: dict[str, Asset]) -> tuple[list[str], list[list[str]]]:
     """Validates asset hierarchy and reports on orphan assets and circular dependency
 
     Parameters

--- a/cognite/neat/graph/stores/__init__.py
+++ b/cognite/neat/graph/stores/__init__.py
@@ -1,4 +1,4 @@
+from .configuration import RdfStoreConfig, RdfStoreType
 from .graph_store import NeatGraphStore, drop_graph_store
-from .configuration import RdfStoreType, RdfStoreConfig
 
 __all__ = ["NeatGraphStore", "drop_graph_store", "RdfStoreType", "RdfStoreConfig"]

--- a/cognite/neat/graph/stores/configuration.py
+++ b/cognite/neat/graph/stores/configuration.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+
 from pydantic import BaseModel
 
 

--- a/cognite/neat/graph/transformations/query_generator/sparql.py
+++ b/cognite/neat/graph/transformations/query_generator/sparql.py
@@ -1,9 +1,11 @@
-from collections import Counter, defaultdict
 import re
+from collections import Counter, defaultdict
+
 from rdflib import Graph, Namespace
 from rdflib.term import URIRef
 
 from cognite.neat.constants import PREFIXES
+from cognite.neat.rules.analysis import get_classes_with_properties
 from cognite.neat.rules.models import TransformationRules
 from cognite.neat.rules.to_rdf_path import (
     AllProperties,
@@ -17,7 +19,6 @@ from cognite.neat.rules.to_rdf_path import (
     parse_rule,
     parse_traversal,
 )
-from cognite.neat.rules.analysis import get_classes_with_properties
 from cognite.neat.utils.utils import remove_namespace
 
 

--- a/cognite/neat/graph/transformations/transformer.py
+++ b/cognite/neat/graph/transformations/transformer.py
@@ -5,15 +5,14 @@ import logging
 import time
 import traceback
 from enum import StrEnum
-from typing import List, Tuple
 
 import pandas as pd
-from cognite.client import CogniteClient
 from prometheus_client import Gauge
 from pydantic import BaseModel
 from rdflib import RDF, Graph
 from rdflib.term import Literal
 
+from cognite.client import CogniteClient
 from cognite.neat.graph.transformations.query_generator.sparql import build_sparql_query
 from cognite.neat.rules.models import TransformationRules
 from cognite.neat.rules.to_rdf_path import AllProperties, AllReferences, RawLookup, parse_rule
@@ -54,7 +53,7 @@ class RuleProcessingReport(BaseModel):
     total_success: int = 0
     total_success_no_results: int = 0
     total_failed: int = 0
-    records: List[RuleProcessingReportRec] = []
+    records: list[RuleProcessingReportRec] = []
     elapsed_time: float = 0
 
 
@@ -63,8 +62,8 @@ def source2solution_graph(
     transformation_rules: TransformationRules,
     solution_knowledge_graph: Graph = None,
     client: CogniteClient = None,
-    cdf_lookup_database: str = None,
-    extra_triples: List[Tuple] = None,
+    cdf_lookup_database: str | None = None,
+    extra_triples: list[tuple] | None = None,
     stop_on_exception: bool = False,
     missing_raw_lookup_value: str = "NaN",
     processing_report: RuleProcessingReport = None,
@@ -91,8 +90,8 @@ def domain2app_knowledge_graph(
     transformation_rules: TransformationRules,
     app_instance_graph: Graph = None,
     client: CogniteClient = None,
-    cdf_lookup_database: str = None,
-    extra_triples: List[Tuple] = None,
+    cdf_lookup_database: str | None = None,
+    extra_triples: list[tuple] | None = None,
     stop_on_exception: bool = False,
     missing_raw_lookup_value: str = "NaN",
     processing_report: RuleProcessingReport = None,
@@ -286,8 +285,8 @@ def domain2app_knowledge_graph(
             try:
                 app_instance_graph.add(triple)
                 check_commit()
-            except ValueError:
-                raise ValueError(f"Triple {i} in extra_triples is not correct and cannot be added!")
+            except ValueError as e:
+                raise ValueError(f"Triple {i} in extra_triples is not correct and cannot be added!") from e
 
     check_commit(force_commit=True)
     return app_instance_graph

--- a/cognite/neat/graph/transformations/transformer.py
+++ b/cognite/neat/graph/transformations/transformer.py
@@ -7,12 +7,12 @@ import traceback
 from enum import StrEnum
 
 import pandas as pd
+from cognite.client import CogniteClient
 from prometheus_client import Gauge
 from pydantic import BaseModel
 from rdflib import RDF, Graph
 from rdflib.term import Literal
 
-from cognite.client import CogniteClient
 from cognite.neat.graph.transformations.query_generator.sparql import build_sparql_query
 from cognite.neat.rules.models import TransformationRules
 from cognite.neat.rules.to_rdf_path import AllProperties, AllReferences, RawLookup, parse_rule

--- a/cognite/neat/rules/__init__.py
+++ b/cognite/neat/rules/__init__.py
@@ -1,11 +1,10 @@
 from cognite.neat.rules import models
 from cognite.neat.rules.parser import (
     parse_rules_from_excel_file,
-    parse_rules_from_google_sheet,
     parse_rules_from_github_sheet,
+    parse_rules_from_google_sheet,
     parse_rules_from_yaml,
 )
-
 
 __all__ = [
     "models",

--- a/cognite/neat/rules/_validation.py
+++ b/cognite/neat/rules/_validation.py
@@ -1,6 +1,6 @@
 import re
-from typing import Literal, overload
 import warnings
+from typing import Literal, overload
 
 from cognite.neat.exceptions import wrangle_warnings
 from cognite.neat.rules import exceptions

--- a/cognite/neat/rules/analysis.py
+++ b/cognite/neat/rules/analysis.py
@@ -1,5 +1,6 @@
-from collections import defaultdict
 import warnings
+from collections import defaultdict
+
 import pandas as pd
 
 from cognite.neat.rules.models import Property, TransformationRules

--- a/cognite/neat/rules/exceptions.py
+++ b/cognite/neat/rules/exceptions.py
@@ -11,10 +11,11 @@ CODES:
 
 #########################################
 # Metadata sheet Error Codes 100 - 199: #
-from cognite.neat.exceptions import NeatException, NeatWarning
 from typing import Any
 
 from rdflib import URIRef
+
+from cognite.neat.exceptions import NeatException, NeatWarning
 
 
 class ExcelFileMissingMandatorySheets(NeatException):
@@ -896,7 +897,6 @@ class NoTransformationRules(NeatWarning):
     fix: str = "No fix is provided for this warning"
 
     # need to have default value set otherwise
-    # warnings.warn(Warning302(property_id, class_id).message, category=Warning302)
     # will raise TypeError: __init__() missing 1 required positional argument: 'property_id'
     # not happy with this solution but it works
     def __init__(self, property_id: str = "", class_id: str = "", verbose=False):
@@ -1249,10 +1249,10 @@ class OntologyMultiTypeProperty(NeatWarning):
     example: str = ""
     fix: str = "If a property takes different value types for different objects, simply define new property"
 
-    def __init__(self, property_id: str = "", types: list[str] = [], verbose=False):
+    def __init__(self, property_id: str = "", types: list[str] | None = None, verbose=False):
         self.message = (
             "It is bad practice to have multi type property! "
-            f"Currently property '{property_id}' is defined as multi type property: {', '.join(types)}"
+            f"Currently property '{property_id}' is defined as multi type property: {', '.join(types or [])}"
         )
         if verbose:
             self.message += f"\nDescription: {self.description}"
@@ -1272,10 +1272,10 @@ class OntologyMultiRangeProperty(NeatWarning):
     example: str = ""
     fix: str = "If a property takes different range of values, simply define new property for each range"
 
-    def __init__(self, property_id: str = "", range_of_values: list[str] = [], verbose=False):
+    def __init__(self, property_id: str = "", range_of_values: list[str] | None = None, verbose=False):
         self.message = (
             "Property should ideally have only single range of values. "
-            f"Currently property '{property_id}' has multiple ranges: {', '.join(range_of_values)}"
+            f"Currently property '{property_id}' has multiple ranges: {', '.join(range_of_values or None)}"
         )
         if verbose:
             self.message += f"\nDescription: {self.description}"
@@ -1296,10 +1296,10 @@ class OntologyMultiDomainProperty(NeatWarning):
         " across different classes and that ideally takes the same range of values"
     )
 
-    def __init__(self, property_id: str = "", classes: list[str] = [], verbose=False):
+    def __init__(self, property_id: str = "", classes: list[str] | None = None, verbose=False):
         self.message = (
             "Property should ideally defined for single class. "
-            f"Currently property '{property_id}' is defined for multiple classes: {', '.join(classes)}"
+            f"Currently property '{property_id}' is defined for multiple classes: {', '.join(classes or [])}"
         )
         if verbose:
             self.message += f"\nDescription: {self.description}"
@@ -1321,10 +1321,10 @@ class OntologyMultiLabeledProperty(NeatWarning):
     example: str = ""
     fix: str = "This would be automatically fixes by taking the first name."
 
-    def __init__(self, property_id: str = "", names: list[str] = [], verbose=False):
+    def __init__(self, property_id: str = "", names: list[str] | None = None, verbose=False):
         self.message = (
             "Property should have single preferred label (human readable name)."
-            f"Currently property '{property_id}' has multiple preferred labels: {', '.join(names)} !"
+            f"Currently property '{property_id}' has multiple preferred labels: {', '.join(names or [])} !"
             f"Only the first name, i.e. '{names[0]}' will be considered!"
         )
         if verbose:
@@ -1403,7 +1403,7 @@ class FieldContainsMoreThanOneValue(NeatWarning):
         "To do this do not bound its `max_count` to 1, either leave it blank or set it to >1."
     )
 
-    def __init__(self, field_name: str = "", no_of_values: int = None, verbose=False):
+    def __init__(self, field_name: str = "", no_of_values: int | None = None, verbose=False):
         self.message = (
             f"Field {field_name} is defined as single value property in TransformationRules,"
             f" but it contains {no_of_values} values!"
@@ -1473,9 +1473,9 @@ class ContainersAlreadyExist(NeatWarning):
     example: str = ""
     fix: str = "Remove existing containers and try again."
 
-    def __init__(self, container_ids: set[str] = set(), space: str = "", verbose=False):
+    def __init__(self, container_ids: set[str] | None = None, space: str = "", verbose=False):
         self.message = (
-            f"Containers {container_ids} already exist in space {space}. "
+            f"Containers {container_ids or set()} already exist in space {space}. "
             "Since update of containers can cause issues, "
             "remove them first prior data model creation!"
             "Aborting containers creation!"
@@ -1497,9 +1497,9 @@ class ViewsAlreadyExist(NeatWarning):
     example: str = ""
     fix: str = "Remove existing views and try again or update version of data model."
 
-    def __init__(self, views_ids: set[str] = set(), version: str = "", space: str = "", verbose=False):
+    def __init__(self, views_ids: set[str] | None = None, version: str = "", space: str = "", verbose=False):
         self.message = (
-            f"Views {views_ids} version {version} already exist in space {space}. "
+            f"Views {views_ids or set()} version {version} already exist in space {space}. "
             "Since update of views raise issues, "
             "remove them first prior data model creation or update version of data model!"
             "Aborting views creation!"

--- a/cognite/neat/rules/exporter/rules2dms.py
+++ b/cognite/neat/rules/exporter/rules2dms.py
@@ -2,32 +2,32 @@
 """
 
 import logging
-from typing import ClassVar, Optional, Self
 import warnings
+from typing import ClassVar, Self
+
 from pydantic import BaseModel, ConfigDict
 
 from cognite.client import CogniteClient
-from cognite.client.data_classes.data_modeling import ContainerApply, ContainerProperty, DirectRelation
 from cognite.client.data_classes.data_modeling import (
-    ViewApply,
-    SpaceApply,
-    DataModelApply,
-    DirectRelationReference,
-)
-from cognite.client.data_classes.data_modeling import (
-    MappedPropertyApply,
+    ContainerApply,
     ContainerId,
-    ViewId,
+    ContainerProperty,
+    DataModelApply,
+    DirectRelation,
+    DirectRelationReference,
+    MappedPropertyApply,
     SingleHopConnectionDefinition,
+    SpaceApply,
+    ViewApply,
+    ViewId,
 )
-from cognite.neat.rules.analysis import to_class_property_pairs
-
-from cognite.neat.rules.models import Property, TransformationRules, DATA_TYPE_MAPPING
 from cognite.neat.rules import exceptions
 from cognite.neat.rules._validation import (
     are_entity_names_dms_compliant,
     are_properties_redefined,
 )
+from cognite.neat.rules.analysis import to_class_property_pairs
+from cognite.neat.rules.models import DATA_TYPE_MAPPING, Property, TransformationRules
 from cognite.neat.utils.utils import generate_exception_report
 
 
@@ -38,8 +38,8 @@ class DataModel(BaseModel):
     space: str
     external_id: str
     version: str
-    description: Optional[str] = None
-    name: Optional[str] = None
+    description: str | None = None
+    name: str | None = None
     containers: dict[str, ContainerApply]
     views: dict[str, ViewApply]
 

--- a/cognite/neat/rules/exporter/rules2dms.py
+++ b/cognite/neat/rules/exporter/rules2dms.py
@@ -5,8 +5,6 @@ import logging
 import warnings
 from typing import ClassVar, Self
 
-from pydantic import BaseModel, ConfigDict
-
 from cognite.client import CogniteClient
 from cognite.client.data_classes.data_modeling import (
     ContainerApply,
@@ -21,6 +19,8 @@ from cognite.client.data_classes.data_modeling import (
     ViewApply,
     ViewId,
 )
+from pydantic import BaseModel, ConfigDict
+
 from cognite.neat.rules import exceptions
 from cognite.neat.rules._validation import (
     are_entity_names_dms_compliant,

--- a/cognite/neat/rules/exporter/rules2graph_sheet.py
+++ b/cognite/neat/rules/exporter/rules2graph_sheet.py
@@ -50,7 +50,7 @@ def rules2graph_capturing_sheet(
         workbook.create_sheet(title=class_)
 
         # Add header rows
-        workbook[class_].append(["identifier"] + list(properties.keys()))
+        workbook[class_].append(["identifier", *list(properties.keys())])
 
         if auto_identifier_type and auto_identifier_type == "index-based":  # default, easy to read
             logging.debug(f"Configuring index-based automatic identifiers for sheet {class_}")

--- a/cognite/neat/rules/exporter/rules2graphql.py
+++ b/cognite/neat/rules/exporter/rules2graphql.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Self
+
 from cognite.neat.rules import exceptions
 from cognite.neat.rules._validation import (
     are_entity_names_dms_compliant,
@@ -8,7 +9,6 @@ from cognite.neat.rules._validation import (
 from cognite.neat.rules.analysis import to_class_property_pairs
 from cognite.neat.rules.models import DATA_TYPE_MAPPING, TransformationRules
 from cognite.neat.utils.utils import generate_exception_report
-
 
 _TYPE = (
     "{% include 'type_header' %}type {{ class_definition.class_id }} {{'{'}}"

--- a/cognite/neat/rules/exporter/rules2ontology.py
+++ b/cognite/neat/rules/exporter/rules2ontology.py
@@ -1,13 +1,14 @@
-from typing import ClassVar, Optional, Self
 import warnings
+from typing import ClassVar, Self
+
 from pydantic import BaseModel, ConfigDict, FieldValidationInfo, field_validator
-from rdflib import OWL, RDF, RDFS, XSD, DCTERMS, BNode, Graph, Literal, URIRef, Namespace
+from rdflib import DCTERMS, OWL, RDF, RDFS, XSD, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.collection import Collection as GraphCollection
 
-from cognite.neat.rules.models import DATA_TYPE_MAPPING, Class, Property, TransformationRules, Metadata
-from cognite.neat.rules.analysis import to_property_dict, to_class_property_pairs
-from cognite.neat.rules._validation import are_properties_redefined
 from cognite.neat.rules import exceptions
+from cognite.neat.rules._validation import are_properties_redefined
+from cognite.neat.rules.analysis import to_class_property_pairs, to_property_dict
+from cognite.neat.rules.models import DATA_TYPE_MAPPING, Class, Metadata, Property, TransformationRules
 from cognite.neat.utils.utils import generate_exception_report, remove_namespace
 
 
@@ -151,9 +152,9 @@ class OWLMetadata(Metadata):
 class OWLClass(OntologyModel):
     id_: URIRef
     type_: URIRef = OWL.Class
-    label: Optional[str]
-    comment: Optional[str]
-    sub_class_of: Optional[URIRef]
+    label: str | None
+    comment: str | None
+    sub_class_of: URIRef | None
     namespace: Namespace
 
     @classmethod
@@ -392,8 +393,8 @@ class SHACLPropertyShape(OntologyModel):
     path: URIRef  # URIRef to property in OWL
     node_kind: URIRef  # SHACL.IRI or SHACL.Literal
     expected_value_type: URIRef
-    min_count: Optional[int]
-    max_count: Optional[int]
+    min_count: int | None
+    max_count: int | None
     namespace: Namespace
 
     @property

--- a/cognite/neat/rules/exporter/rules2pydantic_models.py
+++ b/cognite/neat/rules/exporter/rules2pydantic_models.py
@@ -3,12 +3,12 @@ import warnings
 from datetime import UTC, datetime
 from typing import Any
 
+from cognite.client.data_classes import Asset, Relationship
 from pydantic import BaseModel, ConfigDict, Field, create_model
 from pydantic._internal._model_construction import ModelMetaclass
 from rdflib import Graph, URIRef
 from typing_extensions import TypeAliasType
 
-from cognite.client.data_classes import Asset, Relationship
 from cognite.neat.graph.loaders.core.rdf_to_assets import NeatMetadataKeys
 from cognite.neat.graph.transformations.query_generator.sparql import build_construct_query, triples2dictionary
 from cognite.neat.rules import exceptions

--- a/cognite/neat/rules/exporter/rules2pydantic_models.py
+++ b/cognite/neat/rules/exporter/rules2pydantic_models.py
@@ -1,22 +1,23 @@
-from datetime import datetime, timezone
 import re
-from typing import Any
-from typing_extensions import TypeAliasType
 import warnings
+from datetime import UTC, datetime
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field, create_model
 from pydantic._internal._model_construction import ModelMetaclass
 from rdflib import Graph, URIRef
+from typing_extensions import TypeAliasType
 
 from cognite.client.data_classes import Asset, Relationship
 from cognite.neat.graph.loaders.core.rdf_to_assets import NeatMetadataKeys
+from cognite.neat.graph.transformations.query_generator.sparql import build_construct_query, triples2dictionary
+from cognite.neat.rules import exceptions
 from cognite.neat.rules.analysis import (
-    to_class_property_pairs,
     define_class_asset_mapping,
     define_class_relationship_mapping,
+    to_class_property_pairs,
 )
-from cognite.neat.graph.transformations.query_generator.sparql import build_construct_query, triples2dictionary
 from cognite.neat.rules.models import Property, TransformationRules, type_to_target_convention
-from cognite.neat.rules import exceptions
 
 EdgeOneToOne = TypeAliasType("EdgeOneToOne", str)
 EdgeOneToMany = TypeAliasType("EdgeOneToMany", list[str])
@@ -33,7 +34,7 @@ def default_model_methods():
 
 
 def rules_to_pydantic_models(
-    transformation_rules: TransformationRules, methods: list = None
+    transformation_rules: TransformationRules, methods: list | None = None
 ) -> dict[str, ModelMetaclass]:
     """Generate pydantic models from transformation rules.
 
@@ -152,8 +153,8 @@ def _dictionary_to_pydantic_model(
     name: str,
     model_definition: dict,
     model_configuration: ConfigDict = None,
-    methods: list = None,
-    validators: list = None,
+    methods: list | None = None,
+    validators: list | None = None,
 ) -> type[BaseModel]:
     """Generates pydantic model from dictionary containing definition of fields.
     Additionally it adds methods to the model and validators.
@@ -263,7 +264,7 @@ def to_asset(
     add_system_metadata: bool = True,
     metadata_keys: NeatMetadataKeys | None = None,
     add_labels: bool = True,
-    data_set_id: int = None,
+    data_set_id: int | None = None,
 ) -> Asset:
     """Convert model instance to asset.
 
@@ -309,7 +310,7 @@ def to_asset(
 def _add_system_metadata(self, metadata_keys: NeatMetadataKeys, asset: dict):
     asset["metadata"][metadata_keys.type] = self.__class__.__name__
     asset["metadata"][metadata_keys.identifier] = self.external_id
-    now = str(datetime.now(timezone.utc))
+    now = str(datetime.now(UTC))
     asset["metadata"][metadata_keys.start_time] = now
     asset["metadata"][metadata_keys.update_time] = now
     asset["metadata"][metadata_keys.active] = "true"

--- a/cognite/neat/rules/importer/ontology2excel.py
+++ b/cognite/neat/rules/importer/ontology2excel.py
@@ -10,8 +10,7 @@ import numpy as np
 import pandas as pd
 from rdflib import DC, DCTERMS, OWL, RDF, RDFS, Graph
 
-from cognite.neat.rules import parse_rules_from_excel_file
-from cognite.neat.rules import exceptions
+from cognite.neat.rules import exceptions, parse_rules_from_excel_file
 from cognite.neat.utils.utils import generate_exception_report, get_namespace, remove_namespace
 
 
@@ -95,7 +94,7 @@ def _create_default_properties_parsing_config() -> dict[str, tuple[str, ...]]:
     }
 
 
-def owl2excel(owl_filepath: Path, excel_filepath: Path = None, validate_results: bool = True):
+def owl2excel(owl_filepath: Path, excel_filepath: Path | None = None, validate_results: bool = True):
     """Convert owl ontology to transformation rules serialized as Excel file.
 
     Parameters
@@ -136,7 +135,7 @@ def owl2excel(owl_filepath: Path, excel_filepath: Path = None, validate_results:
         _validate_excel_file(excel_filepath)
 
 
-def _parse_owl_metadata_df(graph: Graph, parsing_config: dict = None) -> pd.DataFrame:
+def _parse_owl_metadata_df(graph: Graph, parsing_config: dict | None = None) -> pd.DataFrame:
     """Parse owl metadata from graph to pandas dataframe.
 
     Parameters
@@ -201,7 +200,7 @@ def _parse_owl_metadata_df(graph: Graph, parsing_config: dict = None) -> pd.Data
     return pd.DataFrame(clean_list, columns=parsing_config["header"]).T
 
 
-def _parse_owl_classes_df(graph: Graph, parsing_config: dict = None) -> pd.DataFrame:
+def _parse_owl_classes_df(graph: Graph, parsing_config: dict | None = None) -> pd.DataFrame:
     """Get all classes from the graph and their parent classes.
 
     Parameters
@@ -265,10 +264,10 @@ SELECT ?class ?name ?description ?parentClass ?deprecated ?deprecationDate
         ]
         for class_, group_df in grouped_df
     ]
-    return pd.DataFrame([parsing_config["helper_row"], parsing_config["header"]] + clean_list)
+    return pd.DataFrame([parsing_config["helper_row"], parsing_config["header"], *clean_list])
 
 
-def _parse_owl_properties_df(graph: Graph, parsing_config: dict = None) -> pd.DataFrame:
+def _parse_owl_properties_df(graph: Graph, parsing_config: dict | None = None) -> pd.DataFrame:
     """Get all properties from the OWL ontology
 
     Parameters
@@ -342,7 +341,7 @@ def _parse_owl_properties_df(graph: Graph, parsing_config: dict = None) -> pd.Da
                 ]
             ]
 
-    return pd.DataFrame([parsing_config["helper_row"], parsing_config["header"]] + clean_list)
+    return pd.DataFrame([parsing_config["helper_row"], parsing_config["header"], *clean_list])
 
 
 def _validate_excel_file(excel_filepath: Path):
@@ -366,5 +365,5 @@ def _validate_excel_file(excel_filepath: Path):
         report += generate_exception_report(validation_warnings, "Warnings")
 
     if report:
-        with open(excel_filepath.parent / "report.txt", "w") as f:
+        with (excel_filepath.parent / "report.txt").open("w") as f:
             f.write(report)

--- a/cognite/neat/rules/models.py
+++ b/cognite/neat/rules/models.py
@@ -7,6 +7,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, ClassVar
 
+from cognite.client.data_classes.data_modeling.data_types import (
+    Boolean,
+    FileReference,
+    Float32,
+    Int32,
+    Int64,
+    Json,
+    SequenceReference,
+    Text,
+    TimeSeriesReference,
+    Timestamp,
+)
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -22,18 +34,6 @@ from pydantic import (
 from pydantic.fields import FieldInfo
 from rdflib import XSD, Literal, Namespace, URIRef
 
-from cognite.client.data_classes.data_modeling.data_types import (
-    Boolean,
-    FileReference,
-    Float32,
-    Int32,
-    Int64,
-    Json,
-    SequenceReference,
-    Text,
-    TimeSeriesReference,
-    Timestamp,
-)
 from cognite.neat.constants import PREFIXES
 from cognite.neat.rules import exceptions
 from cognite.neat.rules.to_rdf_path import (

--- a/cognite/neat/rules/to_rdf_path.py
+++ b/cognite/neat/rules/to_rdf_path.py
@@ -4,7 +4,7 @@ import re
 from collections import Counter
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Literal, Optional, Self
+from typing import Literal, Self
 
 from pydantic import BaseModel, field_validator
 
@@ -119,7 +119,7 @@ _direction_by_symbol = {"->": "target", "<-": "source"}
 
 class Step(BaseModel):
     class_: Entity
-    property: Optional[Entity] = None  # only terminal step has property
+    property: Entity | None = None  # only terminal step has property
     direction: StepDirection
 
     @classmethod

--- a/cognite/neat/utils/utils.py
+++ b/cognite/neat/utils/utils.py
@@ -7,12 +7,12 @@ from functools import wraps
 from typing import TypeAlias
 
 import pandas as pd
-from rdflib import Literal
-from rdflib.term import URIRef
-
 from cognite.client import ClientConfig, CogniteClient
 from cognite.client.credentials import CredentialProvider, OAuthClientCredentials, OAuthInteractive
 from cognite.client.exceptions import CogniteDuplicatedError, CogniteReadTimeout
+from rdflib import Literal
+from rdflib.term import URIRef
+
 from cognite.neat.graph.stores import NeatGraphStore
 from cognite.neat.utils.cdf import CogniteClientConfig, InteractiveCogniteClient, ServiceCogniteClient
 

--- a/cognite/neat/utils/utils.py
+++ b/cognite/neat/utils/utils.py
@@ -2,18 +2,19 @@ import hashlib
 import logging
 import time
 from collections import OrderedDict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from functools import wraps
-from typing_extensions import TypeAlias
+from typing import TypeAlias
+
 import pandas as pd
-from cognite.client import ClientConfig, CogniteClient
-from cognite.client.credentials import CredentialProvider, OAuthClientCredentials, OAuthInteractive
-from cognite.client.exceptions import CogniteDuplicatedError, CogniteReadTimeout
 from rdflib import Literal
 from rdflib.term import URIRef
 
+from cognite.client import ClientConfig, CogniteClient
+from cognite.client.credentials import CredentialProvider, OAuthClientCredentials, OAuthInteractive
+from cognite.client.exceptions import CogniteDuplicatedError, CogniteReadTimeout
 from cognite.neat.graph.stores import NeatGraphStore
-from cognite.neat.utils.cdf import InteractiveCogniteClient, ServiceCogniteClient, CogniteClientConfig
+from cognite.neat.utils.cdf import CogniteClientConfig, InteractiveCogniteClient, ServiceCogniteClient
 
 Triple: TypeAlias = tuple[URIRef, URIRef, Literal | URIRef]
 
@@ -171,7 +172,7 @@ def prettify_generation_order(generation_order: dict, depth: dict | None = None,
 
 
 def epoch_now_ms():
-    return int((datetime.now(timezone.utc) - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds() * 1000)
+    return int((datetime.now(UTC) - datetime(1970, 1, 1, tzinfo=UTC)).total_seconds() * 1000)
 
 
 def chunker(sequence, chunk_size):
@@ -179,7 +180,7 @@ def chunker(sequence, chunk_size):
 
 
 def datetime_utc_now():
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def retry_decorator(max_retries=2, retry_delay=3, component_name=""):

--- a/cognite/neat/workflows/__init__.py
+++ b/cognite/neat/workflows/__init__.py
@@ -1,6 +1,7 @@
 from cognite.neat.workflows.base import BaseWorkflow
-from .model import WorkflowStepDefinition, FlowMessage, WorkflowStepEvent, WorkflowFullStateReport
+
 from .manager import WorkflowManager
+from .model import FlowMessage, WorkflowFullStateReport, WorkflowStepDefinition, WorkflowStepEvent
 
 __all__ = [
     "BaseWorkflow",

--- a/cognite/neat/workflows/base.py
+++ b/cognite/neat/workflows/base.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from threading import Event
 
 import yaml
+from cognite.client import CogniteClient
 from prometheus_client import Gauge
 
-from cognite.client import CogniteClient
 from cognite.neat.app.api.configuration import Config
 from cognite.neat.app.monitoring.metrics import NeatMetricsCollector
 from cognite.neat.utils.cdf import CogniteClientConfig

--- a/cognite/neat/workflows/base.py
+++ b/cognite/neat/workflows/base.py
@@ -1,17 +1,21 @@
 import json
 import logging
-from pathlib import Path
 import threading
 import time
 import traceback
+from pathlib import Path
 from threading import Event
 
 import yaml
-from cognite.client import CogniteClient
 from prometheus_client import Gauge
 
+from cognite.client import CogniteClient
+from cognite.neat.app.api.configuration import Config
 from cognite.neat.app.monitoring.metrics import NeatMetricsCollector
+from cognite.neat.utils.cdf import CogniteClientConfig
 from cognite.neat.utils.utils import retry_decorator
+from cognite.neat.workflows import cdf_store, utils
+from cognite.neat.workflows._exceptions import InvalidStepOutputException
 from cognite.neat.workflows.model import (
     FlowMessage,
     StepExecutionStatus,
@@ -26,14 +30,9 @@ from cognite.neat.workflows.model import (
     WorkflowStepEvent,
     WorkflowSystemComponent,
 )
+from cognite.neat.workflows.steps.step_model import DataContract
 from cognite.neat.workflows.steps_registry import StepsRegistry
 from cognite.neat.workflows.tasks import WorkflowTaskBuilder
-
-from cognite.neat.app.api.configuration import Config
-from cognite.neat.utils.cdf import CogniteClientConfig
-from cognite.neat.workflows import utils, cdf_store
-from cognite.neat.workflows.steps.step_model import DataContract
-from cognite.neat.workflows._exceptions import InvalidStepOutputException
 
 summary_metrics = Gauge("neat_workflow_summary_metrics", "Workflow execution summary metrics", ["wf_name", "name"])
 steps_metrics = Gauge("neat_workflow_steps_metrics", "Workflow step level metrics", ["wf_name", "step_name", "name"])
@@ -46,8 +45,8 @@ class BaseWorkflow:
         name: str,
         client: CogniteClient,
         steps_registry: StepsRegistry = None,
-        workflow_steps: list[WorkflowStepDefinition] = None,
-        default_dataset_id: int = None,
+        workflow_steps: list[WorkflowStepDefinition] | None = None,
+        default_dataset_id: int | None = None,
     ):
         self.name = name
         self.module_name = self.__class__.__module__
@@ -139,7 +138,7 @@ class BaseWorkflow:
     def get_transition_step(self, transitions: list[str]) -> list[str]:
         return [stp for stp in self.workflow_steps if stp.id in transitions and stp.enabled] if transitions else []
 
-    def run_workflow_steps(self, start_step_id: str = None) -> str:
+    def run_workflow_steps(self, start_step_id: str | None = None) -> str:
         if not start_step_id:
             trigger_steps = list(filter(lambda x: x.trigger, self.workflow_steps))
         else:
@@ -316,7 +315,6 @@ class BaseWorkflow:
                 self.state = WorkflowState.RUNNING_WAITING
                 timeout = float(step.params.get("wait_timeout", "60"))
                 # reporting workflow execution before waiting for event
-                # self.report_workflow_execution()
                 logging.info(f"Workflow {self.name} is waiting for event")
                 self.resume_event.wait(timeout=timeout)
                 logging.info(f"Workflow {self.name} resumed after event")
@@ -363,7 +361,7 @@ class BaseWorkflow:
         self.report_step_execution()
         return new_flow_message
 
-    def resume_workflow(self, flow_message: FlowMessage, step_id: str = None):
+    def resume_workflow(self, flow_message: FlowMessage, step_id: str | None = None):
         if step_id:
             if self.current_step != step_id:
                 logging.error(f"Workflow {self.name} is not in step {step_id} , resume is skipped")
@@ -432,7 +430,7 @@ class BaseWorkflow:
     def add_system_component(self, system_components: WorkflowSystemComponent):
         self.workflow_system_components.append(system_components)
 
-    def serialize_workflow(self, output_format: str = "json", custom_implementation_module: str = None) -> str:
+    def serialize_workflow(self, output_format: str = "json", custom_implementation_module: str | None = None) -> str:
         workflow_definitions = WorkflowDefinition(
             name=self.name,
             steps=self.workflow_steps,
@@ -509,7 +507,7 @@ class BaseWorkflow:
     def get_step_by_id(self, step_id: str) -> WorkflowStepDefinition:
         return next((step for step in self.workflow_steps if step.id == step_id), None)
 
-    def get_trigger_step(self, step_id: str = None) -> WorkflowStepDefinition:
+    def get_trigger_step(self, step_id: str | None = None) -> WorkflowStepDefinition:
         if step_id:
             return next((step for step in self.workflow_steps if step.id == step_id and step.enabled), None)
         else:

--- a/cognite/neat/workflows/cdf_store.py
+++ b/cognite/neat/workflows/cdf_store.py
@@ -6,11 +6,11 @@ import time
 import zipfile
 from pathlib import Path
 
+from cognite.client import CogniteClient
+from cognite.client.data_classes import Event, FileMetadataUpdate, LabelDefinition, LabelFilter
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 
-from cognite.client import CogniteClient
-from cognite.client.data_classes import Event, FileMetadataUpdate, LabelDefinition, LabelFilter
 from cognite.neat.workflows.model import WorkflowFullStateReport, WorkflowState, WorkflowStepEvent
 from cognite.neat.workflows.utils import get_file_hash
 

--- a/cognite/neat/workflows/cdf_store.py
+++ b/cognite/neat/workflows/cdf_store.py
@@ -5,13 +5,12 @@ import shutil
 import time
 import zipfile
 from pathlib import Path
-from typing import Dict
 
-from cognite.client import CogniteClient
-from cognite.client.data_classes import Event, FileMetadataUpdate, LabelDefinition, LabelFilter
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 
+from cognite.client import CogniteClient
+from cognite.client.data_classes import Event, FileMetadataUpdate, LabelDefinition, LabelFilter
 from cognite.neat.workflows.model import WorkflowFullStateReport, WorkflowState, WorkflowStepEvent
 from cognite.neat.workflows.utils import get_file_hash
 
@@ -34,14 +33,13 @@ class CdfStore:
         self,
         client: CogniteClient,
         data_set_id: int,
-        workflows_storage_path: Path = None,
-        rules_storage_path: Path = None,
+        workflows_storage_path: Path | None = None,
+        rules_storage_path: Path | None = None,
     ):
         self.client = client
         self.data_set_id = data_set_id
-        # todo use pathlib
-        self.workflows_storage_path = str(workflows_storage_path)
-        self.rules_storage_path = str(rules_storage_path)
+        self.workflows_storage_path = workflows_storage_path
+        self.rules_storage_path = rules_storage_path
         self.workflows_storage_type = "file"
 
     def init_cdf_resources(self, resource_type="all"):
@@ -66,10 +64,10 @@ class CdfStore:
 
     def package_workflow(self, workflow_name):
         """Creates a zip archive from a folder"""
-        folder_path = os.path.join(self.workflows_storage_path, workflow_name)
-        archive_path = os.path.join(self.workflows_storage_path, f"{workflow_name}.zip")
+        folder_path = self.workflows_storage_path / workflow_name
+        archive_path = self.workflows_storage_path / f"{workflow_name}.zip"
         # Make sure the folder exists
-        if not os.path.isdir(folder_path):
+        if not folder_path.is_dir():
             logging.error(f"Error: {folder_path} is not a directory")
             raise Exception(f"Can't package workflow.Error: {folder_path} is not a directory")
 
@@ -78,7 +76,7 @@ class CdfStore:
             # Walk through the directory and add each json file to the archive
             for root, _, files in os.walk(folder_path):
                 for file in files:
-                    file_path = os.path.join(root, file)
+                    file_path = Path(root) / Path(file)
                     # Check if the file has a .json extension
                     if (
                         file.endswith(".yaml")
@@ -96,7 +94,7 @@ class CdfStore:
         workflow_name = workflow_name.replace(".zip", "")
         package_full_path = Path(self.workflows_storage_path).joinpath(f"{workflow_name}.zip")
         output_folder = Path(self.workflows_storage_path).joinpath(workflow_name)
-        if not os.path.isfile(package_full_path):
+        if not package_full_path.is_file():
             print(f"Error: {package_full_path} is not a file")
             raise Exception(f"Can't extract workflow package. Error: {package_full_path} is not a file")
 
@@ -104,13 +102,13 @@ class CdfStore:
         if output_folder.exists():
             shutil.rmtree(output_folder)
         # Create the output folder if it does not exist
-        os.makedirs(output_folder, exist_ok=True)
+        output_folder.mkdir(parents=True, exist_ok=True)
 
         # Extract the contents of the archive to the output folder
         with zipfile.ZipFile(package_full_path, "r") as zipf:
             zipf.extractall(output_folder)
 
-    def load_workflows_from_cfg_by_filter(self, config_filter: list[str] = None) -> str:
+    def load_workflows_from_cfg_by_filter(self, config_filter: list[str] | None = None) -> str:
         """Load workflow package from CDF and extract it to the storage path"""
         # filter syntax: name:workflow_name=version; tag:tag_name
         try:
@@ -136,7 +134,10 @@ class CdfStore:
             logging.error(f"Failed to load workflows by filter. Error: {e}")
 
     def load_workflows_from_cdf(
-        self, workflow_name: str = None, version: str = None, metadata_filter: Dict[str, str] = None
+        self,
+        workflow_name: str | None = None,
+        version: str | None = None,
+        metadata_filter: dict[str, str] | None = None,
     ) -> list[str]:
         """Load workflow package or multiple workfllows from CDF and extract it to the storage path"""
         # TODO: Add workflow and tag filters
@@ -177,7 +178,7 @@ class CdfStore:
             zip_file = Path(self.workflows_storage_path) / f"{name}.zip"
             if zip_file.exists():
                 self.save_resource_to_cdf(name, "workflow-package", zip_file, tag, changed_by, comments)
-                os.remove(zip_file)
+                zip_file.unlink()
                 logging.info(f"Workflow package {name} uploaded to CDF")
             else:
                 logging.error(f"Workflow package {name} not found, skipping")
@@ -195,7 +196,7 @@ class CdfStore:
     ) -> None:
         """Saves resources to cdf. For instance workflow package, rules file, etc"""
         if self.data_set_id and self.client:
-            if not os.path.exists(file_path):
+            if not file_path.exists():
                 logging.error(f"File {file_path} not found, skipping")
                 return
             # removing the latest tag from all files related to this workflow
@@ -231,7 +232,7 @@ class CdfStore:
         else:
             logging.error("No CDF client or data set id provided")
 
-    def load_rules_file_from_cdf(self, name: str, version: str = None):
+    def load_rules_file_from_cdf(self, name: str, version: str | None = None):
         logging.info(f"Loading rules file {name} (version = {version} ) from CDF ")
         # TODO: Download latest if version is not specified
         files_metadata = self.client.files.list(name=name, metadata={"hash": version})
@@ -333,11 +334,9 @@ class CdfStore:
             "workflow_name": report.workflow_name,
         }
         external_id = f"neat-wf-run-{report.run_id}"
-        # serialized_execution_log = json.dumps([step.dict() for step in report.execution_log])
         serialized_execution_log = json.dumps(jsonable_encoder(report.execution_log))
         execution_log_size = bytes(serialized_execution_log, "utf-8").__sizeof__()
         logging.debug(f"Serialized execution log size: {execution_log_size}")
-        # logging.debug(f"Serialized execution log: {serialized_execution_log}")
 
         if report.start_time:
             report.start_time = report.start_time * 1000

--- a/cognite/neat/workflows/inheritance_based/graph2assets_relationships.py
+++ b/cognite/neat/workflows/inheritance_based/graph2assets_relationships.py
@@ -8,13 +8,6 @@ from prometheus_client import Gauge
 from cognite.client import CogniteClient
 from cognite.client.data_classes import AssetFilter
 from cognite.neat.constants import PREFIXES
-
-from cognite.neat.rules.models import TransformationRules
-from cognite.neat.rules.parser import parse_rules_from_excel_file
-from cognite.neat.rules.exporter.rules2triples import get_instances_as_triples
-
-from cognite.neat.graph.stores import NeatGraphStore, drop_graph_store
-from cognite.neat.graph.transformations.transformer import RuleProcessingReport, domain2app_knowledge_graph
 from cognite.neat.graph.loaders.core.labels import upload_labels
 from cognite.neat.graph.loaders.core.rdf_to_assets import categorize_assets, rdf2assets, upload_assets
 from cognite.neat.graph.loaders.core.rdf_to_relationships import (
@@ -23,12 +16,15 @@ from cognite.neat.graph.loaders.core.rdf_to_relationships import (
     upload_relationships,
 )
 from cognite.neat.graph.loaders.validator import validate_asset_hierarchy
-
+from cognite.neat.graph.stores import NeatGraphStore, drop_graph_store
+from cognite.neat.graph.transformations.transformer import RuleProcessingReport, domain2app_knowledge_graph
+from cognite.neat.rules.exporter.rules2triples import get_instances_as_triples
+from cognite.neat.rules.models import TransformationRules
+from cognite.neat.rules.parser import parse_rules_from_excel_file
 from cognite.neat.workflows import utils
-from cognite.neat.workflows.model import FlowMessage
 from cognite.neat.workflows.base import BaseWorkflow
 from cognite.neat.workflows.cdf_store import CdfStore
-
+from cognite.neat.workflows.model import FlowMessage
 
 with contextlib.suppress(ValueError):
     prom_cdf_resource_stats = Gauge(
@@ -68,7 +64,7 @@ class GraphsAndRulesBaseWorkflow(BaseWorkflow):
 
         self.transformation_rules = parse_rules_from_excel_file(rules_file_path)
         self.dataset_id = self.transformation_rules.metadata.data_set_id
-        logging.info(f"Loaded prefixes {str(self.transformation_rules.prefixes)} rules from {rules_file_path.name!r}.")
+        logging.info(f"Loaded prefixes {self.transformation_rules.prefixes!s} rules from {rules_file_path.name!r}.")
         output_text = f"Loaded {len(self.transformation_rules.properties)} rules"
         logging.info(output_text)
         return FlowMessage(output_text=output_text)
@@ -227,7 +223,7 @@ class Graph2AssetHierarchyBaseWorkflow(GraphsAndRulesBaseWorkflow):
             logging.info("No orphaned assets found, your assets look healthy !")
 
         if circular_assets:
-            msg = f"Found circular dependencies: {str(circular_assets)}"
+            msg = f"Found circular dependencies: {circular_assets!s}"
             logging.error(msg)
             raise Exception(msg)
         elif orphan_assets:

--- a/cognite/neat/workflows/inheritance_based/graph2assets_relationships.py
+++ b/cognite/neat/workflows/inheritance_based/graph2assets_relationships.py
@@ -3,10 +3,10 @@ import logging
 import time
 from pathlib import Path
 
-from prometheus_client import Gauge
-
 from cognite.client import CogniteClient
 from cognite.client.data_classes import AssetFilter
+from prometheus_client import Gauge
+
 from cognite.neat.constants import PREFIXES
 from cognite.neat.graph.loaders.core.labels import upload_labels
 from cognite.neat.graph.loaders.core.rdf_to_assets import categorize_assets, rdf2assets, upload_assets

--- a/cognite/neat/workflows/inheritance_based/remove_graphs_and_rules.py
+++ b/cognite/neat/workflows/inheritance_based/remove_graphs_and_rules.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 
 from cognite.client import CogniteClient
+
 from cognite.neat import rules
 from cognite.neat.constants import PREFIXES
 from cognite.neat.graph import extractors

--- a/cognite/neat/workflows/inheritance_based/remove_graphs_and_rules.py
+++ b/cognite/neat/workflows/inheritance_based/remove_graphs_and_rules.py
@@ -2,18 +2,17 @@ import logging
 from pathlib import Path
 
 from cognite.client import CogniteClient
-
 from cognite.neat import rules
-from cognite.neat.graph import extractors
 from cognite.neat.constants import PREFIXES
+from cognite.neat.graph import extractors
 from cognite.neat.graph.stores import NeatGraphStore, drop_graph_store
+from cognite.neat.graph.transformations.transformer import RuleProcessingReport, domain2app_knowledge_graph
 from cognite.neat.rules.exporter.rules2triples import get_instances_as_triples
 from cognite.neat.rules.models import TransformationRules
-from cognite.neat.graph.transformations.transformer import RuleProcessingReport, domain2app_knowledge_graph
 from cognite.neat.workflows import utils
 from cognite.neat.workflows.base import BaseWorkflow
-from cognite.neat.workflows.model import FlowMessage
 from cognite.neat.workflows.cdf_store import CdfStore
+from cognite.neat.workflows.model import FlowMessage
 
 
 class GraphsAndRulesBaseWorkflow(BaseWorkflow):
@@ -44,7 +43,7 @@ class GraphsAndRulesBaseWorkflow(BaseWorkflow):
 
         self.transformation_rules = rules.parse_rules_from_excel_file(rules_file_path)
         self.dataset_id = self.transformation_rules.metadata.data_set_id
-        logging.info(f"Loaded prefixes {str(self.transformation_rules.prefixes)} rules from {rules_file_path.name!r}.")
+        logging.info(f"Loaded prefixes {self.transformation_rules.prefixes!s} rules from {rules_file_path.name!r}.")
         output_text = f"Loaded {len(self.transformation_rules.properties)} rules"
         logging.info(output_text)
         return FlowMessage(output_text=output_text)

--- a/cognite/neat/workflows/inheritance_based/sheet2cdf.py
+++ b/cognite/neat/workflows/inheritance_based/sheet2cdf.py
@@ -3,10 +3,10 @@ import logging
 import time
 from pathlib import Path
 
-from prometheus_client import Gauge
-
 from cognite.client import CogniteClient
 from cognite.client.data_classes import AssetFilter
+from prometheus_client import Gauge
+
 from cognite.neat import rules
 from cognite.neat.graph import extractors
 from cognite.neat.graph.loaders.core.labels import upload_labels

--- a/cognite/neat/workflows/inheritance_based/sheet2cdf.py
+++ b/cognite/neat/workflows/inheritance_based/sheet2cdf.py
@@ -3,10 +3,10 @@ import logging
 import time
 from pathlib import Path
 
-from cognite.client import CogniteClient
-from cognite.client.data_classes import AssetFilter
 from prometheus_client import Gauge
 
+from cognite.client import CogniteClient
+from cognite.client.data_classes import AssetFilter
 from cognite.neat import rules
 from cognite.neat.graph import extractors
 from cognite.neat.graph.loaders.core.labels import upload_labels
@@ -23,14 +23,14 @@ from cognite.neat.graph.loaders.core.rdf_to_relationships import (
     rdf2relationships,
     upload_relationships,
 )
+from cognite.neat.graph.loaders.validator import validate_asset_hierarchy
 from cognite.neat.graph.stores import NeatGraphStore
 from cognite.neat.rules.exporter.rules2triples import get_instances_as_triples
 from cognite.neat.rules.models import TransformationRules
-from cognite.neat.graph.loaders.validator import validate_asset_hierarchy
 from cognite.neat.workflows import utils
 from cognite.neat.workflows.base import BaseWorkflow
-from cognite.neat.workflows.model import FlowMessage
 from cognite.neat.workflows.cdf_store import CdfStore
+from cognite.neat.workflows.model import FlowMessage
 
 with contextlib.suppress(ValueError):
     prom_cdf_resource_stats = Gauge(
@@ -80,7 +80,7 @@ class Sheet2CDFBaseWorkflow(BaseWorkflow):
 
         output_text = f"Loaded {len(self.transformation_rules.properties)} rules from {rules_file_path.name!r}."
         logging.info(output_text)
-        logging.info(f"Loaded prefixes {str(self.transformation_rules.prefixes)} rules")
+        logging.info(f"Loaded prefixes {self.transformation_rules.prefixes!s} rules")
 
         self.dataset_id = self.transformation_rules.metadata.data_set_id
         return FlowMessage(output_text=output_text)
@@ -107,7 +107,6 @@ class Sheet2CDFBaseWorkflow(BaseWorkflow):
 
         output_text = f"Loaded {len(self.instance_ids)} instances out of"
         # Todo: This is no longer exposed in the rules package. Need to extend the load methods to return a rapport.
-        # output_text += f" {len(self.raw_tables['Instances'])} rows in Instances sheet"
 
         logging.info(output_text)
         return FlowMessage(output_text=output_text)

--- a/cognite/neat/workflows/inheritance_based/sme_graph_capture.py
+++ b/cognite/neat/workflows/inheritance_based/sme_graph_capture.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import AssetFilter
-
 from cognite.neat import rules
 from cognite.neat.graph import extractors
 from cognite.neat.graph.loaders.core.labels import upload_labels
@@ -14,15 +13,15 @@ from cognite.neat.graph.loaders.core.rdf_to_relationships import (
     rdf2relationships,
     upload_relationships,
 )
+from cognite.neat.graph.loaders.validator import validate_asset_hierarchy
 from cognite.neat.graph.stores import NeatGraphStore
+from cognite.neat.rules.exporter import rules2graph_sheet
 from cognite.neat.rules.models import TransformationRules
 from cognite.neat.utils.utils import add_triples
-from cognite.neat.graph.loaders.validator import validate_asset_hierarchy
 from cognite.neat.workflows import utils
 from cognite.neat.workflows.base import BaseWorkflow
-from cognite.neat.workflows.model import FlowMessage
 from cognite.neat.workflows.cdf_store import CdfStore
-from cognite.neat.rules.exporter import rules2graph_sheet
+from cognite.neat.workflows.model import FlowMessage
 
 
 class SmeGraphCaptureBaseWorkflow(BaseWorkflow):
@@ -67,7 +66,7 @@ class SmeGraphCaptureBaseWorkflow(BaseWorkflow):
 
         self.transformation_rules = rules.parse_rules_from_excel_file(rules_file_path)
         self.dataset_id = self.transformation_rules.metadata.data_set_id
-        logging.info(f"Loaded prefixes {str(self.transformation_rules.prefixes)} rules")
+        logging.info(f"Loaded prefixes {self.transformation_rules.prefixes!s} rules")
         output_text = f"Loaded {len(self.transformation_rules.properties)} rules"
         logging.info(output_text)
         return FlowMessage(output_text=output_text)

--- a/cognite/neat/workflows/inheritance_based/sme_graph_capture.py
+++ b/cognite/neat/workflows/inheritance_based/sme_graph_capture.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import AssetFilter
+
 from cognite.neat import rules
 from cognite.neat.graph import extractors
 from cognite.neat.graph.loaders.core.labels import upload_labels

--- a/cognite/neat/workflows/manager.py
+++ b/cognite/neat/workflows/manager.py
@@ -8,10 +8,10 @@ import time
 import traceback
 from pathlib import Path
 
+from cognite.client import CogniteClient
 from prometheus_client import Gauge
 from pydantic import BaseModel
 
-from cognite.client import CogniteClient
 from cognite.neat.workflows import BaseWorkflow
 from cognite.neat.workflows.base import WorkflowDefinition
 from cognite.neat.workflows.model import FlowMessage, InstanceStartMethod, WorkflowState

--- a/cognite/neat/workflows/migration/wf_manifests.py
+++ b/cognite/neat/workflows/migration/wf_manifests.py
@@ -17,14 +17,14 @@ def migrate_wf_manifest(wf_store_path: Path):
             metadata_file_migrated = wf_store_path / wf_module_name / "workflow.yaml"
             logging.info(f"Loading workflow {wf_module_name} metadata from {metadata_file}")
             if metadata_file.exists():
-                with open(metadata_file, "r") as f:
+                with metadata_file.open() as f:
                     manifest_yaml = yaml.safe_load(f, Loader=yaml.Loader)
                     logging.info(f"Loaded workflow {wf_module_name} metadata from {metadata_file}")
                 if "groups" in manifest_yaml:
                     logging.info(f"Found groups in {metadata_file}, migrating to system_components")
                     manifest_yaml["system_components"] = manifest_yaml["groups"]
                     del manifest_yaml["groups"]
-                    with open(metadata_file_migrated, "w") as f:
+                    with metadata_file_migrated.open("w") as f:
                         yaml.dump(manifest_yaml, f, indent=4)
                         migrated_files.append(metadata_file_migrated)
             else:

--- a/cognite/neat/workflows/model.py
+++ b/cognite/neat/workflows/model.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, field_validator
 
@@ -35,12 +35,12 @@ class FlowMessage(BaseModel):
     """A message that can be sent between steps in a workflow.It's the only parameter step takes as input."""
 
     payload: Any = None  # The payload of the message
-    headers: Optional[dict[str, str]] = None  # The headers of the message
-    output_text: Optional[str] = None  # The output text of the step that is captured in the execution log
-    error_text: Optional[str] = None  # The error text of the step that is captured in the execution log
-    next_step_ids: Optional[
-        list[str]
-    ] = None  # If set, the workflow will skip default route and go to the next step in the list
+    headers: dict[str, str] | None = None  # The headers of the message
+    output_text: str | None = None  # The output text of the step that is captured in the execution log
+    error_text: str | None = None  # The error text of the step that is captured in the execution log
+    next_step_ids: list[
+        str
+    ] | None = None  # If set, the workflow will skip default route and go to the next step in the list
     step_execution_status: StepExecutionStatus = StepExecutionStatus.UNKNOWN  # The status of the step execution
 
 
@@ -63,26 +63,26 @@ class UIConfig(BaseModel):
 
 class WorkflowConfigItem(BaseModel):
     name: str
-    value: Optional[str] = None
-    label: Optional[str] = None
-    type: Optional[str] = None
+    value: str | None = None
+    label: str | None = None
+    type: str | None = None
     required: bool = False
-    options: Optional[list[str]] = None
-    group: Optional[str] = None
+    options: list[str] | None = None
+    group: str | None = None
 
 
 class WorkflowStepDefinition(BaseModel):
     id: str
-    label: Optional[str] = None
+    label: str | None = None
     stype: str = StepType.PYSTEP
-    description: Optional[str] = None
-    method: Optional[str] = None
+    description: str | None = None
+    method: str | None = None
     enabled: bool = True
-    system_component_id: Optional[str] = None
+    system_component_id: str | None = None
     trigger: bool = False
-    transition_to: Optional[list[str]] = None
+    transition_to: list[str] | None = None
     ui_config: UIConfig = UIConfig()
-    params: Optional[dict[str, str]] = None
+    params: dict[str, str] | None = None
     max_retries: int = 0
     retry_delay: int = 3
 
@@ -91,8 +91,8 @@ class WorkflowSystemComponent(BaseModel):
     # Container for steps
     id: str
     label: str
-    transition_to: Optional[list[str]] = None
-    description: Optional[str] = None
+    transition_to: list[str] | None = None
+    description: str | None = None
     ui_config: UIConfig = UIConfig()
 
 
@@ -100,11 +100,11 @@ class WorkflowDefinition(BaseModel):
     """Workflow definition"""
 
     name: str
-    description: Optional[str] = None
-    implementation_module: Optional[str] = None
+    description: str | None = None
+    implementation_module: str | None = None
     steps: list[WorkflowStepDefinition] = []
-    system_components: Optional[list[WorkflowSystemComponent]] = None
-    configs: Optional[list[WorkflowConfigItem]] = None
+    system_components: list[WorkflowSystemComponent] | None = None
+    configs: list[WorkflowConfigItem] | None = None
 
     def get_config_item(self, name: str) -> WorkflowConfigItem:
         for config in self.configs:
@@ -129,26 +129,26 @@ class WorkflowStepEvent(BaseModel):
     """Workflow step event represent a single step execution"""
 
     id: str
-    system_component_id: Optional[str] = None
+    system_component_id: str | None = None
     state: StepExecutionStatus
     elapsed_time: float
     timestamp: str
-    error: Optional[str] = None
-    output_text: Optional[str] = None
+    error: str | None = None
+    output_text: str | None = None
     data: Any = None
 
 
 class WorkflowFullStateReport(BaseModel):
     """Workflow state report is complete log of workflow execution"""
 
-    workflow_name: Optional[str] = None
-    workflow_version: Optional[str] = None
-    run_id: Optional[str] = None
+    workflow_name: str | None = None
+    workflow_version: str | None = None
+    run_id: str | None = None
     state: WorkflowState
-    start_time: Optional[int] = None
-    end_time: Optional[int] = None
+    start_time: int | None = None
+    end_time: int | None = None
     elapsed_time: float = 0
-    last_error: Optional[str] = None
+    last_error: str | None = None
     execution_log: list[WorkflowStepEvent]
 
     @field_validator("start_time", "end_time", mode="before")

--- a/cognite/neat/workflows/steps/data_contracts.py
+++ b/cognite/neat/workflows/steps/data_contracts.py
@@ -1,11 +1,10 @@
 from pathlib import Path
 
 from cognite.client import CogniteClient
-
+from cognite.client.data_classes import Relationship, RelationshipUpdate
 from cognite.neat.graph.stores import NeatGraphStore
 from cognite.neat.rules.models import TransformationRules
 from cognite.neat.workflows.steps.step_model import DataContract
-from cognite.client.data_classes import Relationship, RelationshipUpdate
 
 
 class RulesData(DataContract):

--- a/cognite/neat/workflows/steps/data_contracts.py
+++ b/cognite/neat/workflows/steps/data_contracts.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Relationship, RelationshipUpdate
+
 from cognite.neat.graph.stores import NeatGraphStore
 from cognite.neat.rules.models import TransformationRules
 from cognite.neat.workflows.steps.step_model import DataContract

--- a/cognite/neat/workflows/steps/lib/cdf_resources.py
+++ b/cognite/neat/workflows/steps/lib/cdf_resources.py
@@ -3,6 +3,7 @@ import time
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import AssetFilter
+
 from cognite.neat.graph.loaders import upload_labels
 from cognite.neat.graph.loaders.core.rdf_to_assets import (
     NeatMetadataKeys,

--- a/cognite/neat/workflows/steps/lib/cdf_resources.py
+++ b/cognite/neat/workflows/steps/lib/cdf_resources.py
@@ -1,5 +1,8 @@
 import logging
 import time
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes import AssetFilter
 from cognite.neat.graph.loaders import upload_labels
 from cognite.neat.graph.loaders.core.rdf_to_assets import (
     NeatMetadataKeys,
@@ -16,11 +19,13 @@ from cognite.neat.graph.loaders.core.rdf_to_relationships import (
 )
 from cognite.neat.graph.loaders.validator import validate_asset_hierarchy
 from cognite.neat.workflows.model import FlowMessage
+from cognite.neat.workflows.steps.data_contracts import (
+    CategorizedAssets,
+    CategorizedRelationships,
+    RulesData,
+    SolutionGraph,
+)
 from cognite.neat.workflows.steps.step_model import Step
-from cognite.client.data_classes import AssetFilter
-
-from cognite.client import CogniteClient
-from ..data_contracts import CategorizedAssets, CategorizedRelationships, RulesData, SolutionGraph
 
 __all__ = [
     "CreateCDFLabels",
@@ -122,7 +127,7 @@ class GenerateCDFAssetsFromGraph(Step):
             logging.info("No orphaned assets found, your assets look healthy !")
 
         if circular_assets:
-            msg = f"Found circular dependencies: {str(circular_assets)}"
+            msg = f"Found circular dependencies: {circular_assets!s}"
             logging.error(msg)
             raise Exception(msg)
         elif orphan_assets:

--- a/cognite/neat/workflows/steps/lib/fdm.py
+++ b/cognite/neat/workflows/steps/lib/fdm.py
@@ -1,5 +1,7 @@
-from pathlib import Path
 import time
+from pathlib import Path
+from typing import ClassVar
+
 from cognite.neat.rules.exporter.rules2graphql import GraphQLSchema
 from cognite.neat.workflows.model import FlowMessage, WorkflowConfigItem
 from cognite.neat.workflows.steps.data_contracts import RulesData
@@ -11,7 +13,7 @@ __all__ = ["GenerateGraphQLSchemaFromRules"]
 class GenerateGraphQLSchemaFromRules(Step):
     description = "The step generates GraphQL schema from data model defined in rules"
     category = "fdm"
-    configuration_templates = [
+    configuration_templates: ClassVar[list[WorkflowConfigItem]] = [
         WorkflowConfigItem(
             name="fdm_schema.file",
             value="fdm_model.graphql",

--- a/cognite/neat/workflows/steps/lib/graph_data_capture.py
+++ b/cognite/neat/workflows/steps/lib/graph_data_capture.py
@@ -1,12 +1,14 @@
 import logging
-from pathlib import Path
 import time
-from cognite.neat.workflows.model import FlowMessage, WorkflowConfigItem
+from pathlib import Path
+from typing import ClassVar
+
 from cognite.neat.graph import extractors
-from cognite.neat.workflows.steps.step_model import Step
-from ..data_contracts import RulesData, SolutionGraph
 from cognite.neat.rules.exporter import rules2graph_sheet
 from cognite.neat.utils.utils import add_triples
+from cognite.neat.workflows.model import FlowMessage, WorkflowConfigItem
+from cognite.neat.workflows.steps.data_contracts import RulesData, SolutionGraph
+from cognite.neat.workflows.steps.step_model import Step
 
 __all__ = ["GenerateDataCaptureSpreadsheet", "ProcessDataCaptureSpreadsheetIntoSolutionGraph"]
 
@@ -14,7 +16,7 @@ __all__ = ["GenerateDataCaptureSpreadsheet", "ProcessDataCaptureSpreadsheetIntoS
 class GenerateDataCaptureSpreadsheet(Step):
     description = "The step generates data capture spreadsheet from data model defined in rules"
     category = "data_capture"
-    configuration_templates = [
+    configuration_templates: ClassVar[list[WorkflowConfigItem]] = [
         WorkflowConfigItem(
             name="graph_capture.file",
             value="graph_capture_sheet.xlsx",

--- a/cognite/neat/workflows/steps/lib/graphs.py
+++ b/cognite/neat/workflows/steps/lib/graphs.py
@@ -1,13 +1,12 @@
 import logging
 from pathlib import Path
+from typing import ClassVar
+
 from cognite.neat.constants import PREFIXES
-
-from cognite.neat.graph.stores import RdfStoreType
-from cognite.neat.graph.stores import NeatGraphStore, drop_graph_store
+from cognite.neat.graph.stores import NeatGraphStore, RdfStoreType, drop_graph_store
 from cognite.neat.workflows.model import FlowMessage, WorkflowConfigItem
+from cognite.neat.workflows.steps.data_contracts import RulesData, SolutionGraph, SourceGraph
 from cognite.neat.workflows.steps.step_model import Step
-
-from ..data_contracts import RulesData, SolutionGraph, SourceGraph
 
 __all__ = ["ConfigureDefaultGraphStores", "LoadInstancesFromRdfFileToSourceGraph", "ResetGraphStores"]
 
@@ -15,7 +14,7 @@ __all__ = ["ConfigureDefaultGraphStores", "LoadInstancesFromRdfFileToSourceGraph
 class ConfigureDefaultGraphStores(Step):
     description = "The step initializes the source and solution graph stores."
     category = "graph_store"
-    configuration_templates = [
+    configuration_templates: ClassVar[list[WorkflowConfigItem]] = [
         WorkflowConfigItem(
             name="source_rdf_store.type",
             value=RdfStoreType.OXIGRAPH,
@@ -139,7 +138,7 @@ class ResetGraphStores(Step):
 class LoadInstancesFromRdfFileToSourceGraph(Step):
     description = "The step loads instances from a file into the source graph.The file must be in RDF format."
     category = "graph_loader"
-    configuration_templates = [
+    configuration_templates: ClassVar[list[WorkflowConfigItem]] = [
         WorkflowConfigItem(
             name="source_rdf_store.file",
             value="source-graphs/source-graph-dump.xml",

--- a/cognite/neat/workflows/steps/lib/transformation_rules.py
+++ b/cognite/neat/workflows/steps/lib/transformation_rules.py
@@ -1,7 +1,10 @@
 import logging
 from pathlib import Path
+from typing import ClassVar
 
 from rdflib import RDF, Literal, URIRef
+
+from cognite.client import CogniteClient
 from cognite.neat.constants import PREFIXES
 from cognite.neat.graph.transformations.transformer import RuleProcessingReport, domain2app_knowledge_graph
 from cognite.neat.rules import parse_rules_from_excel_file
@@ -9,10 +12,8 @@ from cognite.neat.rules.exporter.rules2triples import get_instances_as_triples
 from cognite.neat.workflows import utils
 from cognite.neat.workflows.cdf_store import CdfStore
 from cognite.neat.workflows.model import FlowMessage, WorkflowConfigItem
+from cognite.neat.workflows.steps.data_contracts import RulesData, SolutionGraph, SourceGraph
 from cognite.neat.workflows.steps.step_model import Step
-
-from cognite.client import CogniteClient
-from ..data_contracts import RulesData, SolutionGraph, SourceGraph
 
 __all__ = [
     "LoadTransformationRules",
@@ -25,7 +26,7 @@ __all__ = [
 class LoadTransformationRules(Step):
     description = "The step loads transformation rules from the file or remote location"
     category = "rules"
-    configuration_templates = [
+    configuration_templates: ClassVar[list[WorkflowConfigItem]] = [
         WorkflowConfigItem(
             name="rules.file",
             value="rules.xlsx",
@@ -56,7 +57,7 @@ class LoadTransformationRules(Step):
         )
         rules_metrics.labels({"component": "classes"}).set(len(transformation_rules.classes))
         rules_metrics.labels({"component": "properties"}).set(len(transformation_rules.properties))
-        logging.info(f"Loaded prefixes {str(transformation_rules.prefixes)} rules from {rules_file_path.name!r}.")
+        logging.info(f"Loaded prefixes {transformation_rules.prefixes!s} rules from {rules_file_path.name!r}.")
         output_text = f"Loaded {len(transformation_rules.properties)} rules"
         return FlowMessage(output_text=output_text), RulesData(rules=transformation_rules)
 
@@ -133,7 +134,7 @@ class LoadDataModelFromRulesToSourceGraph(Step):
                 )
             counter += 1
 
-        for property_name, property_def in properties.items():
+        for _property_name, property_def in properties.items():
             rdf_instance_id = URIRef(ns + "_" + property_def.class_id)
             source_graph.graph.graph.add(
                 (rdf_instance_id, URIRef(ns + property_def.property_id), Literal(property_def.expected_value_type))

--- a/cognite/neat/workflows/steps/lib/transformation_rules.py
+++ b/cognite/neat/workflows/steps/lib/transformation_rules.py
@@ -2,9 +2,9 @@ import logging
 from pathlib import Path
 from typing import ClassVar
 
+from cognite.client import CogniteClient
 from rdflib import RDF, Literal, URIRef
 
-from cognite.client import CogniteClient
 from cognite.neat.constants import PREFIXES
 from cognite.neat.graph.transformations.transformer import RuleProcessingReport, domain2app_knowledge_graph
 from cognite.neat.rules import parse_rules_from_excel_file

--- a/cognite/neat/workflows/steps/step_model.py
+++ b/cognite/neat/workflows/steps/step_model.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import ClassVar, TypeVar
-from pydantic import BaseModel, ConfigDict
-from cognite.neat.app.monitoring.metrics import NeatMetricsCollector
 
+from pydantic import BaseModel, ConfigDict
+
+from cognite.neat.app.monitoring.metrics import NeatMetricsCollector
 from cognite.neat.workflows.model import WorkflowConfigItem, WorkflowConfigs
 
 
@@ -22,7 +23,7 @@ T_Output = TypeVar("T_Output", bound=DataContract)
 class Step(ABC):
     description: str = ""
     category: str = "default"
-    configuration_templates: list[WorkflowConfigItem] = []
+    configuration_templates: ClassVar[list[WorkflowConfigItem]] = []
     scope: str = "global"
     metrics: NeatMetricsCollector | None = None
     configs: WorkflowConfigs | None = None

--- a/cognite/neat/workflows/steps_registry.py
+++ b/cognite/neat/workflows/steps_registry.py
@@ -1,19 +1,18 @@
 import importlib
 import inspect
+import logging
 import os
-from pathlib import Path
 import sys
 import types
+from pathlib import Path
 
 from pydantic import BaseModel
+
+import cognite.neat.workflows.steps.lib
 from cognite.neat.app.monitoring.metrics import NeatMetricsCollector
 from cognite.neat.exceptions import InvalidWorkFlowError
 from cognite.neat.workflows.model import FlowMessage, WorkflowConfigItem, WorkflowConfigs
-import cognite.neat.workflows.steps.lib
-import logging
-
-from cognite.neat.workflows.steps.step_model import DataContract, T_Output
-from cognite.neat.workflows.steps.step_model import Step
+from cognite.neat.workflows.steps.step_model import DataContract, Step, T_Output
 
 
 class StepMetadata(BaseModel):
@@ -126,7 +125,6 @@ class StepsRegistry:
                             output_data.append(annotation.__name__)
                     else:
                         output_data.append(return_annotation.__name__)
-                # logging.info(f"Step {name} output data: {return_annotation}")
                 steps.append(
                     StepMetadata(
                         name=step_cls.__name__,

--- a/cognite/neat/workflows/tasks.py
+++ b/cognite/neat/workflows/tasks.py
@@ -1,4 +1,5 @@
 from cognite.client import CogniteClient
+
 from cognite.neat.workflows.model import FlowMessage
 
 

--- a/cognite/neat/workflows/tasks.py
+++ b/cognite/neat/workflows/tasks.py
@@ -1,5 +1,4 @@
 from cognite.client import CogniteClient
-
 from cognite.neat.workflows.model import FlowMessage
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,16 @@ line-length = 120
 target_version = ['py311']
 include = '\.py$'
 
+[tool.ruff]
+# See https://beta.ruff.rs/docs/rules for an overview of ruff rules
+line-length = 120
+target-version = "py311"
+exclude = ["examples","examples-pydantic-v1", "scripts"]
+select = ["E","W","F","I","RUF","TID","UP", "B", "FLY", "PTH", "ERA"]
+fixable = ["E","W","F","I","RUF","TID","UP", "B", "FLY", "PTH", "ERA"]
+fix = true
+ignore = []
+
 [tool.mypy]
 explicit_package_bases = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ fixable = ["E","W","F","I","RUF","TID","UP", "B", "FLY", "PTH", "ERA"]
 fix = true
 ignore = []
 
+[tool.ruff.isort]
+known-third-party = ["cognite.client"]
+
 [tool.mypy]
 explicit_package_bases = true
 

--- a/tests/app/api/memory_cognite_client.py
+++ b/tests/app/api/memory_cognite_client.py
@@ -190,31 +190,6 @@ class AssetsMemory(MemoryClient):
         identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids)
         return self._retrieve_multiple(identifiers=identifiers, ignore_unknown_ids=ignore_unknown_ids)
 
-    def list(
-        self,
-        name: str | None = None,
-        parent_ids: Sequence[int] | None = None,
-        parent_external_ids: Sequence[str] | None = None,
-        asset_subtree_ids: int | Sequence[int] | None = None,
-        asset_subtree_external_ids: str | Sequence[str] | None = None,
-        data_set_ids: int | Sequence[int] | None = None,
-        data_set_external_ids: str | Sequence[str] | None = None,
-        labels: LabelFilter = None,
-        geo_location: GeoLocationFilter = None,
-        metadata: dict[str, str] | None = None,
-        source: str | None = None,
-        created_time: dict[str, Any] | TimestampRange = None,
-        last_updated_time: dict[str, Any] | TimestampRange = None,
-        root: bool | None = None,
-        external_id_prefix: str | None = None,
-        aggregated_properties: Sequence[str] | None = None,
-        partitions: int | None = None,
-        limit: int = LIST_LIMIT_DEFAULT,
-    ) -> AssetList:
-        return self._list(
-            method="POST",
-        )
-
     def aggregate(self, filter: AssetFilter | dict = None) -> list[AssetAggregate]:
         return [AssetAggregate(count=len(self._list_unique_in_store()))]
 
@@ -267,6 +242,31 @@ class AssetsMemory(MemoryClient):
         self, id: int | None = None, external_id: str | None = None, depth: int | None = None
     ) -> AssetList:
         raise NotImplementedError()
+
+    def list(
+        self,
+        name: str | None = None,
+        parent_ids: Sequence[int] | None = None,
+        parent_external_ids: Sequence[str] | None = None,
+        asset_subtree_ids: int | Sequence[int] | None = None,
+        asset_subtree_external_ids: str | Sequence[str] | None = None,
+        data_set_ids: int | Sequence[int] | None = None,
+        data_set_external_ids: str | Sequence[str] | None = None,
+        labels: LabelFilter = None,
+        geo_location: GeoLocationFilter = None,
+        metadata: dict[str, str] | None = None,
+        source: str | None = None,
+        created_time: dict[str, Any] | TimestampRange = None,
+        last_updated_time: dict[str, Any] | TimestampRange = None,
+        root: bool | None = None,
+        external_id_prefix: str | None = None,
+        aggregated_properties: Sequence[str] | None = None,
+        partitions: int | None = None,
+        limit: int = LIST_LIMIT_DEFAULT,
+    ) -> AssetList:
+        return self._list(
+            method="POST",
+        )
 
 
 class RelationshipsMemory(MemoryClient):
@@ -341,6 +341,24 @@ class RelationshipsMemory(MemoryClient):
             identifiers=identifiers,
         )
 
+    def create(self, relationship: Relationship | Sequence[Relationship]) -> Relationship | RelationshipList:
+        if isinstance(relationship, Sequence):
+            relationship = [r._validate_resource_types() for r in relationship]
+        else:
+            relationship = relationship._validate_resource_types()
+
+        return self._create_multiple(items=relationship)
+
+    def update(
+        self, item: Relationship | RelationshipUpdate | Sequence[Relationship | RelationshipUpdate]
+    ) -> Relationship | RelationshipList:
+        raise NotImplementedError()
+        # return self._update_multiple(
+
+    def delete(self, external_id: str | Sequence[str], ignore_unknown_ids: bool = False) -> None:
+        raise NotImplementedError()
+        # self._delete_multiple(
+
     def list(
         self,
         source_external_ids: Sequence[str] | None = None,
@@ -364,24 +382,6 @@ class RelationshipsMemory(MemoryClient):
             method="POST",
         )
 
-    def create(self, relationship: Relationship | Sequence[Relationship]) -> Relationship | RelationshipList:
-        if isinstance(relationship, Sequence):
-            relationship = [r._validate_resource_types() for r in relationship]
-        else:
-            relationship = relationship._validate_resource_types()
-
-        return self._create_multiple(items=relationship)
-
-    def update(
-        self, item: Relationship | RelationshipUpdate | Sequence[Relationship | RelationshipUpdate]
-    ) -> Relationship | RelationshipList:
-        raise NotImplementedError()
-        # return self._update_multiple(
-
-    def delete(self, external_id: str | Sequence[str], ignore_unknown_ids: bool = False) -> None:
-        raise NotImplementedError()
-        # self._delete_multiple(
-
 
 class LabelsMemory(MemoryClient):
     _RESOURCE_PATH = "/labels"
@@ -404,16 +404,6 @@ class LabelsMemory(MemoryClient):
             )
         )
 
-    def list(
-        self,
-        name: str | None = None,
-        external_id_prefix: str | None = None,
-        data_set_ids: int | Sequence[int] | None = None,
-        data_set_external_ids: str | Sequence[str] | None = None,
-        limit: int = LIST_LIMIT_DEFAULT,
-    ) -> LabelDefinitionList:
-        return self._list(method="POST", limit=limit)
-
     def create(self, label: LabelDefinition | Sequence[LabelDefinition]) -> LabelDefinition | LabelDefinitionList:
         if isinstance(label, Sequence):
             if len(label) > 0 and not isinstance(label[0], LabelDefinition):
@@ -424,6 +414,16 @@ class LabelsMemory(MemoryClient):
 
     def delete(self, external_id: str | Sequence[str] | None = None) -> None:
         raise NotImplementedError()
+
+    def list(
+        self,
+        name: str | None = None,
+        external_id_prefix: str | None = None,
+        data_set_ids: int | Sequence[int] | None = None,
+        data_set_external_ids: str | Sequence[str] | None = None,
+        limit: int = LIST_LIMIT_DEFAULT,
+    ) -> LabelDefinitionList:
+        return self._list(method="POST", limit=limit)
 
 
 @contextmanager

--- a/tests/app/api/test_configuration.py
+++ b/tests/app/api/test_configuration.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from cognite.neat.app.api.configuration import Config
 
 

--- a/tests/app/api/test_workflows.py
+++ b/tests/app/api/test_workflows.py
@@ -1,18 +1,18 @@
-import pytest
-from cognite.client import CogniteClient
-from starlette.testclient import TestClient
 from urllib.parse import quote
 
+import pytest
+from starlette.testclient import TestClient
 
 from cognite import neat
+from cognite.client import CogniteClient
+from cognite.neat.app.api.configuration import neat_app
+from cognite.neat.app.api.data_classes.rest import QueryRequest, RuleRequest, RunWorkflowRequest
+from cognite.neat.app.api.utils.query_templates import query_templates
 from cognite.neat.constants import EXAMPLE_WORKFLOWS
 from cognite.neat.rules.models import TransformationRules
 from cognite.neat.workflows.base import BaseWorkflow
 from cognite.neat.workflows.model import WorkflowConfigItem, WorkflowDefinition
-from cognite.neat.app.api.data_classes.rest import RuleRequest, RunWorkflowRequest, QueryRequest
 from tests.app.api.memory_cognite_client import MemoryClient
-from cognite.neat.app.api.utils.query_templates import query_templates
-from cognite.neat.app.api.configuration import neat_app
 
 
 @pytest.fixture(scope="session")

--- a/tests/app/api/test_workflows.py
+++ b/tests/app/api/test_workflows.py
@@ -1,10 +1,10 @@
 from urllib.parse import quote
 
 import pytest
+from cognite.client import CogniteClient
 from starlette.testclient import TestClient
 
 from cognite import neat
-from cognite.client import CogniteClient
 from cognite.neat.app.api.configuration import neat_app
 from cognite.neat.app.api.data_classes.rest import QueryRequest, RuleRequest, RunWorkflowRequest
 from cognite.neat.app.api.utils.query_templates import query_templates

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,13 @@ import pytest
 from rdflib import Namespace
 
 from cognite.neat import rules
-from cognite.neat.graph import loaders, extractors
-from cognite.neat.graph.stores import NeatGraphStore
+from cognite.neat.graph import extractors, loaders
 from cognite.neat.graph.extractors.mocks import generate_triples
-from cognite.neat.rules.parser import RawTables, read_excel_file_to_table_by_name
+from cognite.neat.graph.stores import NeatGraphStore
+from cognite.neat.graph.transformations.transformer import domain2app_knowledge_graph
 from cognite.neat.rules.importer.ontology2excel import owl2excel
 from cognite.neat.rules.models import TransformationRules
-from cognite.neat.graph.transformations.transformer import domain2app_knowledge_graph
+from cognite.neat.rules.parser import RawTables, read_excel_file_to_table_by_name
 from cognite.neat.utils.utils import add_triples
 from tests import config
 
@@ -69,7 +69,6 @@ def simple_rules():
 
 @pytest.fixture(scope="function")
 def graph_capturing_sheet():
-    # return load_workbook(config.GRAPH_CAPTURING_SHEET)
     return extractors.read_graph_excel_file_to_table_by_name(config.GRAPH_CAPTURING_SHEET)
 
 

--- a/tests/graph/extractors/mocks/test_mock_graph.py
+++ b/tests/graph/extractors/mocks/test_mock_graph.py
@@ -1,8 +1,8 @@
 from cognite.neat.graph import loaders
-from cognite.neat.graph.loaders.core import rdf_to_relationships
 from cognite.neat.graph.extractors.mocks import generate_triples
-from cognite.neat.rules.models import TransformationRules
+from cognite.neat.graph.loaders.core import rdf_to_relationships
 from cognite.neat.graph.stores import NeatGraphStore
+from cognite.neat.rules.models import TransformationRules
 from cognite.neat.utils.utils import add_triples, remove_namespace
 
 

--- a/tests/graph/extractors/test_sheet2graph.py
+++ b/tests/graph/extractors/test_sheet2graph.py
@@ -21,7 +21,7 @@ def test_sheet2graph(simple_rules, graph_capturing_sheet):
         )
     }
 
-    assert list(graph_store.graph.query("Select ?o WHERE { neat:Country-1 neat:TSO ?o }"))[0][0] == Literal(
+    assert next(iter(graph_store.graph.query("Select ?o WHERE { neat:Country-1 neat:TSO ?o }")))[0] == Literal(
         "Statnett", datatype=XSD.string
     )
     assert count_dict == {"PriceArea": 2, "CountryGroup": 1, "Country": 1, "PriceAreaConnection": 1}

--- a/tests/graph/loaders/core/test_rdf_to_assets.py
+++ b/tests/graph/loaders/core/test_rdf_to_assets.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 
 import pytest
-
 from cognite.client.data_classes import Asset, AssetList, Label, LabelDefinition, LabelDefinitionList, LabelFilter
 from cognite.client.testing import monkeypatch_cognite_client
+
 from cognite.neat.graph.loaders.core.rdf_to_assets import (
     AssetLike,
     NeatMetadataKeys,

--- a/tests/graph/loaders/core/test_rdf_to_assets.py
+++ b/tests/graph/loaders/core/test_rdf_to_assets.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 
 import pytest
+
 from cognite.client.data_classes import Asset, AssetList, Label, LabelDefinition, LabelDefinitionList, LabelFilter
 from cognite.client.testing import monkeypatch_cognite_client
-
 from cognite.neat.graph.loaders.core.rdf_to_assets import (
     AssetLike,
     NeatMetadataKeys,
@@ -81,7 +81,7 @@ def test_asset_diffing(mock_rdf_assets, mock_cdf_assets, transformation_rules):
                 return AssetList([Asset(**non_active_asset)])
 
         def list_labels(**_):
-            label_names = list(get_labels(transformation_rules)) + ["non-historic", "historic"]
+            label_names = [*list(get_labels(transformation_rules)), "non-historic", "historic"]
             return [Label(external_id=label_name, name=label_names) for label_name in label_names]
 
         client_mock.assets.list = list_assets

--- a/tests/graph/loaders/core/test_rdf_to_relationships.py
+++ b/tests/graph/loaders/core/test_rdf_to_relationships.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 
 from cognite.client.data_classes import Asset, AssetList, Label, LabelFilter, Relationship, RelationshipList
 from cognite.client.testing import monkeypatch_cognite_client
-
 from cognite.neat.graph.loaders.core.rdf_to_assets import rdf2assets
 from cognite.neat.graph.loaders.core.rdf_to_relationships import categorize_relationships, rdf2relationships
 from cognite.neat.rules.exporter.core.rules2labels import get_labels
@@ -71,7 +70,7 @@ def test_relationship_diffing(mock_knowledge_graph, transformation_rules):
                 return historic_asset_list + non_historic_asset_list
 
         def list_labels(**_):
-            label_names = list(get_labels(transformation_rules)) + ["non-historic", "historic"]
+            label_names = [*list(get_labels(transformation_rules)), "non-historic", "historic"]
             return [Label(external_id=label_name, name=label_names) for label_name in label_names]
 
         client_mock.labels.list = list_labels

--- a/tests/graph/loaders/core/test_rdf_to_relationships.py
+++ b/tests/graph/loaders/core/test_rdf_to_relationships.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from cognite.client.data_classes import Asset, AssetList, Label, LabelFilter, Relationship, RelationshipList
 from cognite.client.testing import monkeypatch_cognite_client
+
 from cognite.neat.graph.loaders.core.rdf_to_assets import rdf2assets
 from cognite.neat.graph.loaders.core.rdf_to_relationships import categorize_relationships, rdf2relationships
 from cognite.neat.rules.exporter.core.rules2labels import get_labels

--- a/tests/graph/loaders/test_validator.py
+++ b/tests/graph/loaders/test_validator.py
@@ -1,6 +1,6 @@
 from cognite.neat.graph.loaders.core.rdf_to_assets import rdf2assets
-from cognite.neat.graph.stores import NeatGraphStore
 from cognite.neat.graph.loaders.validator import validate_asset_hierarchy
+from cognite.neat.graph.stores import NeatGraphStore
 
 
 def test_orphan_assets(transformation_rules, solution_knowledge_graph):

--- a/tests/graph/transformations/test_transformer.py
+++ b/tests/graph/transformations/test_transformer.py
@@ -1,7 +1,7 @@
 import pandas as pd
+from cognite.client.testing import monkeypatch_cognite_client
 from rdflib import Graph, Namespace
 
-from cognite.client.testing import monkeypatch_cognite_client
 from cognite.neat.graph.transformations.transformer import domain2app_knowledge_graph
 from cognite.neat.rules.models import TransformationRules
 from cognite.neat.rules.to_rdf_path import RuleType

--- a/tests/graph/transformations/test_transformer.py
+++ b/tests/graph/transformations/test_transformer.py
@@ -1,10 +1,10 @@
 import pandas as pd
-from cognite.client.testing import monkeypatch_cognite_client
 from rdflib import Graph, Namespace
 
+from cognite.client.testing import monkeypatch_cognite_client
+from cognite.neat.graph.transformations.transformer import domain2app_knowledge_graph
 from cognite.neat.rules.models import TransformationRules
 from cognite.neat.rules.to_rdf_path import RuleType
-from cognite.neat.graph.transformations.transformer import domain2app_knowledge_graph
 
 
 def test_domain2app_knowledge_graph(transformation_rules: TransformationRules, source_knowledge_graph: Graph):
@@ -19,7 +19,7 @@ def test_domain2app_knowledge_graph(transformation_rules: TransformationRules, s
     res = app_graph.query(
         """SELECT ?o WHERE {<http://purl.org/nordic44#_f17695aa-9aeb-11e5-91da-b8763fd99c5f> rdf:type ?o}"""
     )
-    assert list(res)[0][0] == Namespace("http://purl.org/cognite/tnt#").Substation
+    assert next(iter(res))[0] == Namespace("http://purl.org/cognite/tnt#").Substation
 
 
 def test_domain2app_knowledge_graph_raw_lookup(
@@ -53,5 +53,5 @@ def test_domain2app_knowledge_graph_raw_lookup(
         "SELECT ?o WHERE {<http://purl.org/nordic44#_2dd9040e-bdfb-11e5-94fa-c8f73332c8f4> "
         "tnt:IdentifiedObject.name ?o}"
     )
-    assert list(Gjerstad_node)[0][0].value == "Gjerstad"
-    assert list(NaN_node)[0][0].value == "NaN"
+    assert next(iter(Gjerstad_node))[0].value == "Gjerstad"
+    assert next(iter(NaN_node))[0].value == "NaN"

--- a/tests/graph_store.py
+++ b/tests/graph_store.py
@@ -2,9 +2,7 @@ import time
 
 import pandas as pd
 
-from cognite.neat.graph.stores import RdfStoreType
-from cognite.neat.graph.stores import NeatGraphStore
-
+from cognite.neat.graph.stores import NeatGraphStore, RdfStoreType
 
 pd.options.display.max_colwidth = 100
 

--- a/tests/rules/exporter/test_rules2dms.py
+++ b/tests/rules/exporter/test_rules2dms.py
@@ -1,6 +1,7 @@
 import pytest
-from cognite.neat.rules.exporter.rules2dms import DataModel
+
 from cognite.neat.rules.exceptions import EntitiesContainNonDMSCompliantCharacters
+from cognite.neat.rules.exporter.rules2dms import DataModel
 
 
 def test_rules2dms(simple_rules):

--- a/tests/rules/exporter/test_rules2graph_sheet.py
+++ b/tests/rules/exporter/test_rules2graph_sheet.py
@@ -1,5 +1,5 @@
-from cognite.neat.rules.parser import read_excel_file_to_table_by_name
 from cognite.neat.rules.exporter.rules2graph_sheet import rules2graph_capturing_sheet
+from cognite.neat.rules.parser import read_excel_file_to_table_by_name
 
 
 def test_graph_capturing_sheet(tmp_path, simple_rules, graph_capturing_sheet):

--- a/tests/rules/exporter/test_rules2graphql.py
+++ b/tests/rules/exporter/test_rules2graphql.py
@@ -1,6 +1,7 @@
 import pytest
-from cognite.neat.rules.exporter.rules2graphql import GraphQLSchema
+
 from cognite.neat.rules.exceptions import EntitiesContainNonDMSCompliantCharacters
+from cognite.neat.rules.exporter.rules2graphql import GraphQLSchema
 
 
 def test_rules2graphql(simple_rules, grid_graphql_schema):

--- a/tests/rules/exporter/test_rules2ontology.py
+++ b/tests/rules/exporter/test_rules2ontology.py
@@ -1,7 +1,9 @@
-import pytest
-from cognite.neat.rules.exporter.rules2ontology import Ontology
-from cognite.neat.rules.exceptions import PropertiesDefinedMultipleTimes
 from copy import deepcopy
+
+import pytest
+
+from cognite.neat.rules.exceptions import PropertiesDefinedMultipleTimes
+from cognite.neat.rules.exporter.rules2ontology import Ontology
 
 
 def test_rules2ontology(transformation_rules):

--- a/tests/rules/exporter/test_rules2pydantic_models.py
+++ b/tests/rules/exporter/test_rules2pydantic_models.py
@@ -1,4 +1,5 @@
 from rdflib import URIRef
+
 from cognite.neat.rules.exporter.rules2pydantic_models import rules_to_pydantic_models
 
 

--- a/tests/rules/test_parser.py
+++ b/tests/rules/test_parser.py
@@ -2,8 +2,7 @@ import pandas as pd
 import pytest
 from pydantic import ValidationError
 
-from cognite.neat.rules.parser import read_excel_file_to_table_by_name
-from cognite.neat.rules.parser import Tables, from_tables
+from cognite.neat.rules.parser import Tables, from_tables, read_excel_file_to_table_by_name
 from tests import config
 
 

--- a/tests/rules/test_to_rdf_path.py
+++ b/tests/rules/test_to_rdf_path.py
@@ -1,9 +1,8 @@
-import pytest
-from tests import config
-from pydantic import ValidationError
-
 import pprint
+
+import pytest
 from IPython.display import Markdown, display
+from pydantic import ValidationError
 
 from cognite.neat.constants import PREFIXES
 from cognite.neat.graph.stores import NeatGraphStore
@@ -17,12 +16,12 @@ from cognite.neat.rules.to_rdf_path import (
     RuleType,
     SingleProperty,
     Step,
+    is_rawlookup,
+    is_rdfpath,
     parse_rule,
     parse_traversal,
-    is_rdfpath,
-    is_rawlookup,
 )
-
+from tests import config
 
 nan = float("nan")
 
@@ -262,7 +261,7 @@ GRAPH = None
 def display_test_parse_traversal(
     raw: str,
     expected_traversal: AllProperties | AllReferences | Entity | Hop | SingleProperty,
-    name: str = None,
+    name: str | None = None,
 ):
     global GRAPH
     if name:

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,6 +1,6 @@
 import pytest
-
 from cognite.client.testing import monkeypatch_cognite_client
+
 from cognite.neat.config import copy_examples_to_directory
 from cognite.neat.workflows import WorkflowManager
 

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,7 +1,6 @@
-# from pathlib import Path
 import pytest
-from cognite.client.testing import monkeypatch_cognite_client
 
+from cognite.client.testing import monkeypatch_cognite_client
 from cognite.neat.config import copy_examples_to_directory
 from cognite.neat.workflows import WorkflowManager
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,8 +1,8 @@
 import filecmp
 from pathlib import Path
 
-from cognite.neat.constants import EXAMPLE_RULES, EXAMPLE_GRAPHS, EXAMPLE_WORKFLOWS
 from cognite.neat.config import copy_examples_to_directory
+from cognite.neat.constants import EXAMPLE_GRAPHS, EXAMPLE_RULES, EXAMPLE_WORKFLOWS
 from cognite.neat.rules.models import TransformationRules
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
-
 from cognite.client.exceptions import CogniteDuplicatedError, CogniteReadTimeout
+
 from cognite.neat.utils.utils import retry_decorator
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
-from cognite.client.exceptions import CogniteDuplicatedError, CogniteReadTimeout
 
+from cognite.client.exceptions import CogniteDuplicatedError, CogniteReadTimeout
 from cognite.neat.utils.utils import retry_decorator
 
 


### PR DESCRIPTION
Initial issues after introducing more rules:
```
cognite\neat\app\api\routers\crud.py:41:21: PTH118 `os.path.join()` should be replaced by `Path` with `/` operator
cognite\neat\app\api\routers\crud.py:42:14: PTH123 `open()` should be replaced by `Path.open()`
cognite\neat\graph\loaders\core\rdf_to_assets.py:489:5: B028 No explicit `stacklevel` keyword argument found
cognite\neat\graph\loaders\core\rdf_to_relationships.py:204:5: B028 No explicit `stacklevel` keyword argument found
cognite\neat\graph\stores\graph_store.py:229:29: PTH107 `os.remove()` should be replaced by `Path.unlink()`
cognite\neat\graph\stores\graph_store.py:229:39: PTH118 `os.path.join()` should be replaced by `Path` with `/` operator
cognite\neat\graph\stores\graph_store.py:311:21: PTH107 `os.remove()` should be replaced by `Path.unlink()`
cognite\neat\graph\stores\graph_store.py:311:31: PTH118 `os.path.join()` should be replaced by `Path` with `/` operator
cognite\neat\graph\stores\oxrdflib.py:130:61: B905 `zip()` without an explicit `strict=` parameter
cognite\neat\graph\transformations\transformer.py:289:17: B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
cognite\neat\rules\exceptions.py:1252:66: B006 Do not use mutable data structures for argument defaults
cognite\neat\rules\exceptions.py:1275:76: B006 Do not use mutable data structures for argument defaults
cognite\neat\rules\exceptions.py:1299:68: B006 Do not use mutable data structures for argument defaults
cognite\neat\rules\exceptions.py:1324:66: B006 Do not use mutable data structures for argument defaults
cognite\neat\rules\exceptions.py:1476:50: B006 Do not use mutable data structures for argument defaults
cognite\neat\rules\exceptions.py:1500:46: B006 Do not use mutable data structures for argument defaults
cognite\neat\rules\importer\ontology2excel.py:368:14: PTH123 `open()` should be replaced by `Path.open()`
cognite\neat\rules\models.py:251:13: B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
cognite\neat\rules\parser.py:155:26: B905 `zip()` without an explicit `strict=` parameter
cognite\neat\rules\parser.py:179:9: B028 No explicit `stacklevel` keyword argument found
cognite\neat\rules\parser.py:348:9: B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
cognite\neat\workflows\cdf_store.py:68:23: PTH118 `os.path.join()` should be replaced by `Path` with `/` operator
cognite\neat\workflows\cdf_store.py:69:24: PTH118 `os.path.join()` should be replaced by `Path` with `/` operator
cognite\neat\workflows\cdf_store.py:71:16: PTH112 `os.path.isdir()` should be replaced by `Path.is_dir()`
cognite\neat\workflows\cdf_store.py:80:33: PTH118 `os.path.join()` should be replaced by `Path` with `/` operator
cognite\neat\workflows\cdf_store.py:98:16: PTH113 `os.path.isfile()` should be replaced by `Path.is_file()`
cognite\neat\workflows\cdf_store.py:106:9: PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
cognite\neat\workflows\cdf_store.py:182:17: PTH107 `os.remove()` should be replaced by `Path.unlink()`
cognite\neat\workflows\cdf_store.py:200:20: PTH110 `os.path.exists()` should be replaced by `Path.exists()`
cognite\neat\workflows\manager.py:104:18: PTH123 `open()` should be replaced by `Path.open()`
cognite\neat\workflows\manager.py:137:24: PTH110 `os.path.exists()` should be replaced by `Path.exists()`
cognite\neat\workflows\manager.py:138:30: PTH123 `open()` should be replaced by `Path.open()`
cognite\neat\workflows\migration\wf_manifests.py:20:22: PTH123 `open()` should be replaced by `Path.open()`
cognite\neat\workflows\migration\wf_manifests.py:27:26: PTH123 `open()` should be replaced by `Path.open()`
cognite\neat\workflows\steps\lib\cdf_resources.py:24:1: TID252 Relative imports from parent modules are banned
cognite\neat\workflows\steps\lib\cdf_resources.py:24:1: TID252 Relative imports from parent modules are banned
cognite\neat\workflows\steps\lib\cdf_resources.py:24:1: TID252 Relative imports from parent modules are banned
cognite\neat\workflows\steps\lib\cdf_resources.py:24:1: TID252 Relative imports from parent modules are banned
cognite\neat\workflows\steps\lib\fdm.py:15:31: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
cognite\neat\workflows\steps\lib\graph_data_capture.py:11:1: TID252 Relative imports from parent modules are banned
cognite\neat\workflows\steps\lib\graph_data_capture.py:11:1: TID252 Relative imports from parent modules are banned
cognite\neat\workflows\steps\lib\graph_data_capture.py:19:31: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
cognite\neat\workflows\steps\lib\graphs.py:9:1: TID252 Relative imports from parent modules are banned
cognite\neat\workflows\steps\lib\graphs.py:9:1: TID252 Relative imports from parent modules are banned
Found 54 errors.
```