### PR TITLE
[NEAT-156] Line endings

### DIFF
--- a/cognite/neat/rules/exporters/_base.py
+++ b/cognite/neat/rules/exporters/_base.py
@@ -14,6 +14,9 @@ T_Export = TypeVar("T_Export")
 
 
 class BaseExporter(ABC, Generic[T_Export]):
+    _new_line = "\n"
+    _encoding = "utf-8"
+
     @abstractmethod
     def export_to_file(self, rules: Rules, filepath: Path) -> None:
         raise NotImplementedError

--- a/cognite/neat/rules/exporters/_rules2dms.py
+++ b/cognite/neat/rules/exporters/_rules2dms.py
@@ -53,6 +53,8 @@ class DMSExporter(CDFExporter[DMSSchema]):
 
     """
 
+    _line_endings = "\n"
+
     def __init__(
         self,
         export_components: Component | Collection[Component] = "all",
@@ -88,7 +90,7 @@ class DMSExporter(CDFExporter[DMSSchema]):
     def _export_to_directory(self, directory: Path, rules: Rules) -> None:
         schema = self.export(rules)
         exclude = self._create_exclude_set()
-        schema.to_directory(directory, exclude=exclude)
+        schema.to_directory(directory, exclude=exclude, new_line=self._line_endings)
 
     def _export_to_zip_file(self, filepath: Path, rules: Rules) -> None:
         if filepath.suffix not in {".zip"}:

--- a/cognite/neat/rules/exporters/_rules2dms.py
+++ b/cognite/neat/rules/exporters/_rules2dms.py
@@ -53,7 +53,7 @@ class DMSExporter(CDFExporter[DMSSchema]):
 
     """
 
