### PR TITLE
[NEAT-183] Refactor entities

### DIFF
--- a/cognite/neat/rules/models/entities.py
+++ b/cognite/neat/rules/models/entities.py
@@ -196,6 +196,9 @@ class ClassEntity(Entity):
 class ParentClassEntity(ClassEntity):
     type_: ClassVar[EntityTypes] = EntityTypes.parent_class
 
+    def as_class_entity(self) -> ClassEntity:
+        return ClassEntity(prefix=self.prefix, suffix=self.suffix, version=self.version)
+
 
 T_ID = TypeVar("T_ID", bound=ContainerId | ViewId | DataModelId | PropertyId)
 

--- a/cognite/neat/rules/models/entities.py
+++ b/cognite/neat/rules/models/entities.py
@@ -162,9 +162,21 @@ class Entity(BaseModel):
         else:
             return f"{self.prefix}:{self.suffix!s}"
 
+    @property
+    def versioned_id(self) -> str:
+        # Todo: Remove. Is here for backwards compatibility
+        return self.id
+
+    def as_non_versioned_entity(self) -> str:
+        # Todo: Remove. Is here for backwards compatibility
+        if self.prefix is Undefined:
+            return f"{self.suffix!s}"
+        return f"{self.prefix}:{self.suffix!s}"
+
 
 class ClassEntity(Entity):
     type_: ClassVar[EntityTypes] = EntityTypes.class_
+    version: str | None = None
 
 
 class ParentClassEntity(Entity):

--- a/cognite/neat/rules/models/entities.py
+++ b/cognite/neat/rules/models/entities.py
@@ -90,6 +90,9 @@ class Entity(BaseModel):
             return data.model_dump()
         elif isinstance(data, dict):
             return data
+        elif hasattr(data, "versioned_id"):
+            # Todo: Remove. Is here for backwards compatibility
+            data = data.versioned_id
         elif not isinstance(data, str):
             raise ValueError(f"Cannot load {cls.__name__} from {data}")
 

--- a/cognite/neat/rules/models/entities.py
+++ b/cognite/neat/rules/models/entities.py
@@ -110,9 +110,7 @@ class Entity(BaseModel):
         return str(self)
 
     def as_tuple(self) -> tuple[str, ...]:
-        extra: tuple[str, ...] = tuple(
-            [v if isinstance(v, str) else str(v or "") for v in self.model_dump().items() if isinstance(v, str | None)]
-        )
+        extra: tuple[str, ...] = tuple([str(v or "") for v in self.model_dump().items() if isinstance(v, str | None)])
         if isinstance(self.prefix, _Undefined):
             return str(self.suffix), *extra
         else:

