### PR TITLE
[NEAT-48] Create view filters

### DIFF
--- a/cognite/neat/rules/models/_rules/dms_architect_rules.py
+++ b/cognite/neat/rules/models/_rules/dms_architect_rules.py
@@ -627,6 +627,7 @@ class _DMSExporter:
 
         node_types = dm.NodeApplyList([])
         parent_views = {parent for view in views for parent in view.implements or []}
+        node_type_flag = False
         for view in views:
             ref_containers = view.referenced_containers()
             has_data = dm.filters.HasData(containers=list(ref_containers)) if ref_containers else None
@@ -635,12 +636,18 @@ class _DMSExporter:
                 view.filter = has_data
             elif has_data is None:
                 # Child filter without container properties
-                view.filter = node_type
-                node_types.append(dm.NodeApply(space=view.space, external_id=view.external_id, sources=[]))
+                if node_type_flag:
+                    # Transformations do not yet support setting node type.
+                    view.filter = node_type
+                    node_types.append(dm.NodeApply(space=view.space, external_id=view.external_id, sources=[]))
             else:
                 # Child filter with its own container properties
-                view.filter = dm.filters.And(has_data, node_type)
-                node_types.append(dm.NodeApply(space=view.space, external_id=view.external_id, sources=[]))
+                if node_type_flag:
+                    # Transformations do not yet support setting node type.
+                    view.filter = dm.filters.And(has_data, node_type)
+                    node_types.append(dm.NodeApply(space=view.space, external_id=view.external_id, sources=[]))
+                else:
+                    view.filter = has_data
         return views, node_types
 
     def _create_containers(

--- a/cognite/neat/rules/models/_rules/dms_architect_rules.py
+++ b/cognite/neat/rules/models/_rules/dms_architect_rules.py
@@ -543,7 +543,6 @@ class _DMSExporter:
         else:
             spaces = dm.SpaceApplyList([metadata.as_space()] + [dm.SpaceApply(space=space) for space in used_spaces])
         if self.instance_space:
-            data_model.space = self.instance_space
             spaces.append(dm.SpaceApply(space=self.instance_space, name=self.instance_space))
         return spaces
 

--- a/tests/tests_integration/test_rules/test_exporters/test_dms_exporters.py
+++ b/tests/tests_integration/test_rules/test_exporters/test_dms_exporters.py
@@ -101,13 +101,16 @@ def table_example() -> InformationRules:
 def table_example_data() -> dict[str, list[Row]]:
     return {
         "Table": [
-            Row("table1", {"externalId": "table1", "color": "brown", "height": 1.0, "width": 2.0}),
-            Row("table2", {"externalId": "table2", "color": "white", "height": 1.5, "width": 3.0}),
+            Row("table1", {"externalId": "table1", "color": "brown", "height": 1.0, "width": 2.0, "type": "Table"}),
+            Row(
+                "table2",
+                {"externalId": "table2", "color": "white", "height": 1.5, "width": 3.0, "type": "Table"},
+            ),
         ],
         "Item": [
-            Row("item1", {"externalId": "item1", "name": "chair", "category": "furniture"}),
-            Row("item2", {"externalId": "item2", "name": "lamp", "category": "lighting"}),
-            Row("item3", {"externalId": "item3", "name": "computer", "category": "electronics"}),
+            Row("item1", {"externalId": "item1", "name": "chair", "category": "furniture", "type": "Item"}),
+            Row("item2", {"externalId": "item2", "name": "lamp", "category": "lighting", "type": "Item"}),
+            Row("item3", {"externalId": "item3", "name": "computer", "category": "electronics", "type": "Item"}),
         ],
         "TableItem": [
             Row("table1item1", {"externalId": "table1item1", "Table": "table1", "Item": "item1"}),

--- a/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
@@ -130,10 +130,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                                 container_property_identifier="ratedPower",
                             ),
                         },
-                        filter=dm.filters.And(
-                            dm.filters.HasData(containers=[dm.ContainerId("my_space", "GeneratingUnit")]),
-                            dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindTurbine"}),
-                        ),
+                        filter=dm.filters.HasData(containers=[dm.ContainerId("my_space", "GeneratingUnit")]),
                     ),
                     dm.ViewApply(
                         space="my_space",
@@ -146,7 +143,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                                 direction="outwards",
                             )
                         },
