### PR TITLE
[NEAT-31] Conversion workflow

### DIFF
--- a/cognite/neat/rules/exporters/_base.py
+++ b/cognite/neat/rules/exporters/_base.py
@@ -6,6 +6,7 @@ from typing import Generic, TypeVar
 from cognite.client import CogniteClient
 
 from cognite.neat.rules._shared import Rules
+from cognite.neat.rules.models._rules import DMSRules, InformationRules, RoleTypes
 
 from ._models import UploadResult
 
@@ -20,6 +21,16 @@ class BaseExporter(ABC, Generic[T_Export]):
     @abstractmethod
     def export(self, rules: Rules) -> T_Export:
         raise NotImplementedError
+
+    def _convert_to_output_role(self, rules: Rules, output_role: RoleTypes | None = None) -> Rules:
+        if rules.metadata.role is output_role or output_role is None:
+            return rules
+        elif output_role is RoleTypes.dms_architect and isinstance(rules, InformationRules):
+            return rules.as_dms_architect_rules()
+        elif output_role is RoleTypes.information_architect and isinstance(rules, DMSRules):
+            return rules.as_information_architect_rules()
+        else:
+            raise NotImplementedError(f"Role {output_role} is not supported for {type(rules).__name__} rules")
 
 
 class CDFExporter(BaseExporter[T_Export]):

--- a/cognite/neat/workflows/examples/Validate Rules/workflow.yaml
+++ b/cognite/neat/workflows/examples/Validate Rules/workflow.yaml
@@ -20,6 +20,7 @@ steps:
     system_component_id: null
     transition_to:
     - step_942973
+    - step_715590
     trigger: false
     ui_config:
         pos_x: 557
@@ -43,4 +44,23 @@ steps:
     ui_config:
         pos_x: 558
         pos_y: -14
+-   complex_configs: {}
+    configs:
+        Output role format: input
+        Styling: default
+    description: null
+    enabled: true
+    id: step_715590
+    label: Convert Rules
+    max_retries: 0
+    method: RulesToExcel
+    params: {}
+    retry_delay: 3
+    stype: stdstep
+    system_component_id: null
+    transition_to: []
+    trigger: false
+    ui_config:
+        pos_x: 558
+        pos_y: 217
 system_components: []

--- a/cognite/neat/workflows/steps/lib/rules_exporter.py
+++ b/cognite/neat/workflows/steps/lib/rules_exporter.py
@@ -162,32 +162,34 @@ class RulesToExcel(Step):
 
         styling = cast(exporters.ExcelExporter.Style, self.configs.get("Styling", "default"))
         role = self.configs.get("Output role format")
-        role_enum = None
+        output_role = None
         if role != "input" and role is not None:
-            role_enum = RoleTypes[role]
+            output_role = RoleTypes[role]
 
-        excel_exporter = exporters.ExcelExporter(styling=styling, output_role=role_enum)
+        excel_exporter = exporters.ExcelExporter(styling=styling, output_role=output_role)
 
         rule_instance: Rules
         if rules.domain:
             rule_instance = rules.domain
         elif rules.information:
             rule_instance = rules.information
+
         elif rules.dms:
             rule_instance = rules.dms
         else:
             output_errors = "No rules provided for export!"
             return FlowMessage(error_text=output_errors, step_execution_status=StepExecutionStatus.ABORT_AND_FAIL)
-
+        if output_role is None:
+            output_role = rule_instance.metadata.role
         output_dir = self.data_store_path / Path("staging")
         output_dir.mkdir(parents=True, exist_ok=True)
-        file_name = f"exported_rules_{rule_instance.metadata.role.value}.xlsx"
+        file_name = f"exported_rules_{output_role.value}.xlsx"
         filepath = output_dir / file_name
         excel_exporter.export_to_file(filepath, rule_instance)
 
         output_text = (
             "<p></p>"
-            f"Download Excel Exported {rule_instance.metadata.role.value} rules: "
+            f"Download Excel Exported {output_role.value} rules: "
             f'- <a href="/data/staging/{file_name}?{time.time()}" '
             f'target="_blank">{file_name}</a>'
         )


### PR DESCRIPTION
* Add `output_role` parameter `Excelporter` such that the user can chose a different output than the input format.
* Added this as as a new configuration to the step.
* Extended the `ValidationRules` with a conversion step. 

![image](https://github.com/cognitedata/neat/assets/60234212/6ec09d6c-4855-49da-b9ee-dfab8622e497)