--- a/cognite/neat/rules/models/entities.py
+++ b/cognite/neat/rules/models/entities.py
@@ -1,0 +1,208 @@
+import re
+import sys
+from functools import total_ordering
+from typing import Any, ClassVar, cast
+
+from cognite.client.data_classes.data_modeling.ids import ContainerId, DataModelId, ViewId
+from pydantic import BaseModel
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+    from typing import Self
+else:
+    from backports.strenum import StrEnum
+    from typing_extensions import Self
+
+
+class EntityTypes(StrEnum):
+    view_non_versioned = "view_non_versioned"
+    subject = "subject"
+    predicate = "predicate"
+    object = "object"
+    class_ = "class"
+    parent_class = "parent_class"
+    property_ = "property"
+    object_property = "ObjectProperty"
+    data_property = "DatatypeProperty"
+    annotation_property = "AnnotationProperty"
+    object_value_type = "object_value_type"
+    data_value_type = "data_value_type"  # these are strings, floats, ...
+    xsd_value_type = "xsd_value_type"
+    dms_value_type = "dms_value_type"
+    view = "view"
+    view_prop = "view_prop"
+    reference_entity = "reference_entity"
+    container = "container"
+    datamodel = "datamodel"
+    undefined = "undefined"
+
+
+# ALLOWED
+_ALLOWED_PATTERN = r"[^a-zA-Z0-9-_.]"
+
+# FOR PARSING STRINGS:
+_PREFIX_REGEX = r"[a-zA-Z]+[a-zA-Z0-9-_.]*[a-zA-Z0-9]+"
+_SUFFIX_REGEX = r"[a-zA-Z0-9-_.]+[a-zA-Z0-9]|[-_.]*[a-zA-Z0-9]+"
+_VERSION_REGEX = r"[a-zA-Z0-9]([.a-zA-Z0-9_-]{0,41}[a-zA-Z0-9])?"
+_PROPERTY_REGEX = r"[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]?"
+_ENTITY_ID_REGEX = rf"{_PREFIX_REGEX}:({_SUFFIX_REGEX})"
+_ENTITY_ID_REGEX_COMPILED = re.compile(rf"^(?P<prefix>{_PREFIX_REGEX}):(?P<suffix>{_SUFFIX_REGEX})$")
+_VERSIONED_ENTITY_REGEX_COMPILED = re.compile(
+    rf"^(?P<prefix>{_PREFIX_REGEX}):(?P<suffix>{_SUFFIX_REGEX})\(version=(?P<version>{_VERSION_REGEX})\)$"
+)
+_CLASS_ID_REGEX = rf"(?P<{EntityTypes.class_}>{_ENTITY_ID_REGEX})"
+_CLASS_ID_REGEX_COMPILED = re.compile(rf"^{_CLASS_ID_REGEX}$")
+_PROPERTY_ID_REGEX = rf"\((?P<{EntityTypes.property_}>{_ENTITY_ID_REGEX})\)"
+
+
+class _Undefined(BaseModel):
+    ...
+
+
+class _Unknown(BaseModel):
+    def __str__(self) -> str:
+        return "#N/A"
+
+
+# This is a trick to make Undefined and Unknown singletons
+Undefined = _Undefined()
+Unknown = _Unknown()
+
+
+@total_ordering
+class Entity(BaseModel):
+    """Entity is a class or property in OWL/RDF sense."""
+
+    type_: ClassVar[EntityTypes] = EntityTypes.undefined
+    prefix: str | _Undefined = Undefined
+    suffix: str | _Unknown
+
+    @classmethod
+    def load(cls, data: Any) -> Self:
+        if isinstance(data, cls):
+            return data
+        elif not isinstance(data, str):
+            raise ValueError(f"Cannot load {cls.__name__} from {data}")
+
+        if result := _ENTITY_ID_REGEX_COMPILED.match(data):
+            return cls(prefix=result.group("prefix"), suffix=result.group("suffix"))
+        elif data == str(Unknown):
+            return cls(prefix=Undefined, suffix=Unknown)
+        else:
+            return cls(prefix=Undefined, suffix=data)
+
+    def dump(self) -> str:
+        return str(self)
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Entity):
+            return NotImplemented
+        return str(self) < str(other)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Entity):
+            return NotImplemented
+        return str(self) == str(other)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def __str__(self) -> str:
+        return self.id
+
+    def __repr__(self) -> str:
+        return f"{self.type_.value}(prefix={self.prefix}, suffix={self.suffix})"
+
+    @property
+    def id(self) -> str:
+        if self.prefix is Undefined:
+            return str(self.suffix)
+        else:
+            return f"{self.prefix}:{self.suffix!s}"
+
+
+class ClassEntity(Entity):
+    type_: ClassVar[EntityTypes] = EntityTypes.class_
+
+
+class ParentClassEntity(Entity):
+    type_: ClassVar[EntityTypes] = EntityTypes.parent_class
+
+
+class DMSEntity(Entity):
+    type_: ClassVar[EntityTypes] = EntityTypes.undefined
+    suffix: str
+
+    @property
+    def space(self) -> str:
+        """Returns entity space in CDF."""
+        if self.prefix is Undefined:
+            raise NotImplementedError()
+            # if default_space is None:
+        else:
+            return cast(str, self.prefix)
+
+    @property
+    def external_id(self) -> str:
+        """Returns entity external id in CDF."""
+        return self.suffix
+
+
+class ContainerEntity(DMSEntity):
+    type_: ClassVar[EntityTypes] = EntityTypes.container
+
+    def as_id(self) -> ContainerId:
+        return ContainerId(space=self.space, external_id=self.external_id)
+
+
+class ViewNonVersionedEntity(DMSEntity):
+    _type = EntityTypes.view_non_versioned
+
+    def as_id(self) -> ViewId:
+        return ViewId(space=self.space, external_id=self.external_id)
+
+
+class DMSVersionedEntity(DMSEntity):
+    version: str | None = None
+
+    def __str__(self) -> str:
+        if self.version is None:
+            return self.id
+        return f"{self.id}(version={self.version})"
+
+    @classmethod
+    def load(cls, data: Any) -> Self:
+        if isinstance(data, str) and (result := _VERSIONED_ENTITY_REGEX_COMPILED.match(data)):
+            return cls(prefix=result.group("prefix"), suffix=result.group("suffix"), version=result.group("version"))
+        return super().load(data)
+
+
+class ViewEntity(DMSVersionedEntity):
+    type_: ClassVar[EntityTypes] = EntityTypes.view
+
+    def as_id(
+        self,
+    ) -> ViewId:
+        return ViewId(space=self.space, external_id=self.external_id, version=self.version)
+
+
+class ViewPropEntity(DMSVersionedEntity):
+    type_: ClassVar[EntityTypes] = EntityTypes.view_prop
+    property_: str
+
+    @classmethod
+    def load(cls, data: Any) -> Self:
+        raise NotImplementedError()
+        # if isinstance(data, str) and (result := _PROPERTY_ID_REGEX.match(data)):
+        #     return cls(
+
+
+class DataModelEntity(DMSVersionedEntity):
+    type_: ClassVar[EntityTypes] = EntityTypes.datamodel
+
+    def as_id(self) -> DataModelId:
+        return DataModelId(space=self.space, external_id=self.external_id, version=self.version)
+
+
+class ReferenceEntity(ViewPropEntity):
+    type_: ClassVar[EntityTypes] = EntityTypes.reference_entity

