### PR TITLE
[Preperation for NEAT-154] Refactor excel importer to do one instantiation.

### DIFF
--- a/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_architect_rules.py
@@ -718,43 +718,9 @@ def rules_schema_tests_cases() -> Iterable[ParameterSet]:
         id="No casing standardization",
     )
 
-    DMSRules(
-        metadata=DMSMetadata(
-            schema_="complete",
-            space="sp_enterprise",
-            external_id="enterprise_model",
-            version="1",
-            creator="Alice",
-            created="2021-01-01T00:00:00",
-            updated="2021-01-01T00:00:00",
-        ),
-        properties=SheetList[DMSProperty](
-            data=[
-                DMSProperty(
-                    class_="Asset",
-                    property_="children",
-                    value_type="Asset",
-                    relation="multiedge",
-                    view="Asset",
-                    view_property="children",
-                ),
-            ]
-        ),
-        containers=SheetList[DMSContainer](
-            data=[
-                DMSContainer(container="Asset", class_="Asset"),
-            ]
-        ),
-        views=SheetList[DMSView](
-            data=[
-                DMSView(view="Asset", class_="Asset"),
-            ]
-        ),
-    )
-
     dms_rules = DMSRules(
         metadata=DMSMetadata(
-            schema_="extended",
+            schema_="complete",
             space="sp_solution",
             external_id="solution_model",
             version="1",


### PR DESCRIPTION
This is a pure refactor to prepare for #378 

**Problem** Current implementation of `ExceImporter` reads a sheets with a reference model and instantiate a `Rule` object for `Reference` and one for `User` rules. When you start to add validation when `schema=extended` this triggers validation on instantiation of the User Rule object and fails because the User rules without reference set it fails.

**Solution** This gather the data from `Reference` and `User` rules and creates a single `dict` that is used to instantiate a `Rule` object for the user rules this time with the `reference` set. 


**In addition** Removing some unused test data