### PR TITLE
[NEAT-177] Reference edge type

### DIFF
--- a/cognite/neat/rules/models/_rules/dms_architect_rules.py
+++ b/cognite/neat/rules/models/_rules/dms_architect_rules.py
@@ -735,11 +735,22 @@ class _DMSExporter:
                             "Multiedge relation must have a view as value type. "
                             "This should have been validated in the rules"
                         )
-                    view_property = dm.MultiEdgeConnectionApply(
-                        type=dm.DirectRelationReference(
+                    if isinstance(prop.reference, ReferenceEntity):
+                        ref_view_prop = prop.reference.as_prop_id(
+                            default_space, default_version, self.standardize_casing
+                        )
+                        edge_type = dm.DirectRelationReference(
+                            space=ref_view_prop.source.space,
+                            external_id=f"{ref_view_prop.source.external_id}.{ref_view_prop.property}",
+                        )
+                    else:
+                        edge_type = dm.DirectRelationReference(
                             space=source.space,
                             external_id=f"{prop.view.external_id}.{prop.view_property}",
-                        ),
+                        )
+
+                    view_property = dm.MultiEdgeConnectionApply(
+                        type=edge_type,
                         source=source,
                         direction="outwards",
                     )
@@ -768,6 +779,7 @@ class _DMSExporter:
                         view_property = dm.MultiEdgeConnectionApply(
                             type=dm.DirectRelationReference(
                                 space=source.space,
+                                # Todo Need to use the reference if it is there
                                 external_id=f"{reverse_prop.view.external_id}.{reverse_prop.view_property}",
                             ),
                             source=source,

--- a/cognite/neat/rules/models/_rules/dms_architect_rules.py
+++ b/cognite/neat/rules/models/_rules/dms_architect_rules.py
@@ -776,12 +776,21 @@ class _DMSExporter:
                         warnings.warn(
                             issues.dms.ReverseOfDirectRelationListWarning(view_id, prop.property_), stacklevel=2
                         )
-                        view_property = dm.MultiEdgeConnectionApply(
-                            type=dm.DirectRelationReference(
+                        if isinstance(reverse_prop.reference, ReferenceEntity):
+                            ref_view_prop = reverse_prop.reference.as_prop_id(
+                                default_space, default_version, self.standardize_casing
+                            )
+                            edge_type = dm.DirectRelationReference(
+                                space=ref_view_prop.source.space,
+                                external_id=f"{ref_view_prop.source.external_id}.{ref_view_prop.property}",
+                            )
+                        else:
+                            edge_type = dm.DirectRelationReference(
                                 space=source.space,
-                                # Todo Need to use the reference if it is there
                                 external_id=f"{reverse_prop.view.external_id}.{reverse_prop.view_property}",
-                            ),
+                            )
+                        view_property = dm.MultiEdgeConnectionApply(
+                            type=edge_type,
                             source=source,
                             direction="inwards",
                         )

--- a/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
@@ -771,12 +771,12 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
             data=[
                 DMSProperty(
                     class_="Asset",
-                    property_="children",
+                    property_="kinderen",
                     value_type="Asset",
                     relation="multiedge",
                     reference="sp_enterprise:enterprise_model(property=children)",
                     view="Asset",
-                    view_property="children",
+                    view_property="kinderen",
                 ),
             ]
         ),

--- a/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
@@ -774,7 +774,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                     property_="kinderen",
                     value_type="Asset",
                     relation="multiedge",
-                    reference="sp_enterprise:enterprise_model(property=children)",
+                    reference="sp_enterprise:Asset(property=children)",
                     view="Asset",
                     view_property="kinderen",
                 ),
@@ -800,7 +800,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                     external_id="Asset",
                     version="1",
                     properties={
-                        "children": dm.MultiEdgeConnectionApply(
+                        "kinderen": dm.MultiEdgeConnectionApply(
                             type=dm.DirectRelationReference(
                                 space="sp_enterprise",
                                 external_id="Asset.children",
@@ -826,6 +826,7 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
                 )
             ]
         ),
+        node_types=dm.NodeApplyList([dm.NodeApply(space="sp_solution", external_id="Asset", sources=[])]),
     )
 
     yield pytest.param(

--- a/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
@@ -723,6 +723,118 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
         id="No casing standardization",
     )
 
+    DMSRules(
+        metadata=DMSMetadata(
+            schema_="complete",
+            space="sp_enterprise",
+            external_id="enterprise_model",
+            version="1",
+            creator="Alice",
+            created="2021-01-01T00:00:00",
+            updated="2021-01-01T00:00:00",
+        ),
+        properties=SheetList[DMSProperty](
+            data=[
+                DMSProperty(
+                    class_="Asset",
+                    property_="children",
+                    value_type="Asset",
+                    relation="multiedge",
+                    view="Asset",
+                    view_property="children",
+                ),
+            ]
+        ),
+        containers=SheetList[DMSContainer](
+            data=[
+                DMSContainer(container="Asset", class_="Asset"),
+            ]
+        ),
+        views=SheetList[DMSView](
+            data=[
+                DMSView(view="Asset", class_="Asset"),
+            ]
+        ),
+    )
+
+    dms_rules = DMSRules(
+        metadata=DMSMetadata(
+            schema_="extended",
+            space="sp_solution",
+            external_id="solution_model",
+            version="1",
+            creator="Bob",
+            created="2021-01-01T00:00:00",
+            updated="2021-01-01T00:00:00",
+        ),
+        properties=SheetList[DMSProperty](
+            data=[
+                DMSProperty(
+                    class_="Asset",
+                    property_="children",
+                    value_type="Asset",
+                    relation="multiedge",
+                    reference="sp_enterprise:enterprise_model(property=children)",
+                    view="Asset",
+                    view_property="children",
+                ),
+            ]
+        ),
+        views=SheetList[DMSView](
+            data=[
+                DMSView(view="Asset", class_="Asset"),
+            ]
+        ),
+    )
+
+    expected_schema = DMSSchema(
+        spaces=dm.SpaceApplyList(
+            [
+                dm.SpaceApply(space="sp_solution"),
+            ]
+        ),
+        views=dm.ViewApplyList(
+            [
+                dm.ViewApply(
+                    space="sp_solution",
+                    external_id="Asset",
+                    version="1",
+                    properties={
+                        "children": dm.MultiEdgeConnectionApply(
+                            type=dm.DirectRelationReference(
+                                space="sp_enterprise",
+                                external_id="Asset.children",
+                            ),
+                            source=dm.ViewId("sp_solution", "Asset", "1"),
+                            direction="outwards",
+                        ),
+                    },
+                    filter=dm.filters.Equals(["node", "type"], {"space": "sp_solution", "externalId": "Asset"}),
+                ),
+            ]
+        ),
+        data_models=dm.DataModelApplyList(
+            [
+                dm.DataModelApply(
+                    space="sp_solution",
+                    external_id="solution_model",
+                    version="1",
+                    description="Creator: Bob",
+                    views=[
+                        dm.ViewId(space="sp_solution", external_id="Asset", version="1"),
+                    ],
+                )
+            ]
+        ),
+    )
+
+    yield pytest.param(
+        dms_rules,
+        expected_schema,
+        True,
+        id="Edge Reference to another data model",
+    )
+
 
 def valid_rules_tests_cases() -> Iterable[ParameterSet]:
     yield pytest.param(


### PR DESCRIPTION
**Problem** When referencing the edge.type should be set to the original type. This is not happening.

Here is the manual fixe needed in the customer project when trying to build a solution model and reuse a multiedge property, 
and being surprised when no edges showed up. 


![image](https://github.com/cognitedata/neat/assets/60234212/d9ff693c-3b14-4dd3-80e7-7d6f3a4b6401)
