### PR TITLE
fix: interface of Base/CDF Exporter

### DIFF
--- a/cognite/neat/rules/exporters/_base.py
+++ b/cognite/neat/rules/exporters/_base.py
@@ -22,7 +22,7 @@ class BaseExporter(ABC, Generic[T_Export]):
         raise NotImplementedError
 
 
-class CDFExporter(ABC, Generic[T_Export]):
+class CDFExporter(BaseExporter[T_Export]):
     @abstractmethod
     def export_to_cdf(self, client: CogniteClient, rules: Rules, dry_run: bool = False) -> Iterable[UploadResult]:
         raise NotImplementedError

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,6 +1,7 @@
 cdf_client:
     project: get-power-grid
     client_id: ca4b8f9c6-7d6e-4d7b-9cf3-6d4a32f8b7e1
+    # This is a fake secret, replace with your own
     client_secret: Zy7!nM4cFp9sH3gR6tB8kL0oP7eU6wD5vQ4zN9yF
     base_url: https://az-power-no-northeurope.cognitedata.com
     scopes:

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -2,7 +2,7 @@ cdf_client:
     project: get-power-grid
     client_id: ca4b8f9c6-7d6e-4d7b-9cf3-6d4a32f8b7e1
     # This is a fake secret, replace with your own
-    client_secret: Zy7!nM4cFp9sH3gR6tB8kL0oP7eU6wD5vQ4zN9yF
+    client_secret: Zy7!nM4cFp9...
     base_url: https://az-power-no-northeurope.cognitedata.com
     scopes:
       - https://az-power-no-northeurope.cognitedata.com/.default


### PR DESCRIPTION
Two fixes
* CDFExporter is a type of BaseExporter
* It looks like the example `config.yaml` have a real secret. Make it clear that this is fake