-                        filter=dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindFarm"}),
+                        filter=None,
                     ),
                 ]
             ),
@@ -167,20 +164,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                     ),
                 ]
             ),
-            node_types=dm.NodeApplyList(
-                [
-                    dm.NodeApply(
-                        space="my_space",
-                        external_id="WindTurbine",
-                        sources=[],
-                    ),
-                    dm.NodeApply(
-                        space="my_space",
-                        external_id="WindFarm",
-                        sources=[],
-                    ),
-                ]
-            ),
+            node_types=dm.NodeApplyList([]),
         ),
         id="Two properties, one container, one view",
     )
@@ -274,10 +258,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                             direction="outwards",
                         ),
                     },
-                    filter=dm.filters.And(
-                        dm.filters.HasData(containers=[dm.ContainerId("my_space", "Asset")]),
-                        dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindFarm"}),
-                    ),
+                    filter=dm.filters.HasData(containers=[dm.ContainerId("my_space", "Asset")]),
                 ),
                 dm.ViewApply(
                     space="my_space",
@@ -288,10 +269,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                             container=dm.ContainerId("my_space", "Asset"), container_property_identifier="name"
                         )
                     },
-                    filter=dm.filters.And(
-                        dm.filters.HasData(containers=[dm.ContainerId("my_space", "Asset")]),
-                        dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindTurbine"}),
-                    ),
+                    filter=dm.filters.HasData(containers=[dm.ContainerId("my_space", "Asset")]),
                 ),
             ]
         ),
@@ -304,20 +282,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                 ),
             ]
         ),
-        node_types=dm.NodeApplyList(
-            [
-                dm.NodeApply(
-                    space="my_space",
-                    external_id="WindFarm",
-                    sources=[],
-                ),
-                dm.NodeApply(
-                    space="my_space",
-                    external_id="WindTurbine",
-                    sources=[],
-                ),
-            ]
-        ),
+        node_types=dm.NodeApplyList([]),
     )
     yield pytest.param(
         dms_rules,
@@ -410,10 +375,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                         ),
                     },
                     implements=[dm.ViewId("my_space", "Asset", "1")],
-                    filter=dm.filters.And(
-                        dm.filters.HasData(containers=[dm.ContainerId("my_space", "WindTurbine")]),
-                        dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindTurbine"}),
-                    ),
+                    filter=dm.filters.HasData(containers=[dm.ContainerId("my_space", "WindTurbine")]),
                 ),
             ],
         ),
@@ -432,15 +394,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                 ),
             ],
         ),
-        node_types=dm.NodeApplyList(
-            [
-                dm.NodeApply(
-                    space="my_space",
-                    external_id="WindTurbine",
-                    sources=[],
-                ),
-            ]
-        ),
+        node_types=dm.NodeApplyList([]),
     )
 
     yield pytest.param(

--- a/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
@@ -1027,6 +1027,10 @@ class TestDMSRules:
         expected_schema.views = dm.ViewApplyList(sorted(expected_schema.views, key=lambda v: v.external_id))
         assert actual_schema.views.dump() == expected_schema.views.dump()
 
+        actual_schema.node_types = dm.NodeApplyList(sorted(actual_schema.node_types, key=lambda n: n.external_id))
+        expected_schema.node_types = dm.NodeApplyList(sorted(expected_schema.node_types, key=lambda n: n.external_id))
+        assert actual_schema.node_types.dump() == expected_schema.node_types.dump()
+
     def test_alice_as_information(self, alice_spreadsheet: dict[str, dict[str, Any]]) -> None:
         alice_rules = DMSRules.model_validate(alice_spreadsheet)
         info_rules = alice_rules.as_information_architect_rules()

--- a/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
@@ -113,6 +113,11 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                                 container=dm.ContainerId("my_space", "Asset"), container_property_identifier="name"
                             )
                         },
