### PR TITLE
[NEAT-209] DMSExporter Support skipping node_types

### DIFF
--- a/cognite/neat/rules/exporters/_rules2dms.py
+++ b/cognite/neat/rules/exporters/_rules2dms.py
@@ -27,7 +27,7 @@ from cognite.neat.utils.cdf_loaders import (
 from ._base import CDFExporter
 from ._models import UploadResult
 
-Component: TypeAlias = Literal["all", "spaces", "data_models", "views", "containers"]
+Component: TypeAlias = Literal["all", "spaces", "data_models", "views", "containers", "node_types"]
 
 
 class DMSExporter(CDFExporter[DMSSchema]):
@@ -99,7 +99,7 @@ class DMSExporter(CDFExporter[DMSSchema]):
         if "all" in self.export_components:
             exclude = set()
         else:
-            exclude = {"spaces", "data_models", "views", "containers"} - self.export_components
+            exclude = {"spaces", "data_models", "views", "containers", "node_types"} - self.export_components
         return exclude
 
     def export(self, rules: Rules) -> DMSSchema:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+### Added
+- `DMSExporter` now supports skipping of export of `node_types`.
+
 ## [0.75.5] - 24-05-24
 ### Fixed
 - Potential of having duplicated spaces are now fixed


### PR DESCRIPTION
Turns out it was already implemented but not exposed in the `DMSExporter`