### PR TITLE
[NEAT-115] Add support for node type

### DIFF
--- a/cognite/neat/rules/issues/dms.py
+++ b/cognite/neat/rules/issues/dms.py
@@ -339,7 +339,7 @@ class UnsupportedFilterWarning(DMSSchemaWarning):
     filter_type: str
 
     def message(self) -> str:
-        return f"The filter {self.filter_type} in {self.view_id} is not supported. This filter will be ignored."
+        return f"The filter {self.filter_type} in {self.view_id} is not supported. This filter will be ignored. Contact the neat team for more information on custom filters."
 
     def dump(self) -> dict[str, Any]:
         output = super().dump()

--- a/cognite/neat/rules/issues/dms.py
+++ b/cognite/neat/rules/issues/dms.py
@@ -339,7 +339,10 @@ class UnsupportedFilterWarning(DMSSchemaWarning):
     filter_type: str
 
     def message(self) -> str:
-        return f"The filter {self.filter_type} in {self.view_id} is not supported. This filter will be ignored. Contact the neat team for more information on custom filters."
+        return (
+            f"The filter {self.filter_type} in {self.view_id} is not supported. This filter will be ignored. "
+            "Contact the neat team for more information on custom filters."
+        )
 
     def dump(self) -> dict[str, Any]:
         output = super().dump()

--- a/cognite/neat/rules/issues/dms.py
+++ b/cognite/neat/rules/issues/dms.py
@@ -310,3 +310,39 @@ class UnsupportedRelationWarning(DMSSchemaWarning):
         output["property"] = self.property
         output["relation"] = self.relation
         return output
+
+
+@dataclass(frozen=True)
+class CannotCreateFilterWarning(DMSSchemaWarning):
+    description = "The filter cannot be created"
+    fix = "Change the filter to a supported type"
+    view_id: dm.ViewId
+    filter_type: str
+    reason: str
+
+    def message(self) -> str:
+        return f"The filter {self.filter_type} in {self.view_id} cannot be created: {self.reason}."
+
+    def dump(self) -> dict[str, Any]:
+        output = super().dump()
+        output["view_id"] = self.view_id.dump()
+        output["reason"] = self.reason
+        output["filter_type"] = self.filter_type
+        return output
+
+
+@dataclass(frozen=True)
+class UnsupportedFilterWarning(DMSSchemaWarning):
+    description = "The filter type is not supported by neat"
+    fix = "Change the filter to a supported type"
+    view_id: dm.ViewId
+    filter_type: str
+
+    def message(self) -> str:
+        return f"The filter {self.filter_type} in {self.view_id} is not supported. This filter will be ignored."
+
+    def dump(self) -> dict[str, Any]:
+        output = super().dump()
+        output["view_id"] = self.view_id.dump()
+        output["filter_type"] = self.filter_type
+        return output

--- a/cognite/neat/rules/models/_rules/dms_architect_rules.py
+++ b/cognite/neat/rules/models/_rules/dms_architect_rules.py
@@ -231,7 +231,14 @@ class DMSContainer(SheetEntity):
 class DMSView(SheetEntity):
     view: ViewType = Field(alias="View")
     implements: ViewListType | None = Field(None, alias="Implements")
+    filter_: list[Literal["hasData", "nodeType"]] | None = Field(None, alias="Filter")
     in_model: bool = Field(True, alias="InModel")
+
+    @field_validator("filter_", mode="before")
+    def split_comma_separated_filter(cls, value: Any) -> Any | None:
+        if isinstance(value, str):
+            return value.split(",")
+        return value
 
     def as_view(self, default_space: str, default_version: str, standardize_casing: bool = True) -> dm.ViewApply:
         view_id = self.view.as_id(default_space, default_version, standardize_casing)

--- a/cognite/neat/rules/models/_rules/dms_architect_rules.py
+++ b/cognite/neat/rules/models/_rules/dms_architect_rules.py
@@ -719,7 +719,8 @@ class _DMSExporter:
             selected_filters = dms_view_by_view_id[view.as_id()].filter_
 
             filters: list[dm.filters.Filter] = []
-            for selected_filter in selected_filters or ["hasData"]:
+            default_filters = ["hasData"]
+            for selected_filter in selected_filters or default_filters:
                 if selected_filter == "hasData":
                     ref_containers = view.referenced_containers()
                     if not ref_containers and selected_filter:

--- a/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
@@ -74,8 +74,10 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
             views=SheetList[DMSView](
                 data=[
                     DMSView(class_="Asset", view="Asset"),
-                    DMSView(class_="WindTurbine", view="WindTurbine", implements=["Asset"]),
-                    DMSView(class_="WindFarm", view="WindFarm"),
+                    DMSView(
+                        class_="WindTurbine", view="WindTurbine", implements=["Asset"], filter_=["hasData", "nodeType"]
+                    ),
+                    DMSView(class_="WindFarm", view="WindFarm", filter_=["nodeType"]),
                 ]
             ),
         ),
@@ -130,7 +132,10 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                                 container_property_identifier="ratedPower",
                             ),
                         },
-                        filter=dm.filters.HasData(containers=[dm.ContainerId("my_space", "GeneratingUnit")]),
+                        filter=dm.filters.And(
+                            dm.filters.HasData(containers=[dm.ContainerId("my_space", "GeneratingUnit")]),
+                            dm.filters.Equals(["node", "type"], {"space": "my_space", "externalId": "WindTurbine"}),
+                        ),
                     ),
                     dm.ViewApply(
                         space="my_space",
@@ -143,7 +148,13 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                                 direction="outwards",
                             )
                         },
-                        filter=None,
+                        filter=dm.filters.Equals(
+                            ["node", "type"],
+                            {
+                                "space": "my_space",
+                                "externalId": "WindFarm",
+                            },
+                        ),
                     ),
                 ]
             ),

--- a/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
@@ -175,7 +175,18 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                     ),
                 ]
             ),
-            node_types=dm.NodeApplyList([]),
+            node_types=dm.NodeApplyList(
+                [
+                    dm.NodeApply(
+                        space="my_space",
+                        external_id="WindTurbine",
+                    ),
+                    dm.NodeApply(
+                        space="my_space",
+                        external_id="WindFarm",
+                    ),
+                ]
+            ),
         ),
         id="Two properties, one container, one view",
     )


### PR DESCRIPTION
Adds `Filter` column that can be either `hasData`, `nodeType`, or `hasData,nodeType`. 

Starting intentionally with minimum of filters supported, lets instead wait for people to request more before we add it. 