--- a/cognite/neat/rules/models/entities.py
+++ b/cognite/neat/rules/models/entities.py
@@ -160,10 +160,21 @@ class Entity(BaseModel):
 
     @property
     def id(self) -> str:
+        # We have overwritten the serialization to str, so we need to do it manually
+        model_dump = (
+            (field.alias or field_name, v)
+            for field_name, field in self.model_fields.items()
+            if (v := getattr(self, field_name)) is not None and field_name not in {"prefix", "suffix"}
+        )
+        args = ",".join([f"{k}={v}" for k, v in model_dump])
         if self.prefix is Undefined:
-            return str(self.suffix)
+            base_id = str(self.suffix)
         else:
-            return f"{self.prefix}:{self.suffix!s}"
+            base_id = f"{self.prefix}:{self.suffix!s}"
+        if args:
+            return f"{base_id}({args})"
+        else:
+            return base_id
 
     @property
     def versioned_id(self) -> str:

--- a/tests/tests_unit/rules/test_models/test_entities.py
+++ b/tests/tests_unit/rules/test_models/test_entities.py
@@ -1,8 +1,19 @@
 from typing import Any
 
 import pytest
+from cognite.client.data_classes.data_modeling import ContainerId, DataModelId, ViewId
 
-from cognite.neat.rules.models.entities import ClassEntity, Entity, PropertyEntity, Undefined, Unknown, ViewEntity
+from cognite.neat.rules.models.entities import (
+    ClassEntity,
+    ContainerEntity,
+    DataModelEntity,
+    DMSEntity,
+    Entity,
+    PropertyEntity,
+    Undefined,
+    Unknown,
+    ViewEntity,
+)
 
 
 class TestEntities:
@@ -45,3 +56,20 @@ class TestEntities:
         loaded = cls_.load(raw)
 
         assert loaded == expected
