### PR TITLE
feat: Add IMF rules importer

### DIFF
--- a/cognite/neat/rules/importers/__init__.py
+++ b/cognite/neat/rules/importers/__init__.py
@@ -1,6 +1,7 @@
 from ._base import BaseImporter
 from ._dms2rules import DMSImporter
 from ._dtdl2rules import DTDLImporter
+from ._imf2rules import IMFImporter
 from ._inference2rules import InferenceImporter
 from ._owl2rules import OWLImporter
 from ._spreadsheet2rules import ExcelImporter, GoogleSheetImporter
@@ -9,6 +10,7 @@ from ._yaml2rules import YAMLImporter
 __all__ = [
     "BaseImporter",
     "OWLImporter",
+    "IMFImporter",
     "DMSImporter",
     "ExcelImporter",
     "GoogleSheetImporter",

--- a/cognite/neat/rules/importers/_imf2rules/__init__.py
+++ b/cognite/neat/rules/importers/_imf2rules/__init__.py
@@ -1,0 +1,3 @@
+from ._imf2rules import IMFImporter
+
+__all__ = ["IMFImporter"]

--- a/cognite/neat/rules/importers/_imf2rules/_imf2classes.py
+++ b/cognite/neat/rules/importers/_imf2rules/_imf2classes.py
@@ -1,0 +1,240 @@
+from typing import cast
+
+import numpy as np
+import pandas as pd
+from rdflib import OWL, Graph
+
+from cognite.neat.rules.models._base import MatchType
+from cognite.neat.utils.utils import remove_namespace_from_uri
+
+
+def parse_imf_to_classes(graph: Graph, language: str = "en") -> list[dict]:
+    """Parse IMF elements from RDF-graph and extract classes to pandas dataframe.
+
+    Args:
+        graph: Graph containing imf elements
+        language: Language to use for parsing, by default "en"
+
+    Returns:
+        Dataframe containing imf elements
+
+    !!! note "IMF Compliance"
+        The IMF elements are expressed in RDF, primarily using SHACL and OWL. To ensure
+        that the resulting classes are compliant with CDF, similar validation checks as
+        in the OWL ontology importer are applied.
+
+        For the IMF-types more of the compliance logic is placed directly in the SPARQL
+        query. Among these are the creation of class name not starting with a number,
+        and ensuring that all classes have a parent.
+
+        IMF-attributes are considered both classes and properties. This kind of punning
+        is necessary to capture additional information carried by attributes. They carry,
+        among other things, a set of relationsships to reference terms, units of measure,
+        and qualifiers that together make up the meaning of the attribute.
+    """
+
+    query = """
+    SELECT ?class ?name ?description ?parentClass ?reference ?match ?comment
+    WHERE {
+        #Finding IMF - elements
+        VALUES ?type { imf:BlockType imf:TerminalType imf:AttributeType }
+        ?imfClass a ?type .
+        OPTIONAL {?imfClass rdfs:subClassOf ?parent }.
+        OPTIONAL {?imfClass rdfs:label | skos:prefLabel ?name }.
+        OPTIONAL {?imfClass rdfs:comment | skos:description ?description} .
+
+        # Finding the last segment of the class IRI
+        BIND(STR(?imfClass) AS ?classString)
+        BIND(REPLACE(?classString, "^.*[/#]([^/#]*)$", "$1") AS ?classSegment)
+        BIND(IF(CONTAINS(?classString, "imf/"), CONCAT("IMF_", ?classSegment) , ?classSegment) AS ?class)
+
+        # Add imf:Attribute as parent class
+        BIND(IF(!bound(?parent) && ?type = imf:AttributeType, imf:Attribute, ?parent) AS ?parentClass)
+
+        # Rebind the IRI of the IMF-type to the ?reference variable to align with dataframe column headers
+        # This is solely for readability, the ?imfClass could have been returnered directly instead of ?reference
+        BIND(?imfClass AS ?reference)
+
+        FILTER (!isBlank(?class))
+        FILTER (!bound(?parentClass) || !isBlank(?parentClass))
+        FILTER (!bound(?name) || LANG(?name) = "" || LANGMATCHES(LANG(?name), "en"))
+        FILTER (!bound(?description) || LANG(?description) = "" || LANGMATCHES(LANG(?description), "en"))
+    }
+    """
+
+    # create raw dataframe
+    raw_df = _parse_raw_dataframe(cast(list[tuple], list(graph.query(query.replace("en", language)))))
+    if raw_df.empty:
+        return []
+
+    # group values and clean up
+    processed_df = _clean_up_classes(raw_df)
+
+    # make compliant
+    processed_df = make_classes_compliant(processed_df)
+
+    # Make Parent Class list elements into string joined with comma
+    processed_df["Parent Class"] = processed_df["Parent Class"].apply(
+        lambda x: ", ".join(x) if isinstance(x, list) and x else None
+    )
+
+    return processed_df.dropna(axis=0, how="all").replace(float("nan"), None).to_dict(orient="records")
+
+
+def _parse_raw_dataframe(query_results: list[tuple]) -> pd.DataFrame:
+    df = pd.DataFrame(
+        query_results,
+        columns=["Class", "Name", "Description", "Parent Class", "Reference", "Match", "Comment"],
+    )
+    if df.empty:
+        return df
+
+    # # remove NaNs
+    df.replace(np.nan, "", regex=True, inplace=True)
+
+    df["Reference"] = df.Reference
+    df["Class"] = df.Class
+    df["Match Type"] = len(df) * [MatchType.exact]
+    df["Comment"] = len(df) * [None]
+    df["Parent Class"] = df["Parent Class"].apply(lambda x: remove_namespace_from_uri(x))
+
+    return df
+
+
+def _clean_up_classes(df: pd.DataFrame) -> pd.DataFrame:
+    clean_list = [
+        {
+            "Class": class_,
+            "Name": group_df["Name"].unique()[0],
+            "Description": "\n".join(list(group_df["Description"].unique())),
+            "Parent Class": ", ".join(list(group_df["Parent Class"].unique())),
+            "Reference": group_df["Reference"].unique()[0],
+            "Match Type": group_df["Match Type"].unique()[0],
+            "Comment": group_df["Comment"].unique()[0],
+        }
+        for class_, group_df in df.groupby("Class")
+    ]
+
+    df = pd.DataFrame(clean_list)
+
+    # bring NaNs back
+    df.replace("", None, inplace=True)
+
+    # split Parent Class column back into list
+    df["Parent Class"] = df["Parent Class"].apply(lambda x: x.split(", ") if isinstance(x, str) else None)
+
+    return df
+
+
+def make_classes_compliant(classes: pd.DataFrame) -> pd.DataFrame:
+    """Make classes compliant.
+
+    Returns:
+        Dataframe containing compliant classes
+
+    !!! note "About the compliant classes"
+        The compliant classes are based on the OWL base ontology, but adapted to NEAT and use in CDF.
+        One thing to note is that this method would not be able to fix issues with class ids which
+        are not compliant with the CDF naming convention. For example, if a class id contains a space,
+        starts with a number, etc. This will cause issues when trying to create the class in CDF.
+    """
+
+    # Replace empty or non-string values in "Match" column with "exact"
+    classes["Match Type"] = classes["Match Type"].fillna(MatchType.exact)
+    classes["Match Type"] = classes["Match Type"].apply(
+        lambda x: MatchType.exact if not isinstance(x, str) or len(x) == 0 else x
+    )
+
+    # Replace empty or non-string values in "Comment" column with a default value
+    classes["Comment"] = classes["Comment"].fillna("Imported from IMF type by NEAT")
+    classes["Comment"] = classes["Comment"].apply(
+        lambda x: "Imported from IMF by NEAT" if not isinstance(x, str) or len(x) == 0 else x
+    )
+
+    # Add _object_property_class, _data_type_property_class, _thing_class to the dataframe
+    classes = pd.concat(
+        [classes, pd.DataFrame([_object_property_class(), _data_type_property_class(), _thing_class()])],
+        ignore_index=True,
+    )
+
+    # Reduce length of elements in the "Description" column to 1024 characters
+    classes["Description"] = classes["Description"].apply(lambda x: x[:1024] if isinstance(x, str) else None)
+
+    # Add missing parent classes to the dataframe
+    classes = pd.concat(
+        [classes, pd.DataFrame(_add_parent_class(classes))],
+        ignore_index=True,
+    )
+
+    return classes
+
+
+def _object_property_class() -> dict:
+    return {
+        "Class": "ObjectProperty",
+        "Name": None,
+        "Description": "The class of object properties.",
+        "Parent Class": None,
+        "Reference": OWL.ObjectProperty,
+        "Match Type": MatchType.exact,
+        "Comment": "Added by NEAT based on owl:ObjectProperty but adapted to NEAT and use in CDF.",
+    }
+
+
+def _data_type_property_class() -> dict:
+    return {
+        "Class": "DatatypeProperty",
+        "Name": None,
+        "Description": "The class of data properties.",
+        "Parent Class": None,
+        "Reference": OWL.DatatypeProperty,
+        "Match Type": MatchType.exact,
+        "Comment": "Added by NEAT based on owl:DatatypeProperty but adapted to NEAT and use in CDF.",
+    }
+
+
+def _thing_class() -> dict:
+    return {
+        "Class": "Thing",
+        "Name": None,
+        "Description": "The class of holding class individuals.",
+        "Parent Class": None,
+        "Reference": OWL.Thing,
+        "Match Type": MatchType.exact,
+        "Comment": (
+            "Added by NEAT. "
+            "Imported from OWL base ontology, it is meant for use as a default"
+            " value type for object properties which miss a declared range."
+        ),
+    }
+
+
+def _add_parent_class(df: pd.DataFrame) -> list[dict]:
+    parent_set = {
+        item
+        for sublist in df["Parent Class"].tolist()
+        if sublist
+        for item in sublist
+        if item != "" and item is not None
+    }
+    class_set = set(df["Class"].tolist())
+
+    rows = []
+    for missing_parent_class in parent_set.difference(class_set):
+        rows += [
+            {
+                "Class": missing_parent_class,
+                "Name": None,
+                "Description": None,
+                "Parent Class": None,
+                "Reference": None,
+                "Match Type": None,
+                "Comment": (
+                    "Added by NEAT. "
+                    "This is a parent class that is missing in the ontology. "
+                    "It is added by NEAT to make the ontology compliant with CDF."
+                ),
+            }
+        ]
+
+    return rows

--- a/cognite/neat/rules/importers/_imf2rules/_imf2metadata.py
+++ b/cognite/neat/rules/importers/_imf2rules/_imf2metadata.py
@@ -1,0 +1,182 @@
+import datetime
+import re
+
+from rdflib import Namespace
+
+from cognite.neat.rules.models import RoleTypes, SchemaCompleteness
+from cognite.neat.rules.models._types._base import (
+    PREFIX_COMPLIANCE_REGEX,
+    VERSION_COMPLIANCE_REGEX,
+)
+from cognite.neat.utils.utils import convert_rdflib_content
+
+
+def parse_imf_metadata() -> dict:
+    """Provide hardcoded IMF metadata to dict.
+
+    Returns:
+        Dictionary containing IMF metadata
+
+    !!! note "Compliant IMF metadata"
+        The current RDF provide IMF types as SHACL, but there are not any metadata describing
+        the actual content.
+
+    """
+
+    raw_metadata = convert_rdflib_content(
+        {
+            "role": RoleTypes.information_architect,
+            "schema": SchemaCompleteness.partial,
+            "prefix": "imf",
+            "namespace": Namespace("http://posccaesar.org/imf"),
+            "version": None,
+            "created": None,
+            "updated": None,
+            "title": "IMF - types",
+            "description": "IMF - types",
+            "creator": None,
+            "rights": None,
+            "license": None,
+        }
+    )
+
+    return make_metadata_compliant(raw_metadata)
+
+
+def make_metadata_compliant(metadata: dict) -> dict:
+    """Attempts to fix errors in metadata, otherwise defaults to values that will pass validation.
+
+    Args:
+        metadata: Dictionary containing metadata
+
+    Returns:
+        Dictionary containing metadata with fixed errors
+    """
+
+    metadata = fix_namespace(metadata, default=Namespace("https://posccaesar.org/imf/"))
+    metadata = fix_prefix(metadata, default="pca-imf")
+    metadata = fix_version(metadata)
+    metadata = fix_date(metadata, date_type="created", default=datetime.datetime.now().replace(microsecond=0))
+    metadata = fix_date(metadata, date_type="updated", default=datetime.datetime.now().replace(microsecond=0))
+    metadata = fix_title(metadata)
+    metadata = fix_description(metadata)
+    metadata = fix_author(metadata, "creator")
+    metadata = fix_rights(metadata)
+    metadata = fix_license(metadata)
+
+    return metadata
+
+
+def fix_license(metadata: dict, default: str = "Unknown license") -> dict:
+    if license := metadata.get("license", None):
+        if not isinstance(license, str):
+            metadata["license"] = default
+        elif isinstance(license, str) and len(license) == 0:
+            metadata["license"] = default
+    else:
+        metadata["license"] = default
+    return metadata
+
+
+def fix_rights(metadata: dict, default: str = "Unknown rights") -> dict:
+    if rights := metadata.get("rights", None):
+        if not isinstance(rights, str):
+            metadata["rights"] = default
+        elif isinstance(rights, str) and len(rights) == 0:
+            metadata["rights"] = default
+    else:
+        metadata["rights"] = default
+    return metadata
+
+
+def fix_author(metadata: dict, author_type: str = "creator", default: str = "NEAT") -> dict:
+    if author := metadata.get(author_type, None):
+        if not isinstance(author, str) or isinstance(author, list):
+            metadata[author_type] = default
+        elif isinstance(author, str) and len(author) == 0:
+            metadata[author_type] = default
+    else:
+        metadata[author_type] = default
+    return metadata
+
+
+def fix_description(metadata: dict, default: str = "This model has been inferred from OWL ontology") -> dict:
+    if description := metadata.get("description", None):
+        if not isinstance(description, str) or len(description) == 0:
+            metadata["description"] = default
+        elif isinstance(description, str) and len(description) > 1024:
+            metadata["description"] = metadata["description"][:1024]
+    else:
+        metadata["description"] = default
+    return metadata
+
+
+def fix_prefix(metadata: dict, default: str) -> dict:
+    if prefix := metadata.get("prefix", None):
+        if not isinstance(prefix, str) or not re.match(PREFIX_COMPLIANCE_REGEX, prefix):
+            metadata["prefix"] = default
+    else:
+        metadata["prefix"] = default
+    return metadata
+
+
+def fix_namespace(metadata: dict, default: Namespace) -> dict:
+    if namespace := metadata.get("namespace", None):
+        if not isinstance(namespace, Namespace):
+            try:
+                metadata["namespace"] = Namespace(namespace)
+            except Exception:
+                metadata["namespace"] = default
+    else:
+        metadata["namespace"] = default
+
+    return metadata
+
+
+def fix_date(
+    metadata: dict,
+    date_type: str,
+    default: datetime.datetime,
+) -> dict:
+    if date := metadata.get(date_type, None):
+        try:
+            if isinstance(date, datetime.datetime):
+                return metadata
+            elif isinstance(date, datetime.date):
+                metadata[date_type] = datetime.datetime.combine(metadata[date_type], datetime.datetime.min.time())
+            elif isinstance(date, str):
+                metadata[date_type] = datetime.datetime.strptime(metadata[date_type], "%Y-%m-%dT%H:%M:%SZ")
+            else:
+                metadata[date_type] = default
+        except Exception:
+            metadata[date_type] = default
+    else:
+        metadata[date_type] = default
+
+    return metadata
+
+
+def fix_version(metadata: dict, default: str = "1.0.0") -> dict:
+    if version := metadata.get("version", None):
+        if not re.match(VERSION_COMPLIANCE_REGEX, version):
+            metadata["version"] = default
+    else:
+        metadata["version"] = default
+
+    return metadata
+
+
+def fix_title(metadata: dict, default: str = "OWL Inferred Data Model") -> dict:
+    if title := metadata.get("title", None):
+        if not isinstance(title, str):
+            metadata["title"] = default
+        elif isinstance(title, str) and len(title) == 0:
+            metadata["title"] = default
+        elif isinstance(title, str) and len(title) > 255:
+            metadata["title"] = metadata["title"][:255]
+        else:
+            pass
+    else:
+        metadata["title"] = default
+
+    return metadata

--- a/cognite/neat/rules/importers/_imf2rules/_imf2properties.py
+++ b/cognite/neat/rules/importers/_imf2rules/_imf2properties.py
@@ -1,0 +1,259 @@
+from typing import cast
+
+import numpy as np
+import pandas as pd
+from rdflib import Graph, Literal
+
+from cognite.neat.rules.models._base import MatchType
+from cognite.neat.utils.utils import remove_namespace_from_uri
+
+from ._imf2classes import _data_type_property_class, _object_property_class, _thing_class
+
+
+def parse_imf_to_properties(graph: Graph, language: str = "en") -> list[dict]:
+    """Parse IMF elements from RDF-graph and extract properties to pandas dataframe.
+
+    Args:
+        graph: Graph containing imf elements
+        language: Language to use for parsing, by default "en"
+
+    Returns:
+        List of dictionaries containing properties extracted from IMF elements
+
+    !!! note "IMF Compliance"
+        The IMF elements are expressed in RDF, primarily using SHACL and OWL. To ensure
+        that the resulting properties are compliant with CDF, similar validation checks
+        as in the OWL ontology importer are applied.
+
+        For the IMF-types more of the compliance logic is placed directly in the SPARQL
+        query. Among these are the creation of class and property names not starting
+        with a number, ensuring property types as well as default cardinality boundraries.
+
+        IMF-attributes are considered both classes and properties. This kind of punning
+        is necessary to capture additional information carried by attributes. They carry,
+        among other things, a set of relationsships to reference terms, units of measure,
+        and qualifiers that together make up the meaning of the attribute. These references
+        are listed as additional properties with default values.
+    """
+
+    query = """
+    SELECT ?class ?property ?name ?description ?valueType ?minCount ?maxCount ?default ?reference
+    ?match ?comment ?propertyType
+    WHERE
+    {
+        # Finding IMF-blocks and terminals
+        {
+            VALUES ?classType { imf:BlockType imf:TerminalType }
+            ?imfClass a ?classType ;
+                sh:property ?propertyShape .
+                ?propertyShape sh:path ?imfProperty .
+
+            OPTIONAL { ?imfProperty skos:prefLabel ?name . }
+            OPTIONAL { ?imfProperty skos:description ?description . }
+            OPTIONAL { ?imfProperty rdfs:range ?valueType . }
+            OPTIONAL { ?imfProperty a ?type . }
+            OPTIONAL { ?propertyShape sh:minCount ?minCardinality} .
+            OPTIONAL { ?propertyShape sh:maxCount ?maxCardinality} .
+            OPTIONAL { ?propertyShape sh:hasValue | sh:class | sh:qualifiedValueShape/sh:class ?default }
+        }
+        UNION
+        # Finding the IMF-attribute types
+        {
+            ?imfClass a imf:AttributeType ;
+                ?imfProperty ?default .
+
+            # imf:predicate is required
+            BIND(IF(?imfProperty = <http://ns.imfid.org/imf#predicate>, 1, 0) AS ?minCardinality)
+
+            # The following information is used to describe the attribute when it is connected to a block or a terminal
+            # and not duplicated here.
+            FILTER(?imfProperty != rdf:type && ?imfProperty != skos:prefLabel && ?imfProperty != skos:description)
+        }
+
+        # Finding the last segment of the class IRI
+        BIND(STR(?imfClass) AS ?classString)
+        BIND(REPLACE(?classString, "^.*[/#]([^/#]*)$", "$1") AS ?classSegment)
+        BIND(IF(CONTAINS(?classString, "imf/"), CONCAT("IMF_", ?classSegment) , ?classSegment) AS ?class)
+
+        # Finding the last segment of the property IRI
+        BIND(STR(?imfProperty) AS ?propertyString)
+        BIND(REPLACE(?propertyString, "^.*[/#]([^/#]*)$", "$1") AS ?propertySegment)
+        BIND(IF(CONTAINS(?propertyString, "imf/"), CONCAT("IMF_", ?propertySegment) , ?propertySegment) AS ?property)
+
+        # If no type is provided for the the property bind it to ObjectProperty
+        BIND(IF(BOUND(?range) , ?range , "") AS ?valueType)
+
+        # Included to account for future domain and range within IMF-attributes
+        BIND(IF(BOUND(?type) && ?type = owl:DatatypeProperty, ?type , owl:ObjectProperty) AS ?propertyType)
+
+        # Assert cardinality values if they do not exist
+        BIND(IF(BOUND(?minCardinality), ?minCardinality, 0) AS ?minCount)
+        BIND(IF(BOUND(?maxCardinality), ?maxCardinality, 1) AS ?maxCount)
+
+        # Rebind the IRI of the IMF-attribute to the ?reference variable to align with dataframe column headers
+        # This is solely for readability, the ?imfClass could have been returnered directly instead of ?reference
+        BIND(?imfProperty AS ?reference)
+
+        FILTER (!isBlank(?property))
+        FILTER (!bound(?class) || !isBlank(?class))
+        FILTER (!bound(?name) || LANG(?name) = "" || LANGMATCHES(LANG(?name), "en"))
+        FILTER (!bound(?description) || LANG(?description) = "" || LANGMATCHES(LANG(?description), "en"))
+    }
+    """
+
+    raw_df = _parse_raw_dataframe(cast(list[tuple], list(graph.query(query.replace("en", language)))))
+    if raw_df.empty:
+        return []
+
+    # group values and clean up
+    processed_df = _clean_up_properties(raw_df)
+
+    # make compliant
+    processed_df = make_properties_compliant(processed_df)
+
+    # drop column _property_type, which was a helper column:
+    processed_df.drop(columns=["_property_type"], inplace=True)
+
+    return processed_df.to_dict(orient="records")
+
+
+def _parse_raw_dataframe(query_results: list[tuple]) -> pd.DataFrame:
+    df = pd.DataFrame(
+        query_results,
+        columns=[
+            "Class",
+            "Property",
+            "Name",
+            "Description",
+            "Value Type",
+            "Min Count",
+            "Max Count",
+            "Default",
+            "Reference",
+            "Match Type",
+            "Comment",
+            "_property_type",
+        ],
+    )
+    if df.empty:
+        return df
+
+    df.replace(np.nan, "", regex=True, inplace=True)
+
+    df["Match Type"] = len(df) * [MatchType.exact]
+    df["Comment"] = len(df) * [None]
+    df["_property_type"] = df["_property_type"].apply(lambda x: remove_namespace_from_uri(x))
+
+    return df
+
+
+def _clean_up_properties(df: pd.DataFrame) -> pd.DataFrame:
+    class_grouped_dfs = df.groupby("Class")
+
+    clean_list = []
+
+    for class_, class_grouped_df in class_grouped_dfs:
+        property_grouped_dfs = class_grouped_df.groupby("Property")
+        for property_, property_grouped_df in property_grouped_dfs:
+            clean_list += [
+                {
+                    "Class": class_,
+                    "Property": property_,
+                    "Name": property_grouped_df["Name"].unique()[0],
+                    "Description": "\n".join(list(property_grouped_df["Description"].unique()))[:1024],
+                    "Value Type": ", ".join(list(property_grouped_df["Value Type"].unique())),
+                    "Min Count": property_grouped_df["Min Count"].unique()[0],
+                    "Max Count": property_grouped_df["Max Count"].unique()[0],
+                    "Default": property_grouped_df["Default"].unique()[0],
+                    "Reference": property_grouped_df["Reference"].unique()[0],
+                    "Match Type": property_grouped_df["Match Type"].unique()[0],
+                    "Comment": property_grouped_df["Comment"].unique()[0],
+                    "_property_type": property_grouped_df["_property_type"].unique()[0],
+                }
+            ]
+
+    df = pd.DataFrame(clean_list)
+    df.replace("", None, inplace=True)
+
+    return df
+
+
+def make_properties_compliant(properties: pd.DataFrame) -> pd.DataFrame:
+    # default to 0 if "Min Count" is not specified
+    properties["Min Count"] = properties["Min Count"].apply(lambda x: 0 if not isinstance(x, Literal) or x == "" else x)
+
+    # default to 1 if "Max Count" is not specified
+    properties["Max Count"] = properties["Max Count"].apply(lambda x: 1 if not isinstance(x, Literal) or x == "" else x)
+
+    # Replace empty or non-string values in "Match Type" column with "exact"
+    properties["Match Type"] = properties["Match Type"].fillna("exact")
+    properties["Match Type"] = properties["Match Type"].apply(
+        lambda x: "exact" if not isinstance(x, str) or len(x) == 0 else x
+    )
+
+    # Replace empty or non-string values in "Comment" column with a default value
+    properties["Comment"] = properties["Comment"].fillna("Imported from IMF type by NEAT")
+    properties["Comment"] = properties["Comment"].apply(
+        lambda x: "Imported from Ontology by NEAT" if not isinstance(x, str) or len(x) == 0 else x
+    )
+
+    # Reduce length of elements in the "Description" column to 1024 characters
+    properties["Description"] = properties["Description"].apply(lambda x: x[:1024] if isinstance(x, str) else None)
+
+    # fixes and additions
+    properties = fix_dangling_properties(properties)
+    properties = fix_missing_property_value_type(properties)
+
+    return properties
+
+
+def fix_dangling_properties(properties: pd.DataFrame) -> pd.DataFrame:
+    """This method fixes properties which are missing a domain definition in the ontology.
+
+    Args:
+        properties: Dataframe containing properties
+
+    Returns:
+        Dataframe containing properties with fixed domain
+    """
+    domain = {
+        "ObjectProperty": _object_property_class()["Class"],
+        "DatatypeProperty": _data_type_property_class()["Class"],
+    }
+
+    # apply missing range
+    properties["Class"] = properties.apply(
+        lambda row: (
+            domain[row._property_type]
+            if row._property_type == "ObjectProperty" and pd.isna(row["Class"])
+            else domain["DatatypeProperty"]
+            if pd.isna(row["Class"])
+            else row["Class"]
+        ),
+        axis=1,
+    )
+    return properties
+
+
+def fix_missing_property_value_type(properties: pd.DataFrame) -> pd.DataFrame:
+    """This method fixes properties which are missing a range definition in the ontology.
+
+    Args:
+        properties: Dataframe containing properties
+
+    Returns:
+        Dataframe containing properties with fixed range
+    """
+    # apply missing range
+    properties["Value Type"] = properties.apply(
+        lambda row: (
+            _thing_class()["Class"]
+            if row._property_type == "ObjectProperty" and pd.isna(row["Value Type"])
+            else "string"
+            if pd.isna(row["Value Type"])
+            else row["Value Type"]
+        ),
+        axis=1,
+    )
+
+    return properties

--- a/cognite/neat/rules/importers/_imf2rules/_imf2rules.py
+++ b/cognite/neat/rules/importers/_imf2rules/_imf2rules.py
@@ -1,0 +1,192 @@
+"""This module performs importing of various formats to one of serializations for which
+there are loaders to TransformationRules pydantic class."""
+
+from pathlib import Path
+from typing import Literal, overload
+
+from rdflib import DC, DCTERMS, OWL, RDF, RDFS, SH, SKOS, Graph
+
+from cognite.neat.rules.importers._base import BaseImporter, Rules
+from cognite.neat.rules.issues import IssueList
+from cognite.neat.rules.models import InformationRules, RoleTypes
+from cognite.neat.rules.models.data_types import _XSD_TYPES
+
+from ._imf2classes import parse_imf_to_classes
+from ._imf2metadata import parse_imf_metadata
+from ._imf2properties import parse_imf_to_properties
+
+
+class IMFImporter(BaseImporter):
+    """Convert SHACL shapes to tables/ transformation rules / Excel file.
+
+        Args:
+            filepath: Path to RDF file containing the SHACL Shapes
+
+    !!! Note
+        Rewrite to fit the SHACL rules we apply
+        OWL Ontologies are information models which completeness varies. As such, constructing functional
+        data model directly will often be impossible, therefore the produced Rules object will be ill formed.
+        To avoid this, neat will automatically attempt to make the imported rules compliant by adding default
+        values for missing information, attaching dangling properties to default containers based on the
+        property type, etc.
+
+        One has to be aware that NEAT will be opinionated about how to make the ontology
+        compliant, and that the resulting rules may not be what you expect.
+
+    """
+
+    def __init__(self, filepath: Path):
+        self.owl_filepath = filepath
+
+    @overload
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+
+    @overload
+    def to_rules(
+        self, errors: Literal["continue"] = "continue", role: RoleTypes | None = None
+    ) -> tuple[Rules | None, IssueList]: ...
+
+    def to_rules(
+        self, errors: Literal["raise", "continue"] = "continue", role: RoleTypes | None = None
+    ) -> tuple[Rules | None, IssueList] | Rules:
+        graph = Graph()
+        try:
+            graph.parse(self.owl_filepath)
+        except Exception as e:
+            raise Exception(f"Could not parse owl file: {e}") from e
+
+        # bind key namespaces
+        graph.bind("owl", OWL)
+        graph.bind("rdf", RDF)
+        graph.bind("rdfs", RDFS)
+        graph.bind("dcterms", DCTERMS)
+        graph.bind("dc", DC)
+        graph.bind("skos", SKOS)
+        graph.bind("sh", SH)
+        graph.bind("xsd", _XSD_TYPES)
+        graph.bind("imf", "http://ns.imfid.org/imf#")
+
+        components = {
+            "Metadata": parse_imf_metadata(),
+            "Classes": parse_imf_to_classes(graph),
+            "Properties": parse_imf_to_properties(graph),
+        }
+
+        components = make_components_compliant(components)
+
+        rules = InformationRules.model_validate(components)
+        return self._to_output(rules, IssueList(), errors, role)
+
+
+def make_components_compliant(components: dict) -> dict:
+    components = _add_missing_classes(components)
+    components = _add_missing_value_types(components)
+    components = _add_default_property_to_dangling_classes(components)
+
+    return components
+
+
+def _add_missing_classes(components: dict[str, list[dict]]) -> dict:
+    """Add missing classes to Classes.
+
+    Args:
+        tables: imported tables from owl ontology
+
+    Returns:
+        Updated tables with missing classes added to containers
+    """
+
+    missing_classes = {definition["Class"] for definition in components["Properties"]} - {
+        definition["Class"] for definition in components["Classes"]
+    }
+
+    comment = (
+        "Added by NEAT. "
+        "This is a class that a domain of a property but was not defined in the ontology. "
+        "It is added by NEAT to make the ontology compliant with CDF."
+    )
+
+    for class_ in missing_classes:
+        components["Classes"].append({"Class": class_, "Comment": comment})
+
+    return components
+
+
+def _add_missing_value_types(components: dict) -> dict:
+    """Add properties to classes that do not have any properties defined to them
+
+    Args:
+        tables: imported tables from owl ontology
+
+    Returns:
+        Updated tables with missing properties added to containers
+    """
+
+    xsd_types = _XSD_TYPES
+    candidate_value_types = {definition["Value Type"] for definition in components["Properties"]} - {
+        definition["Class"] for definition in components["Classes"]
+    }
+
+    # to avoid issue of case sensitivity for xsd types
+    value_types_lower = {v.lower() for v in candidate_value_types}
+
+    xsd_types_lower = {x.lower() for x in xsd_types}
+
+    # Create a mapping from lowercase strings to original strings
+    value_types_mapping = {v.lower(): v for v in candidate_value_types}
+
+    # Find the difference
+    difference = value_types_lower - xsd_types_lower
+
+    # Convert the difference back to the original case
+    difference_original_case = {value_types_mapping[d] for d in difference}
+
+    for class_ in difference_original_case:
+        components["Classes"].append(
+            {
+                "Class": class_,
+                "Comment": (
+                    "Added by NEAT. "
+                    "This is a class that a domain of a property but was not defined in the ontology. "
+                    "It is added by NEAT to make the ontology compliant with CDF."
+                ),
+            }
+        )
+
+    return components
+
+
+def _add_default_property_to_dangling_classes(components: dict[str, list[dict]]) -> dict:
+    """Add missing classes to Classes.
+
+    Args:
+        tables: imported tables from owl ontology
+
+    Returns:
+        Updated tables with missing classes added to containers
+    """
+
+    dangling_classes = {
+        definition["Class"] for definition in components["Classes"] if not definition.get("Parent Class", None)
+    } - {definition["Class"] for definition in components["Properties"]}
+
+    comment = (
+        "Added by NEAT. "
+        "This is property has been added to this class since otherwise it will create "
+        "dangling classes in the ontology."
+    )
+
+    for class_ in dangling_classes:
+        components["Properties"].append(
+            {
+                "Class": class_,
+                "Property": "label",
+                "Value Type": "string",
+                "Comment": comment,
+                "Min Count": 0,
+                "Max Count": 1,
+                "Reference": "http://www.w3.org/2000/01/rdf-schema#label",
+            }
+        )
+
+    return components

--- a/cognite/neat/workflows/steps/lib/current/rules_importer.py
+++ b/cognite/neat/workflows/steps/lib/current/rules_importer.py
@@ -19,6 +19,7 @@ CATEGORY = __name__.split(".")[-1].replace("_", " ").title()
 __all__ = [
     "ExcelToRules",
     "OntologyToRules",
+    "IMFToRules",
     "DMSToRules",
     "RulesInferenceFromRdfFile",
 ]
@@ -143,6 +144,77 @@ class OntologyToRules(Step):
             role_enum = RoleTypes[role]
 
         ontology_importer = importers.OWLImporter(filepath=rules_file_path)
+        rules, issues = ontology_importer.to_rules(errors="continue", role=role_enum)
+
+        if rules is None:
+            output_dir = self.config.staging_path
+            report_writer = FORMATTER_BY_NAME[self.configs["Report formatter"]]()
+            report_writer.write_to_file(issues, file_or_dir_path=output_dir)
+            report_file = report_writer.default_file_name
+            error_text = (
+                "<p></p>"
+                f'<a href="/data/staging/{report_file}?{time.time()}" '
+                f'target="_blank">Failed to validate rules, click here for report</a>'
+            )
+            return FlowMessage(error_text=error_text, step_execution_status=StepExecutionStatus.ABORT_AND_FAIL)
+
+        output_text = "Rules validation passed successfully!"
+
+        return FlowMessage(output_text=output_text), MultiRuleData.from_rules(rules)
+
+
+class IMFToRules(Step):
+    """This step import rules from the IMF-types and validates them."""
+
+    description = "This step imports rules from an RDF file "
+    version = "private-beta"
+    category = CATEGORY
+    configurables: ClassVar[list[Configurable]] = [
+        Configurable(
+            name="File name",
+            value="",
+            label="""Full file name of the RDF-file containing the IMF-types in the rules folder.
+                If not provided, step will attempt to get file name from payload
+                    of 'File Uploader' step (if exist)""",
+        ),
+        Configurable(
+            name="Report formatter",
+            value=next(iter(FORMATTER_BY_NAME.keys())),
+            label="The format of the report for the validation of the rules",
+            options=list(FORMATTER_BY_NAME),
+        ),
+        Configurable(
+            name="Role",
+            value="infer",
+            label="For what role Rules are intended?",
+            options=["infer", *RoleTypes.__members__.keys()],
+        ),
+    ]
+
+    def run(self, flow_message: FlowMessage) -> (FlowMessage, MultiRuleData):  # type: ignore[syntax, override]
+        if self.configs is None or self.data_store_path is None:
+            raise StepNotInitialized(type(self).__name__)
+
+        file_name = self.configs.get("File name", None)
+
+        full_path = flow_message.payload.get("full_path", None) if flow_message.payload else None
+
+        if file_name:
+            rules_file_path = self.config.rules_store_path / file_name
+
+        elif full_path:
+            rules_file_path = full_path
+        else:
+            error_text = "Expected either 'File name' in the step config or 'File uploader' step uploading Excel Rules."
+            return FlowMessage(error_text=error_text, step_execution_status=StepExecutionStatus.ABORT_AND_FAIL)
+
+        # if role is None, it will be inferred from the rules file
+        role = self.configs.get("Role")
+        role_enum = None
+        if role != "infer" and role is not None:
+            role_enum = RoleTypes[role]
+
+        ontology_importer = importers.IMFImporter(filepath=rules_file_path)
         rules, issues = ontology_importer.to_rules(errors="continue", role=role_enum)
 
         if rules is None:


### PR DESCRIPTION
A new step for importing rules has been added. The step converts
Information Modelling Framework (IMF) types, given as SHACL shapes,
into rules.

The new importer follows the compliance rules set by the OWL Importer,
but most of the logic are, in this case, included the SPARQL queries.
However, the validation checks are kept to ensure conformance.

The IMF identifiers are given as UUIDs, but CDF does not allow identifiers
starting with a number. All the relevant identifiers are therefore prefixed
with "IMF_"

IMF - attributes are properties that are described with several triples.
An attribute contains relations to reference data describing the meaning
of the attribute, as well as potential qualifiers and units of measure.
To ensure that this information is included the attributes are created as
both a class and property. This punning is required to ensure that both
the usage of the attribute relative to an IMF block or terminal and the
relationship to relevant reference data is captured.