-    _line_endings = "\n"
+    _new_line = "\n"
 
     def __init__(
         self,
@@ -90,7 +90,7 @@ class DMSExporter(CDFExporter[DMSSchema]):
     def _export_to_directory(self, directory: Path, rules: Rules) -> None:
         schema = self.export(rules)
         exclude = self._create_exclude_set()
-        schema.to_directory(directory, exclude=exclude, new_line=self._line_endings)
+        schema.to_directory(directory, exclude=exclude, new_line=self._new_line)
 
     def _export_to_zip_file(self, filepath: Path, rules: Rules) -> None:
         if filepath.suffix not in {".zip"}:

--- a/cognite/neat/rules/exporters/_rules2dms.py
+++ b/cognite/neat/rules/exporters/_rules2dms.py
@@ -53,8 +53,6 @@ class DMSExporter(CDFExporter[DMSSchema]):
 
     """
 
-    _new_line = "\n"
-
     def __init__(
         self,
         export_components: Component | Collection[Component] = "all",
@@ -90,7 +88,7 @@ class DMSExporter(CDFExporter[DMSSchema]):
     def _export_to_directory(self, directory: Path, rules: Rules) -> None:
         schema = self.export(rules)
         exclude = self._create_exclude_set()
-        schema.to_directory(directory, exclude=exclude, new_line=self._new_line)
+        schema.to_directory(directory, exclude=exclude, new_line=self._new_line, encoding=self._encoding)
 
     def _export_to_zip_file(self, filepath: Path, rules: Rules) -> None:
         if filepath.suffix not in {".zip"}:

--- a/cognite/neat/rules/exporters/_rules2ontology.py
+++ b/cognite/neat/rules/exporters/_rules2ontology.py
@@ -33,7 +33,7 @@ from cognite.neat.rules._shared import Rules
 
 class GraphExporter(BaseExporter[Graph], ABC):
     def export_to_file(self, rules: Rules, filepath: Path) -> None:
-        self.export(rules).serialize(destination=filepath)
+        self.export(rules).serialize(destination=filepath, encoding=self._encoding, newline=self._new_line)
 
 
 class OWLExporter(GraphExporter):

--- a/cognite/neat/rules/exporters/_rules2yaml.py
+++ b/cognite/neat/rules/exporters/_rules2yaml.py
@@ -22,7 +22,7 @@ class YAMLExporter(BaseExporter[str]):
 
     The following formats are available:
 
-    - "single": A single YAML file will containe the entire rules.
+    - "single": A single YAML file will contain the entire rules.
 
     .. note::
 
@@ -37,8 +37,6 @@ class YAMLExporter(BaseExporter[str]):
 
     file_option = get_args(Files)
     format_option = get_args(Format)
-
-    _new_line = "\n"
 
     def __init__(self, files: Files = "single", output: Format = "yaml", output_role: RoleTypes | None = None):
         if files not in self.file_option:
@@ -55,7 +53,7 @@ class YAMLExporter(BaseExporter[str]):
             if filepath.suffix != f".{self.output}":
                 warnings.warn(f"File extension is not .{self.output}, adding it to the file name", stacklevel=2)
                 filepath = filepath.with_suffix(f".{self.output}")
-            filepath.write_text(self.export(rules), encoding="utf-8", newline=self._new_line)
+            filepath.write_text(self.export(rules), encoding=self._encoding, newline=self._new_line)
         else:
             raise NotImplementedError(f"Exporting to {self.files} files is not supported")
 

--- a/cognite/neat/rules/exporters/_rules2yaml.py
+++ b/cognite/neat/rules/exporters/_rules2yaml.py
@@ -38,6 +38,8 @@ class YAMLExporter(BaseExporter[str]):
     file_option = get_args(Files)
     format_option = get_args(Format)
 
+    _new_line = "\n"
+
     def __init__(self, files: Files = "single", output: Format = "yaml", output_role: RoleTypes | None = None):
         if files not in self.file_option:
             raise ValueError(f"Invalid files: {files}. Valid options are {self.file_option}")
@@ -53,7 +55,7 @@ class YAMLExporter(BaseExporter[str]):
             if filepath.suffix != f".{self.output}":
                 warnings.warn(f"File extension is not .{self.output}, adding it to the file name", stacklevel=2)
                 filepath = filepath.with_suffix(f".{self.output}")
-            filepath.write_text(self.export(rules))
+            filepath.write_text(self.export(rules), encoding="utf-8", newline=self._new_line)
         else:
             raise NotImplementedError(f"Exporting to {self.files} files is not supported")
 

--- a/cognite/neat/rules/models/_rules/dms_schema.py
+++ b/cognite/neat/rules/models/_rules/dms_schema.py
@@ -111,12 +111,13 @@ class DMSSchema:
                         data[attr_name].append(loaded)
         return data
 
-    def to_directory(self, directory: str | Path, exclude: set[str] | None = None) -> None:
+    def to_directory(self, directory: str | Path, exclude: set[str] | None = None, new_line: str | None = "\n") -> None:
         """Save the schema to a directory as YAML files. This is compatible with the Cognite-Toolkit convention.
 
         Args:
             directory (str | Path): The directory to save the schema to.
             exclude (set[str]): A set of attributes to exclude from the output.
+            new_line (str): The line endings to use in the output files. Defaults to "\n".
         """
         path_dir = Path(directory)
         exclude_set = exclude or set()
@@ -124,25 +125,27 @@ class DMSSchema:
         data_models.mkdir(parents=True, exist_ok=True)
         if "spaces" not in exclude_set:
             for space in self.spaces:
-                (data_models / f"{space.space}.space.yaml").write_text(space.dump_yaml())
+                (data_models / f"{space.space}.space.yaml").write_text(space.dump_yaml(), newline=new_line)
         if "data_models" not in exclude_set:
             for model in self.data_models:
-                (data_models / f"{model.external_id}.datamodel.yaml").write_text(model.dump_yaml())
+                (data_models / f"{model.external_id}.datamodel.yaml").write_text(model.dump_yaml(), newline=new_line)
         if "views" not in exclude_set and self.views:
             view_dir = data_models / "views"
             view_dir.mkdir(parents=True, exist_ok=True)
             for view in self.views:
-                (view_dir / f"{view.external_id}.view.yaml").write_text(view.dump_yaml())
+                (view_dir / f"{view.external_id}.view.yaml").write_text(view.dump_yaml(), newline=new_line)
         if "containers" not in exclude_set and self.containers:
             container_dir = data_models / "containers"
             container_dir.mkdir(parents=True, exist_ok=True)
             for container in self.containers:
-                (container_dir / f"{container.external_id}.container.yaml").write_text(container.dump_yaml())
+                (container_dir / f"{container.external_id}.container.yaml").write_text(
+                    container.dump_yaml(), newline=new_line
+                )
         if "node_types" not in exclude_set and self.node_types:
             node_dir = data_models / "nodes"
             node_dir.mkdir(parents=True, exist_ok=True)
             for node in self.node_types:
-                (node_dir / f"{node.external_id}.node.yaml").write_text(node.dump_yaml())
+                (node_dir / f"{node.external_id}.node.yaml").write_text(node.dump_yaml(), newline=new_line)
 
     @classmethod
     def from_zip(cls, zip_file: str | Path) -> Self:
@@ -401,7 +404,7 @@ class PipelineSchema(DMSSchema):
                     data[attr_name].append(loaded)
         return data
 
-    def to_directory(self, directory: str | Path, exclude: set[str] | None = None) -> None:
+    def to_directory(self, directory: str | Path, exclude: set[str] | None = None, new_line: str | None = "\n") -> None:
         super().to_directory(directory, exclude)
         exclude_set = exclude or set()
         path_dir = Path(directory)
@@ -409,14 +412,16 @@ class PipelineSchema(DMSSchema):
             transformation_dir = path_dir / "transformations"
             transformation_dir.mkdir(exist_ok=True, parents=True)
             for transformation in self.transformations:
-                (transformation_dir / f"{transformation.external_id}.yaml").write_text(transformation.dump_yaml())
+                (transformation_dir / f"{transformation.external_id}.yaml").write_text(
+                    transformation.dump_yaml(), newline=new_line
+                )
         if "raw" not in exclude_set and self.raw_tables:
             # The RAW Databases are not written to file. This is because cognite-toolkit expects the RAW databases
             # to be in the same file as the RAW tables.
             raw_dir = path_dir / "raw"
             raw_dir.mkdir(exist_ok=True, parents=True)
             for raw_table in self.raw_tables:
-                (raw_dir / f"{raw_table.name}.yaml").write_text(raw_table.dump_yaml())
+                (raw_dir / f"{raw_table.name}.yaml").write_text(raw_table.dump_yaml(), newline=new_line)
 
     def to_zip(self, zip_file: str | Path, exclude: set[str] | None = None) -> None:
         super().to_zip(zip_file, exclude)

--- a/cognite/neat/rules/models/_rules/dms_schema.py
+++ b/cognite/neat/rules/models/_rules/dms_schema.py
@@ -124,6 +124,7 @@ class DMSSchema:
             directory (str | Path): The directory to save the schema to.
             exclude (set[str]): A set of attributes to exclude from the output.
             new_line (str): The line endings to use in the output files. Defaults to "\n".
+            encoding (str): The encoding to use in the output files. Defaults to "utf-8".
         """
         path_dir = Path(directory)
         exclude_set = exclude or set()

--- a/cognite/neat/rules/models/_rules/dms_schema.py
+++ b/cognite/neat/rules/models/_rules/dms_schema.py
@@ -111,7 +111,13 @@ class DMSSchema:
                         data[attr_name].append(loaded)
         return data
 
-    def to_directory(self, directory: str | Path, exclude: set[str] | None = None, new_line: str | None = "\n") -> None:
+    def to_directory(
+        self,
+        directory: str | Path,
+        exclude: set[str] | None = None,
+        new_line: str | None = "\n",
+        encoding: str | None = "utf-8",
+    ) -> None:
         """Save the schema to a directory as YAML files. This is compatible with the Cognite-Toolkit convention.
 
         Args:
@@ -125,27 +131,35 @@ class DMSSchema:
         data_models.mkdir(parents=True, exist_ok=True)
         if "spaces" not in exclude_set:
             for space in self.spaces:
-                (data_models / f"{space.space}.space.yaml").write_text(space.dump_yaml(), newline=new_line)
+                (data_models / f"{space.space}.space.yaml").write_text(
+                    space.dump_yaml(), newline=new_line, encoding=encoding
+                )
         if "data_models" not in exclude_set:
             for model in self.data_models:
-                (data_models / f"{model.external_id}.datamodel.yaml").write_text(model.dump_yaml(), newline=new_line)
+                (data_models / f"{model.external_id}.datamodel.yaml").write_text(
+                    model.dump_yaml(), newline=new_line, encoding=encoding
+                )
         if "views" not in exclude_set and self.views:
             view_dir = data_models / "views"
             view_dir.mkdir(parents=True, exist_ok=True)
             for view in self.views:
-                (view_dir / f"{view.external_id}.view.yaml").write_text(view.dump_yaml(), newline=new_line)
+                (view_dir / f"{view.external_id}.view.yaml").write_text(
+                    view.dump_yaml(), newline=new_line, encoding=encoding
+                )
         if "containers" not in exclude_set and self.containers:
             container_dir = data_models / "containers"
             container_dir.mkdir(parents=True, exist_ok=True)
             for container in self.containers:
                 (container_dir / f"{container.external_id}.container.yaml").write_text(
-                    container.dump_yaml(), newline=new_line
+                    container.dump_yaml(), newline=new_line, encoding=encoding
                 )
         if "node_types" not in exclude_set and self.node_types:
             node_dir = data_models / "nodes"
             node_dir.mkdir(parents=True, exist_ok=True)
             for node in self.node_types:
-                (node_dir / f"{node.external_id}.node.yaml").write_text(node.dump_yaml(), newline=new_line)
+                (node_dir / f"{node.external_id}.node.yaml").write_text(
+                    node.dump_yaml(), newline=new_line, encoding=encoding
+                )
 
     @classmethod
     def from_zip(cls, zip_file: str | Path) -> Self:
@@ -404,7 +418,13 @@ class PipelineSchema(DMSSchema):
                     data[attr_name].append(loaded)
         return data
 
-    def to_directory(self, directory: str | Path, exclude: set[str] | None = None, new_line: str | None = "\n") -> None:
+    def to_directory(
+        self,
+        directory: str | Path,
+        exclude: set[str] | None = None,
+        new_line: str | None = "\n",
+        encoding: str | None = "utf-8",
+    ) -> None:
         super().to_directory(directory, exclude)
         exclude_set = exclude or set()
         path_dir = Path(directory)
@@ -413,7 +433,7 @@ class PipelineSchema(DMSSchema):
             transformation_dir.mkdir(exist_ok=True, parents=True)
             for transformation in self.transformations:
                 (transformation_dir / f"{transformation.external_id}.yaml").write_text(
-                    transformation.dump_yaml(), newline=new_line
+                    transformation.dump_yaml(), newline=new_line, encoding=encoding
                 )
         if "raw" not in exclude_set and self.raw_tables:
             # The RAW Databases are not written to file. This is because cognite-toolkit expects the RAW databases
@@ -421,7 +441,9 @@ class PipelineSchema(DMSSchema):
             raw_dir = path_dir / "raw"
             raw_dir.mkdir(exist_ok=True, parents=True)
             for raw_table in self.raw_tables:
-                (raw_dir / f"{raw_table.name}.yaml").write_text(raw_table.dump_yaml(), newline=new_line)
+                (raw_dir / f"{raw_table.name}.yaml").write_text(
+                    raw_table.dump_yaml(), newline=new_line, encoding=encoding
+                )
 
     def to_zip(self, zip_file: str | Path, exclude: set[str] | None = None) -> None:
         super().to_zip(zip_file, exclude)


### PR DESCRIPTION
**Problem**: By default, when `Python` write to file it uses the default line endings of the OS system. This leads to problem when using neat to generate data models which are checked into Git history, as two users with different OSes, will get a massive diff due to the line endings.


**Suggested solution**: Neat is opinionated about the line endings (and encodings) to ensure consistent user experience between different OSes.

**Why hide it?** On the importers this is a hidden configuration (private class attribute). The reason for this is that importers are made for the most basic user that should not try to change this. However, in an edge case when someone wants to change it, they can although with no guarantee from **NEAT** that it will continue to work :) 