+
+    @pytest.mark.parametrize(
+        "entity, default_space, expected_id",
+        [
+            (ContainerEntity.load("Person"), "sp_default_space", ContainerId("sp_default_space", "Person")),
+            (ViewEntity.load("Person(version=1.0)"), "sp_default_space", ViewId("sp_default_space", "Person", "1.0")),
+            (
+                DataModelEntity.load("my_space:my_model(version=1)"),
+                "sp_default_space",
+                DataModelId("my_space", "my_model", "1"),
+            ),
+        ],
+    )
+    def test_default_space(self, entity: DMSEntity, default_space: str, expected_id: Any):
+        DMSEntity.set_default_space(default_space)
+
+        assert entity.as_id() == expected_id

--- a/tests/tests_unit/rules/test_models/test_entities.py
+++ b/tests/tests_unit/rules/test_models/test_entities.py
@@ -2,19 +2,46 @@ from typing import Any
 
 import pytest
 
-from cognite.neat.rules.models.entities import Entity, ViewEntity, ViewNonVersionedEntity
+from cognite.neat.rules.models.entities import ClassEntity, Entity, PropertyEntity, Undefined, Unknown, ViewEntity
 
 
 class TestEntities:
     @pytest.mark.parametrize(
-        "cls_, raw",
+        "cls_, raw, expected",
         [
-            (Entity, "subject:person"),
-            (ViewNonVersionedEntity, "subject:person"),
-            (ViewEntity, "subject:person(version=1.0)"),
+            (ClassEntity, "subject:person", ClassEntity(prefix="subject", suffix="person")),
+            (ViewEntity, "subject:person(version=1.0)", ViewEntity(prefix="subject", suffix="person", version="1.0")),
+            (Entity, "#N/A", Entity(prefix=Undefined, suffix=Unknown)),
+            (ViewEntity, "Person", ViewEntity(prefix=Undefined, suffix="Person", version=None)),
+            (ViewEntity, "Person(version=3)", ViewEntity(prefix=Undefined, suffix="Person", version="3")),
+            (
+                PropertyEntity,
+                "Person(property=name)",
+                PropertyEntity(prefix=Undefined, suffix="Person", version=None, property="name"),
+            ),
+            (
+                PropertyEntity,
+                "Person(property=name, version=1)",
+                PropertyEntity(prefix=Undefined, suffix="Person", version="1", property="name"),
+            ),
+            (
+                PropertyEntity,
+                "Person(property=name,version=1)",
+                PropertyEntity(prefix=Undefined, suffix="Person", version="1", property="name"),
+            ),
+            (
+                PropertyEntity,
+                "sp_my_space:Person(property=name,version=1)",
+                PropertyEntity(prefix="sp_my_space", suffix="Person", version="1", property="name"),
+            ),
+            (
+                PropertyEntity,
+                "sp_my_space:Person(version=1, property=name)",
+                PropertyEntity(prefix="sp_my_space", suffix="Person", version="1", property="name"),
+            ),
         ],
     )
-    def test_load_dump(self, cls_: type[Entity], raw: Any) -> None:
+    def test_load(self, cls_: type[Entity], raw: Any, expected: Entity) -> None:
         loaded = cls_.load(raw)
 
-        assert loaded.dump() == str(raw)
+        assert loaded == expected

--- a/tests/tests_unit/rules/test_models/test_entities.py
+++ b/tests/tests_unit/rules/test_models/test_entities.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+import pytest
+
+from cognite.neat.rules.models.entities import Entity, ViewEntity, ViewNonVersionedEntity
+
+
+class TestEntities:
+    @pytest.mark.parametrize(
+        "cls_, raw",
+        [
+            (Entity, "subject:person"),
+            (ViewNonVersionedEntity, "subject:person"),
+            (ViewEntity, "subject:person(version=1.0)"),
+        ],
+    )
+    def test_load_dump(self, cls_: type[Entity], raw: Any) -> None:
+        loaded = cls_.load(raw)
+
+        assert loaded.dump() == str(raw)


### PR DESCRIPTION
## Why Refactor Entities.

* There is a lot of repeated code in the current Entities. 
* This implementation split parsing from validation. This enables us to have Warnings instead of Errors, ref NEAT-59, NEAT-79.
* This implementation has the logic in the base `Entity` class, with relatively easy extensions.