### PR TITLE
[NEAT-107] Setup coverage job

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -163,4 +163,4 @@ jobs:
         with:
             coverageFile: coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
-            thresholdAll: 0.7
+            thresholdAll: 0.6

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -62,15 +62,14 @@ jobs:
       - name: Run unit tests
         run: export PYTHONPATH=$PYTHONPATH:$(pwd); poetry run pytest tests/tests_unit
 
-
-      - name: Run integration tests
-        env:
-          CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
-          CDF_PROJECT: ${{ vars.CDF_PROJECT }}
-          IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
-          IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
-          IDP_TENANT_ID: ${{ secrets.IDP_TENANT_ID }}
-        run: export PYTHONPATH=$PYTHONPATH:$(pwd); poetry run pytest tests/tests_integration
+#      - name: Run integration tests
+#        env:
+#          CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
+#          CDF_PROJECT: ${{ vars.CDF_PROJECT }}
+#          IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
+#          IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
+#          IDP_TENANT_ID: ${{ secrets.IDP_TENANT_ID }}
+#        run: export PYTHONPATH=$PYTHONPATH:$(pwd); poetry run pytest tests/tests_integration
 
       # needs update of some dep due to new version of ipynb test
       # - name: Run notebook tests

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -163,3 +163,4 @@ jobs:
         with:
             coverageFile: coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
+            thresholdAll: 0.6

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -156,7 +156,7 @@ jobs:
           IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
           IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
           IDP_TENANT_ID: ${{ secrets.IDP_TENANT_ID }}
-        run: export PYTHONPATH=$PYTHONPATH:$(pwd); pytest --cov=cognite_toolkit/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/
+        run: export PYTHONPATH=$PYTHONPATH:$(pwd); poetry run pytest --cov=cognite_toolkit/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/
 
       - name: Push coverage report to PR
         uses: orgoro/coverage@v3.1

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -156,7 +156,7 @@ jobs:
           IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
           IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
           IDP_TENANT_ID: ${{ secrets.IDP_TENANT_ID }}
-        run: export PYTHONPATH=$PYTHONPATH:$(pwd); poetry run pytest --cov=cognite_toolkit/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/
+        run: export PYTHONPATH=$PYTHONPATH:$(pwd); poetry run pytest --cov=cognite/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/
 
       - name: Push coverage report to PR
         uses: orgoro/coverage@v3.1

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -124,3 +124,43 @@ jobs:
       - name: Build documentation
         run: |
           mkdocs build
+
+
+  coverage:
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.12
+
+      - name: Set up cache
+        uses: actions/cache@v3.3.1
+        with:
+          path: .venv
+          key: venv-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('poetry.lock') }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.5.1
+
+      - run: poetry install -E all
+
+      - name: Create test coverage report
+        env:
+          CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
+          CDF_PROJECT: ${{ vars.CDF_PROJECT }}
+          IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
+          IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
+          IDP_TENANT_ID: ${{ secrets.IDP_TENANT_ID }}
+        run: export PYTHONPATH=$PYTHONPATH:$(pwd); pytest --cov=cognite_toolkit/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/
+
+      - name: Push coverage report to PR
+        uses: orgoro/coverage@v3.1
+        with:
+            coverageFile: coverage.xml
+            token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -163,4 +163,4 @@ jobs:
         with:
             coverageFile: coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
-            thresholdAll: 0.6
+            thresholdAll: 0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ types-setuptools = "^68"
 #cognite-toolkit = {git = "https://github.com/cognitedata/cdf-project-templates.git", branch = "main"}
 
 [tool.coverage.report]
-fail_under = 40
+fail_under = 60
 show_missing = true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,10 +147,6 @@ types-setuptools = "^68"
 # current strict upper bound on cognite-sdk.
 #cognite-toolkit = {git = "https://github.com/cognitedata/cdf-project-templates.git", branch = "main"}
 
-[tool.coverage.report]
-fail_under = 60
-show_missing = true
-
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,11 @@ types-setuptools = "^68"
 # current strict upper bound on cognite-sdk.
 #cognite-toolkit = {git = "https://github.com/cognitedata/cdf-project-templates.git", branch = "main"}
 
+[tool.coverage.report]
+fail_under = 40
+show_missing = true
+
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Removed the integration tests from the regular test job and only run it on the coverage instead. 

Reason is that when we run 3.10 and 3.12 in parallel the integration tests could easily (and is already) interfering with each other. Now we only run integration tests once.