+                        filter=dm.filters.HasData(
+                            containers=[
+                                dm.ContainerId("my_space", "Asset"),
+                            ]
+                        ),
                     ),
                     dm.ViewApply(
                         space="my_space",
@@ -125,6 +130,10 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                                 container_property_identifier="ratedPower",
                             ),
                         },
+                        filter=dm.filters.And(
+                            dm.filters.HasData(containers=[dm.ContainerId("my_space", "GeneratingUnit")]),
+                            dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindTurbine"}),
+                        ),
                     ),
                     dm.ViewApply(
                         space="my_space",
@@ -137,6 +146,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                                 direction="outwards",
                             )
                         },
+                        filter=dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindFarm"}),
                     ),
                 ]
             ),
@@ -154,6 +164,20 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                             "ratedPower": dm.ContainerProperty(type=dm.Float64(), nullable=True),
                         },
                         constraints={"my_space_Asset": dm.RequiresConstraint(dm.ContainerId("my_space", "Asset"))},
+                    ),
+                ]
+            ),
+            node_types=dm.NodeApplyList(
+                [
+                    dm.NodeApply(
+                        space="my_space",
+                        external_id="WindTurbine",
+                        sources=[],
+                    ),
+                    dm.NodeApply(
+                        space="my_space",
+                        external_id="WindFarm",
+                        sources=[],
                     ),
                 ]
             ),
@@ -250,6 +274,10 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                             direction="outwards",
                         ),
                     },
+                    filter=dm.filters.And(
+                        dm.filters.HasData(containers=[dm.ContainerId("my_space", "Asset")]),
+                        dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindFarm"}),
+                    ),
                 ),
                 dm.ViewApply(
                     space="my_space",
@@ -260,6 +288,10 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                             container=dm.ContainerId("my_space", "Asset"), container_property_identifier="name"
                         )
                     },
+                    filter=dm.filters.And(
+                        dm.filters.HasData(containers=[dm.ContainerId("my_space", "Asset")]),
+                        dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindTurbine"}),
+                    ),
                 ),
             ]
         ),
@@ -269,6 +301,20 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                     space="my_space",
                     external_id="Asset",
                     properties={"name": dm.ContainerProperty(type=dm.Text(), nullable=True)},
+                ),
+            ]
+        ),
+        node_types=dm.NodeApplyList(
+            [
+                dm.NodeApply(
+                    space="my_space",
+                    external_id="WindFarm",
+                    sources=[],
+                ),
+                dm.NodeApply(
+                    space="my_space",
+                    external_id="WindTurbine",
+                    sources=[],
                 ),
             ]
         ),
@@ -351,6 +397,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                             container=dm.ContainerId("my_space", "Asset"), container_property_identifier="name"
                         ),
                     },
+                    filter=dm.filters.HasData(containers=[dm.ContainerId("my_space", "Asset")]),
                 ),
                 dm.ViewApply(
                     external_id="WindTurbine",
@@ -363,6 +410,10 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                         ),
                     },
                     implements=[dm.ViewId("my_space", "Asset", "1")],
+                    filter=dm.filters.And(
+                        dm.filters.HasData(containers=[dm.ContainerId("my_space", "WindTurbine")]),
+                        dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindTurbine"}),
+                    ),
                 ),
             ],
         ),
@@ -380,6 +431,15 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                     properties={"maxPower": dm.ContainerProperty(type=dm.Float64(), nullable=True)},
                 ),
             ],
+        ),
+        node_types=dm.NodeApplyList(
+            [
+                dm.NodeApply(
+                    space="my_space",
+                    external_id="WindTurbine",
+                    sources=[],
+                ),
+            ]
         ),
     )
 


### PR DESCRIPTION
**This needs be done after** #321  
In addition, to all these less related PRs.
Merge after #315 #316 #317 #318 #319 

This adds the filters to the views that are created. This is not yet exposed to the user as something they can set. Moving that for a separate task. 

We are potentially in trouble on this one. It seem like you cannot populate node type in transformations, which is why the the test is failing. Ref https://cognitedata.slack.com/archives/C0654Q63B6H/p1710667747367909

Reverted filter to only set explicitly the HasData filter that will be implicitly set when you create the filter anyways. Lets push on the data onboarding team to implement node type support. 

