### PR TITLE
[NEAT-389] 🏗Introduce rules transformation

### DIFF
--- a/cognite/neat/rules/_shared.py
+++ b/cognite/neat/rules/_shared.py
@@ -6,5 +6,12 @@ from cognite.neat.rules.models import (
     DomainRules,
     InformationRules,
 )
+from cognite.neat.rules.models.asset._rules_input import AssetRulesInput
+from cognite.neat.rules.models.dms._rules_input import DMSRulesInput
+from cognite.neat.rules.models.information._rules_input import InformationRulesInput
 
-Rules: TypeAlias = DomainRules | InformationRules | DMSRules | AssetRules
+VerifiedRules: TypeAlias = DomainRules | InformationRules | DMSRules | AssetRules
+InputRules: TypeAlias = AssetRulesInput | DMSRulesInput | InformationRulesInput
+Rules: TypeAlias = (
+    AssetRulesInput | DMSRulesInput | InformationRulesInput | DomainRules | InformationRules | DMSRules | AssetRules
+)

--- a/cognite/neat/rules/_shared.py
+++ b/cognite/neat/rules/_shared.py
@@ -1,4 +1,4 @@
-from typing import TypeAlias
+from typing import TypeAlias, TypeVar
 
 from cognite.neat.rules.models import (
     AssetRules,
@@ -15,3 +15,4 @@ InputRules: TypeAlias = AssetRulesInput | DMSRulesInput | InformationRulesInput
 Rules: TypeAlias = (
     AssetRulesInput | DMSRulesInput | InformationRulesInput | DomainRules | InformationRules | DMSRules | AssetRules
 )
+T_Rules = TypeVar("T_Rules", bound=Rules)

--- a/cognite/neat/rules/exporters/_base.py
+++ b/cognite/neat/rules/exporters/_base.py
@@ -5,7 +5,7 @@ from typing import Generic, TypeVar
 
 from cognite.client import CogniteClient
 
-from cognite.neat.rules._shared import Rules
+from cognite.neat.rules._shared import VerifiedRules
 from cognite.neat.rules.models import DMSRules, InformationRules, RoleTypes
 from cognite.neat.utils.auxiliary import class_html_doc
 from cognite.neat.utils.upload import UploadResult, UploadResultList
@@ -18,14 +18,14 @@ class BaseExporter(ABC, Generic[T_Export]):
     _encoding = "utf-8"
 
     @abstractmethod
-    def export_to_file(self, rules: Rules, filepath: Path) -> None:
+    def export_to_file(self, rules: VerifiedRules, filepath: Path) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def export(self, rules: Rules) -> T_Export:
+    def export(self, rules: VerifiedRules) -> T_Export:
         raise NotImplementedError
 
-    def _convert_to_output_role(self, rules: Rules, output_role: RoleTypes | None = None) -> Rules:
+    def _convert_to_output_role(self, rules: VerifiedRules, output_role: RoleTypes | None = None) -> VerifiedRules:
         if rules.metadata.role is output_role or output_role is None:
             return rules
         elif output_role is RoleTypes.dms and isinstance(rules, InformationRules):
@@ -43,9 +43,9 @@ class BaseExporter(ABC, Generic[T_Export]):
 class CDFExporter(BaseExporter[T_Export]):
     @abstractmethod
     def export_to_cdf_iterable(
-        self, rules: Rules, client: CogniteClient, dry_run: bool = False
+        self, rules: VerifiedRules, client: CogniteClient, dry_run: bool = False
     ) -> Iterable[UploadResult]:
         raise NotImplementedError
 
-    def export_to_cdf(self, rules: Rules, client: CogniteClient, dry_run: bool = False) -> UploadResultList:
+    def export_to_cdf(self, rules: VerifiedRules, client: CogniteClient, dry_run: bool = False) -> UploadResultList:
         return UploadResultList(self.export_to_cdf_iterable(rules, client, dry_run))

--- a/cognite/neat/rules/exporters/_rules2excel.py
+++ b/cognite/neat/rules/exporters/_rules2excel.py
@@ -12,7 +12,7 @@ from openpyxl.cell import MergedCell
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.worksheet.worksheet import Worksheet
 
-from cognite.neat.rules._shared import Rules
+from cognite.neat.rules._shared import VerifiedRules
 from cognite.neat.rules.models import (
     DataModelType,
     ExtensionCategory,
@@ -89,7 +89,7 @@ class ExcelExporter(BaseExporter[Workbook]):
         self.new_model_id = new_model_id
         self.dump_as = dump_as
 
-    def export_to_file(self, rules: Rules, filepath: Path) -> None:
+    def export_to_file(self, rules: VerifiedRules, filepath: Path) -> None:
         """Exports transformation rules to excel file."""
         data = self.export(rules)
         try:
@@ -98,7 +98,7 @@ class ExcelExporter(BaseExporter[Workbook]):
             data.close()
         return None
 
-    def export(self, rules: Rules) -> Workbook:
+    def export(self, rules: VerifiedRules) -> Workbook:
         rules = self._convert_to_output_role(rules, self.output_role)
         workbook = Workbook()
         # Remove default sheet named "Sheet"
@@ -147,7 +147,7 @@ class ExcelExporter(BaseExporter[Workbook]):
         self,
         workbook: Workbook,
         dumped_rules: dict[str, Any],
-        rules: Rules,
+        rules: VerifiedRules,
         sheet_prefix: str = "",
     ):
         for sheet_name, headers in rules.headers_by_sheet(by_alias=True).items():

--- a/cognite/neat/rules/exporters/_rules2ontology.py
+++ b/cognite/neat/rules/exporters/_rules2ontology.py
@@ -34,32 +34,32 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
-from cognite.neat.rules._shared import Rules
+from cognite.neat.rules._shared import VerifiedRules
 
 
 class GraphExporter(BaseExporter[Graph], ABC):
-    def export_to_file(self, rules: Rules, filepath: Path) -> None:
+    def export_to_file(self, rules: VerifiedRules, filepath: Path) -> None:
         self.export(rules).serialize(destination=filepath, encoding=self._encoding, newline=self._new_line)
 
 
 class OWLExporter(GraphExporter):
     """Exports rules to an OWL ontology."""
 
-    def export(self, rules: Rules) -> Graph:
+    def export(self, rules: VerifiedRules) -> Graph:
         return Ontology.from_rules(rules).as_owl()
 
 
 class SHACLExporter(GraphExporter):
     """Exports rules to a SHACL graph."""
 
-    def export(self, rules: Rules) -> Graph:
+    def export(self, rules: VerifiedRules) -> Graph:
         return Ontology.from_rules(rules).as_shacl()
 
 
 class SemanticDataModelExporter(GraphExporter):
     """Exports rules to a semantic data model."""
 
-    def export(self, rules: Rules) -> Graph:
+    def export(self, rules: VerifiedRules) -> Graph:
         return Ontology.from_rules(rules).as_semantic_data_model()
 
 
@@ -86,7 +86,7 @@ class Ontology(OntologyModel):
     prefixes: dict[str, Namespace]
 
     @classmethod
-    def from_rules(cls, input_rules: Rules) -> Self:
+    def from_rules(cls, input_rules: VerifiedRules) -> Self:
         """
         Generates an ontology from a set of transformation rules.
 

--- a/cognite/neat/rules/exporters/_rules2yaml.py
+++ b/cognite/neat/rules/exporters/_rules2yaml.py
@@ -5,7 +5,7 @@ from typing import Literal, get_args
 
 import yaml
 
-from cognite.neat.rules._shared import Rules
+from cognite.neat.rules._shared import VerifiedRules
 from cognite.neat.rules.models import RoleTypes
 
 from ._base import BaseExporter
@@ -47,7 +47,7 @@ class YAMLExporter(BaseExporter[str]):
         self.output = output
         self.output_role = output_role
 
-    def export_to_file(self, rules: Rules, filepath: Path) -> None:
+    def export_to_file(self, rules: VerifiedRules, filepath: Path) -> None:
         """Exports transformation rules to YAML/JSON file(s)."""
         if self.files == "single":
             if filepath.suffix != f".{self.output}":
@@ -57,7 +57,7 @@ class YAMLExporter(BaseExporter[str]):
         else:
             raise NotImplementedError(f"Exporting to {self.files} files is not supported")
 
-    def export(self, rules: Rules) -> str:
+    def export(self, rules: VerifiedRules) -> str:
         """Export rules to YAML (or JSON) format.
 
         Args:

--- a/cognite/neat/rules/importers/_base.py
+++ b/cognite/neat/rules/importers/_base.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 from rdflib import Namespace
 
 from cognite.neat.issues import IssueList, NeatError, NeatWarning
-from cognite.neat.rules._shared import Rules
+from cognite.neat.rules._shared import VerifiedRules
 from cognite.neat.rules.models import AssetRules, DMSRules, InformationRules, RoleTypes
 from cognite.neat.utils.auxiliary import class_html_doc
 
@@ -21,19 +21,19 @@ class BaseImporter(ABC):
     """
 
     @overload
-    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> VerifiedRules: ...
 
     @overload
     def to_rules(
         self, errors: Literal["continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList]: ...
+    ) -> tuple[VerifiedRules | None, IssueList]: ...
 
     @abstractmethod
     def to_rules(
         self,
         errors: Literal["raise", "continue"] = "continue",
         role: RoleTypes | None = None,
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         """
         Creates `Rules` object from the data for target role.
         """
@@ -42,11 +42,11 @@ class BaseImporter(ABC):
     @classmethod
     def _to_output(
         cls,
-        rules: Rules,
+        rules: VerifiedRules,
         issues: IssueList,
         errors: Literal["raise", "continue"] = "continue",
         role: RoleTypes | None = None,
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         """Converts the rules to the output format."""
 
         if rules.metadata.role is role or role is None:

--- a/cognite/neat/rules/importers/_dms2rules.py
+++ b/cognite/neat/rules/importers/_dms2rules.py
@@ -25,7 +25,7 @@ from cognite.neat.issues.warnings import (
     PropertyTypeNotSupportedWarning,
     ResourceNotFoundWarning,
 )
-from cognite.neat.rules.importers._base import BaseImporter, Rules, _handle_issues
+from cognite.neat.rules.importers._base import BaseImporter, VerifiedRules, _handle_issues
 from cognite.neat.rules.models import (
     DataModelType,
     DMSRules,
@@ -204,16 +204,16 @@ class DMSImporter(BaseImporter):
         return cls(schema, issue_list)
 
     @overload
-    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> VerifiedRules: ...
 
     @overload
     def to_rules(
         self, errors: Literal["continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList]: ...
+    ) -> tuple[VerifiedRules | None, IssueList]: ...
 
     def to_rules(
         self, errors: Literal["raise", "continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         if self.issue_list.has_errors:
             # In case there were errors during the import, the to_rules method will return None
             return self._return_or_raise(self.issue_list, errors)

--- a/cognite/neat/rules/importers/_dtdl2rules/dtdl_importer.py
+++ b/cognite/neat/rules/importers/_dtdl2rules/dtdl_importer.py
@@ -14,7 +14,7 @@ from cognite.neat.issues.warnings import (
     FileTypeUnexpectedWarning,
     NeatValueWarning,
 )
-from cognite.neat.rules._shared import Rules
+from cognite.neat.rules._shared import VerifiedRules
 from cognite.neat.rules.importers._base import BaseImporter, _handle_issues
 from cognite.neat.rules.importers._dtdl2rules.dtdl_converter import _DTDLConverter
 from cognite.neat.rules.importers._dtdl2rules.spec import DTDL_CLS_BY_TYPE_BY_SPEC, DTDLBase, Interface
@@ -126,16 +126,16 @@ class DTDLImporter(BaseImporter):
         return cls(items, zip_file.stem, read_issues=issues)
 
     @overload
-    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> VerifiedRules: ...
 
     @overload
     def to_rules(
         self, errors: Literal["continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList]: ...
+    ) -> tuple[VerifiedRules | None, IssueList]: ...
 
     def to_rules(
         self, errors: Literal["raise", "continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         converter = _DTDLConverter(self._read_issues)
 
         converter.convert(self._items)

--- a/cognite/neat/rules/importers/_rdf/_imf2rules/_imf2rules.py
+++ b/cognite/neat/rules/importers/_rdf/_imf2rules/_imf2rules.py
@@ -7,7 +7,7 @@ from typing import Literal, overload
 from rdflib import DC, DCTERMS, OWL, RDF, RDFS, SH, SKOS, Graph
 
 from cognite.neat.issues import IssueList
-from cognite.neat.rules.importers._base import BaseImporter, Rules
+from cognite.neat.rules.importers._base import BaseImporter, VerifiedRules
 from cognite.neat.rules.models import InformationRules, RoleTypes
 from cognite.neat.rules.models.data_types import _XSD_TYPES
 
@@ -39,16 +39,16 @@ class IMFImporter(BaseImporter):
         self.owl_filepath = filepath
 
     @overload
-    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> VerifiedRules: ...
 
     @overload
     def to_rules(
         self, errors: Literal["continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList]: ...
+    ) -> tuple[VerifiedRules | None, IssueList]: ...
 
     def to_rules(
         self, errors: Literal["raise", "continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         graph = Graph()
         try:
             graph.parse(self.owl_filepath)

--- a/cognite/neat/rules/importers/_rdf/_inference2rules.py
+++ b/cognite/neat/rules/importers/_rdf/_inference2rules.py
@@ -9,7 +9,7 @@ from rdflib import Literal as RdfLiteral
 from cognite.neat.constants import DEFAULT_NAMESPACE, get_default_prefixes
 from cognite.neat.issues import IssueList
 from cognite.neat.issues.errors import FileReadError
-from cognite.neat.rules.importers._base import BaseImporter, Rules, _handle_issues
+from cognite.neat.rules.importers._base import BaseImporter, VerifiedRules, _handle_issues
 from cognite.neat.rules.models import InformationRules, RoleTypes
 from cognite.neat.rules.models._base import MatchType
 from cognite.neat.rules.models.information import (
@@ -148,20 +148,20 @@ class InferenceImporter(BaseImporter):
         raise NotImplementedError("JSON file format is not supported yet.")
 
     @overload
-    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> VerifiedRules: ...
 
     @overload
     def to_rules(
         self,
         errors: Literal["continue"] = "continue",
         role: RoleTypes | None = None,
-    ) -> tuple[Rules | None, IssueList]: ...
+    ) -> tuple[VerifiedRules | None, IssueList]: ...
 
     def to_rules(
         self,
         errors: Literal["raise", "continue"] = "continue",
         role: RoleTypes | None = None,
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         """
         Creates `Rules` object from the data for target role.
         """

--- a/cognite/neat/rules/importers/_rdf/_owl2rules/_owl2rules.py
+++ b/cognite/neat/rules/importers/_rdf/_owl2rules/_owl2rules.py
@@ -7,7 +7,7 @@ from typing import Literal, overload
 from rdflib import DC, DCTERMS, OWL, RDF, RDFS, SKOS, Graph
 
 from cognite.neat.issues import IssueList
-from cognite.neat.rules.importers._base import BaseImporter, Rules
+from cognite.neat.rules.importers._base import BaseImporter, VerifiedRules
 from cognite.neat.rules.importers._rdf._shared import make_components_compliant
 from cognite.neat.rules.models import InformationRules, RoleTypes
 
@@ -38,18 +38,18 @@ class OWLImporter(BaseImporter):
         self.owl_filepath = filepath
 
     @overload
-    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> VerifiedRules: ...
 
     @overload
     def to_rules(
         self, errors: Literal["continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList]: ...
+    ) -> tuple[VerifiedRules | None, IssueList]: ...
 
     def to_rules(
         self,
         errors: Literal["raise", "continue"] = "continue",
         role: RoleTypes | None = None,
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         graph = Graph()
         try:
             graph.parse(self.owl_filepath)

--- a/cognite/neat/rules/importers/_spreadsheet2rules.py
+++ b/cognite/neat/rules/importers/_spreadsheet2rules.py
@@ -34,7 +34,7 @@ from cognite.neat.utils.auxiliary import local_import
 from cognite.neat.utils.spreadsheet import SpreadsheetRead, read_individual_sheet
 from cognite.neat.utils.text import humanize_collection
 
-from ._base import BaseImporter, Rules, _handle_issues
+from ._base import BaseImporter, VerifiedRules, _handle_issues
 
 SOURCE_SHEET__TARGET_FIELD__HEADERS = [
     (
@@ -218,18 +218,18 @@ class ExcelImporter(BaseImporter):
         self.filepath = filepath
 
     @overload
-    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> VerifiedRules: ...
 
     @overload
     def to_rules(
         self,
         errors: Literal["continue"] = "continue",
         role: RoleTypes | None = None,
-    ) -> tuple[Rules | None, IssueList]: ...
+    ) -> tuple[VerifiedRules | None, IssueList]: ...
 
     def to_rules(
         self, errors: Literal["raise", "continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         issue_list = IssueList(title=f"'{self.filepath.name}'")
         if not self.filepath.exists():
             issue_list.append(FileNotFoundNeatError(self.filepath))
@@ -286,7 +286,7 @@ class ExcelImporter(BaseImporter):
             error_cls=NeatError,
             error_args={"read_info_by_sheet": read_info_by_sheet},
         ) as future:
-            rules: Rules
+            rules: VerifiedRules
             if rules_cls is DMSRules:
                 rules = DMSRulesInput.load(sheets).as_rules()
             elif rules_cls is InformationRules:
@@ -324,16 +324,16 @@ class GoogleSheetImporter(BaseImporter):
         self.skiprows = skiprows
 
     @overload
-    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> VerifiedRules: ...
 
     @overload
     def to_rules(
         self, errors: Literal["continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList]: ...
+    ) -> tuple[VerifiedRules | None, IssueList]: ...
 
     def to_rules(
         self, errors: Literal["raise", "continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         local_import("gspread", "google")
         import gspread  # type: ignore[import]
 

--- a/cognite/neat/rules/importers/_yaml2rules.py
+++ b/cognite/neat/rules/importers/_yaml2rules.py
@@ -14,7 +14,7 @@ from cognite.neat.issues.warnings import NeatValueWarning
 from cognite.neat.rules.models import RULES_PER_ROLE, DMSRules, RoleTypes
 from cognite.neat.rules.models.dms import DMSRulesInput
 
-from ._base import BaseImporter, Rules, _handle_issues
+from ._base import BaseImporter, VerifiedRules, _handle_issues
 
 
 class YAMLImporter(BaseImporter):
@@ -52,16 +52,16 @@ class YAMLImporter(BaseImporter):
         return cls(yaml.safe_load(filepath.read_text()), filepaths=[filepath])
 
     @overload
-    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> Rules: ...
+    def to_rules(self, errors: Literal["raise"], role: RoleTypes | None = None) -> VerifiedRules: ...
 
     @overload
     def to_rules(
         self, errors: Literal["continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList]: ...
+    ) -> tuple[VerifiedRules | None, IssueList]: ...
 
     def to_rules(
         self, errors: Literal["raise", "continue"] = "continue", role: RoleTypes | None = None
-    ) -> tuple[Rules | None, IssueList] | Rules:
+    ) -> tuple[VerifiedRules | None, IssueList] | VerifiedRules:
         if self._read_issues.has_errors or not self.raw_data:
             if errors == "raise":
                 raise self._read_issues.as_errors()
@@ -98,7 +98,7 @@ class YAMLImporter(BaseImporter):
         rules_model = RULES_PER_ROLE[role_enum]
 
         with _handle_issues(issue_list) as future:
-            rules: Rules
+            rules: VerifiedRules
             if rules_model is DMSRules:
                 rules = DMSRulesInput.load(self.raw_data).as_rules()
             else:

--- a/cognite/neat/rules/transformers/_base.py
+++ b/cognite/neat/rules/transformers/_base.py
@@ -7,7 +7,7 @@ T_RulesIn = TypeVar("T_RulesIn", bound=Rules)
 T_RulesOut = TypeVar("T_RulesOut", bound=Rules)
 
 
-class RuleTransformer(ABC, Generic[T_RulesIn, T_RulesOut]):
+class RulesTransformer(ABC, Generic[T_RulesIn, T_RulesOut]):
     """This is the base class for all rule transformers."""
 
     @abstractmethod

--- a/cognite/neat/rules/transformers/_base.py
+++ b/cognite/neat/rules/transformers/_base.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+from rdflib import Graph
+
+
+class RuleTransformer(ABC):
+    @abstractmethod
+    def transform(self, graph: Graph) -> None:
+        raise NotImplementedError()

--- a/cognite/neat/rules/transformers/_base.py
+++ b/cognite/neat/rules/transformers/_base.py
@@ -1,9 +1,15 @@
 from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
 
-from rdflib import Graph
+from cognite.neat.rules._shared import Rules
+
+T_RulesIn = TypeVar("T_RulesIn", bound=Rules)
+T_RulesOut = TypeVar("T_RulesOut", bound=Rules)
 
 
-class RuleTransformer(ABC):
+class RuleTransformer(ABC, Generic[T_RulesIn, T_RulesOut]):
+    """This is the base class for all rule transformers."""
+
     @abstractmethod
-    def transform(self, graph: Graph) -> None:
+    def transform(self, rules: T_RulesIn) -> T_RulesOut:
         raise NotImplementedError()

--- a/cognite/neat/workflows/steps/lib/current/rules_exporter.py
+++ b/cognite/neat/workflows/steps/lib/current/rules_exporter.py
@@ -4,7 +4,7 @@ from typing import ClassVar, Literal, cast
 
 from cognite.neat.issues.errors import WorkflowStepNotInitializedError
 from cognite.neat.rules import exporters
-from cognite.neat.rules._shared import DMSRules, InformationRules, Rules
+from cognite.neat.rules._shared import DMSRules, InformationRules, VerifiedRules
 from cognite.neat.rules.models import RoleTypes
 from cognite.neat.workflows.model import FlowMessage, StepExecutionStatus
 from cognite.neat.workflows.steps.data_contracts import CogniteClient, MultiRuleData
@@ -317,7 +317,7 @@ class RulesToExcel(Step):
             new_model_id=new_model_id,
         )
 
-        rule_instance: Rules
+        rule_instance: VerifiedRules
         if rules.domain:
             rule_instance = rules.domain
         elif rules.information:


### PR DESCRIPTION
Went with `RulesTransformation` instead of `ModelTransformation` to make it clear that it should be used with Rules.

Did a renaming of the `Rules` alias to `VerifiedRules`, such that I could introduce `InputRules` and `Rules` for the combination of the two.