### PR TITLE
[NEAT-419] 🐳 Cleanup serialization Part 1

### DIFF
--- a/cognite/neat/issues/_base.py
+++ b/cognite/neat/issues/_base.py
@@ -190,6 +190,10 @@ class NeatError(NeatIssue, Exception):
         read_info_by_sheet = kwargs.get("read_info_by_sheet")
 
         for error in errors:
+            if error["type"] == "is_instance_of" and error["loc"][1] == "is-instance[SheetList]":
+                # Skip the error for SheetList, as it is not relevant for the user. This is an
+                # internal class used to have helper methods for a lists as .to_pandas()
+                continue
             ctx = error.get("ctx")
             if isinstance(ctx, dict) and isinstance(multi_error := ctx.get("error"), MultiValueError):
                 if read_info_by_sheet:

--- a/cognite/neat/rules/exporters/_rules2excel.py
+++ b/cognite/neat/rules/exporters/_rules2excel.py
@@ -17,7 +17,7 @@ from cognite.neat.rules.models import (
     DataModelType,
     ExtensionCategory,
     SchemaCompleteness,
-    SheetEntity,
+    SheetRow,
 )
 from cognite.neat.rules.models.dms import DMSMetadata
 from cognite.neat.rules.models.domain import DomainMetadata
@@ -210,14 +210,14 @@ class ExcelExporter(BaseExporter[VerifiedRules, Workbook]):
                 cell.font = Font(bold=True, size=12)
 
     @classmethod
-    def _get_item_class(cls, annotation: GenericAlias) -> type[SheetEntity]:
+    def _get_item_class(cls, annotation: GenericAlias) -> type[SheetRow]:
         if not isinstance(annotation, GenericAlias):
             raise ValueError(f"Expected annotation to be a GenericAlias, but got {type(annotation)}")
         args = get_args(annotation)
         if len(args) != 1:
             raise ValueError(f"Expected annotation to have exactly one argument, but got {len(args)}")
         arg = args[0]
-        if not issubclass(arg, SheetEntity):
+        if not issubclass(arg, SheetRow):
             raise ValueError(f"Expected annotation to have a BaseModel argument, but got {type(arg)}")
         return arg
 

--- a/cognite/neat/rules/models/__init__.py
+++ b/cognite/neat/rules/models/__init__.py
@@ -4,7 +4,7 @@ from cognite.neat.rules.models.domain import DomainInputRules, DomainRules
 from cognite.neat.rules.models.information._rules import InformationRules
 from cognite.neat.rules.models.information._rules_input import InformationInputRules
 
-from ._base_rules import DataModelType, ExtensionCategory, RoleTypes, SchemaCompleteness, SheetEntity, SheetList
+from ._base_rules import DataModelType, ExtensionCategory, RoleTypes, SchemaCompleteness, SheetList, SheetRow
 from .dms._rules import DMSRules
 from .dms._rules_input import DMSInputRules
 from .dms._schema import DMSSchema
@@ -42,5 +42,5 @@ __all__ = [
     "ExtensionCategory",
     "DataModelType",
     "SheetList",
-    "SheetEntity",
+    "SheetRow",
 ]

--- a/cognite/neat/rules/models/_base_input.py
+++ b/cognite/neat/rules/models/_base_input.py
@@ -18,7 +18,7 @@ from dataclasses import Field, dataclass, fields, is_dataclass
 from types import GenericAlias, UnionType
 from typing import Any, Generic, TypeVar, Union, cast, get_args, get_origin, overload
 
-from ._base_rules import BaseRules, RuleModel
+from ._base_rules import BaseRules, NeatModel
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -26,7 +26,7 @@ else:
     from typing_extensions import Self
 
 T_BaseRules = TypeVar("T_BaseRules", bound=BaseRules)
-T_RuleModel = TypeVar("T_RuleModel", bound=RuleModel)
+T_RuleModel = TypeVar("T_RuleModel", bound=NeatModel)
 
 
 @dataclass

--- a/cognite/neat/rules/models/_base_rules.py
+++ b/cognite/neat/rules/models/_base_rules.py
@@ -133,7 +133,7 @@ class NeatModel(BaseModel):
                     # We know that this is a SheetList, so we can safely access the annotation
                     # which is the concrete type of the SheetEntity.
                     args = get_args(annotation)
-                    model_fields = ards[0].model_fields  # type: ignore[union-attr]
+                    model_fields = args[0].model_fields  # type: ignore[union-attr]
                 elif isinstance(annotation, type) and issubclass(annotation, BaseModel):
                     model_fields = annotation.model_fields
                 else:
@@ -244,8 +244,8 @@ class SheetList(list, MutableSequence[T_SheetRow]):
         args = get_args(source)
         if args:
             # replace the type and rely on Pydantic to generate the right schema
-            # for `Sequence`
-            sequence_t_schema = handler.generate_schema(MutableSequence[args[0]])
+            # for `T_SheetRow`
+            sequence_t_schema = handler.generate_schema(MutableSequence[args[0]])  # type: ignore[valid-type]
         else:
             sequence_t_schema = handler.generate_schema(MutableSequence)
 

--- a/cognite/neat/rules/models/_base_rules.py
+++ b/cognite/neat/rules/models/_base_rules.py
@@ -8,7 +8,7 @@ import sys
 import types
 from abc import ABC, abstractmethod
 from collections.abc import Callable, MutableSequence, Sequence
-from typing import Annotated, Any, ClassVar, Literal, TypeVar, get_args
+from typing import Annotated, Any, ClassVar, Literal, TypeVar, get_args, get_origin
 
 import pandas as pd
 from pydantic import (
@@ -129,11 +129,10 @@ class NeatModel(BaseModel):
                 annotation = annotation.__args__[0]
 
             try:
-                if isinstance(annotation, type) and issubclass(annotation, SheetList):
+                if isinstance(annotation, types.GenericAlias) and get_origin(annotation) is SheetList:
                     # We know that this is a SheetList, so we can safely access the annotation
                     # which is the concrete type of the SheetEntity.
-                    args = get_args(annotation)
-                    model_fields = args[0].model_fields  # type: ignore[union-attr]
+                    model_fields = get_args(annotation)[0].model_fields  # type: ignore[union-attr]
                 elif isinstance(annotation, type) and issubclass(annotation, BaseModel):
                     model_fields = annotation.model_fields
                 else:

--- a/cognite/neat/rules/models/dms/_rules.py
+++ b/cognite/neat/rules/models/dms/_rules.py
@@ -21,8 +21,8 @@ from cognite.neat.rules.models._base_rules import (
     ExtensionCategory,
     RoleTypes,
     SchemaCompleteness,
-    SheetEntity,
     SheetList,
+    SheetRow,
 )
 from cognite.neat.rules.models._types import (
     ExternalIdType,
@@ -144,7 +144,7 @@ class DMSMetadata(BaseMetadata):
         return self.space
 
 
-class DMSProperty(SheetEntity):
+class DMSProperty(SheetRow):
     view: ViewEntity = Field(alias="View")
     view_property: str = Field(alias="View Property")
     name: str | None = Field(alias="Name", default=None)
@@ -192,7 +192,7 @@ class DMSProperty(SheetEntity):
             return str(value_type)
 
 
-class DMSContainer(SheetEntity):
+class DMSContainer(SheetRow):
     container: ContainerEntity = Field(alias="Container")
     name: str | None = Field(alias="Name", default=None)
     description: str | None = Field(alias="Description", default=None)
@@ -219,7 +219,7 @@ class DMSContainer(SheetEntity):
         )
 
 
-class DMSView(SheetEntity):
+class DMSView(SheetRow):
     view: ViewEntity = Field(alias="View")
     name: str | None = Field(alias="Name", default=None)
     description: str | None = Field(alias="Description", default=None)
@@ -249,7 +249,7 @@ class DMSView(SheetEntity):
         )
 
 
-class DMSNode(SheetEntity):
+class DMSNode(SheetRow):
     node: DMSNodeEntity = Field(alias="Node")
     usage: Literal["type", "collection"] = Field(alias="Usage")
     name: str | None = Field(alias="Name", default=None)
@@ -264,7 +264,7 @@ class DMSNode(SheetEntity):
             raise ValueError(f"Unknown usage {self.usage}")
 
 
-class DMSEnum(SheetEntity):
+class DMSEnum(SheetRow):
     collection: ClassEntity = Field(alias="Collection")
     value: str = Field(alias="Value")
     name: str | None = Field(alias="Name", default=None)

--- a/cognite/neat/rules/models/dms/_serializer.py
+++ b/cognite/neat/rules/models/dms/_serializer.py
@@ -72,21 +72,21 @@ class _DMSRulesSerializer:
     def clean(self, dumped: dict[str, Any], as_reference: bool) -> dict[str, Any]:
         # Sorting to get a deterministic order
         dumped[self.prop_name] = sorted(
-            dumped[self.prop_name]["data"], key=lambda p: (p[self.prop_view], p[self.prop_view_property])
+            dumped[self.prop_name], key=lambda p: (p[self.prop_view], p[self.prop_view_property])
         )
-        dumped[self.view_name] = sorted(dumped[self.view_name]["data"], key=lambda v: v[self.view_view])
+        dumped[self.view_name] = sorted(dumped[self.view_name], key=lambda v: v[self.view_view])
         if container_data := dumped.get(self.container_name):
-            dumped[self.container_name] = sorted(container_data["data"], key=lambda c: c[self.container_container])
+            dumped[self.container_name] = sorted(container_data, key=lambda c: c[self.container_container])
         else:
             dumped.pop(self.container_name, None)
 
         if enum_data := dumped.get(self.enum_name):
-            dumped[self.enum_name] = sorted(enum_data["data"], key=lambda e: e[self.enum_collection])
+            dumped[self.enum_name] = sorted(enum_data, key=lambda e: e[self.enum_collection])
         else:
             dumped.pop(self.enum_name, None)
 
         if node_types_data := dumped.get(self.nodes_name):
-            dumped[self.nodes_name] = sorted(node_types_data["data"], key=lambda n: n[self.nodes_node])
+            dumped[self.nodes_name] = sorted(node_types_data, key=lambda n: n[self.nodes_node])
         else:
             dumped.pop(self.nodes_name, None)
 

--- a/cognite/neat/rules/models/domain.py
+++ b/cognite/neat/rules/models/domain.py
@@ -13,8 +13,8 @@ from ._base_rules import (
     BaseMetadata,
     BaseRules,
     RoleTypes,
-    SheetEntity,
     SheetList,
+    SheetRow,
 )
 from ._types import PropertyType, StrOrListType
 
@@ -30,7 +30,7 @@ class DomainMetadata(BaseMetadata):
         return "domain"
 
 
-class DomainProperty(SheetEntity):
+class DomainProperty(SheetRow):
     class_: ClassEntity = Field(alias="Class")
     property_: PropertyType = Field(alias="Property")
     name: str | None = Field(alias="Name", default=None)
@@ -52,7 +52,7 @@ class DomainProperty(SheetEntity):
         return value
 
 
-class DomainClass(SheetEntity):
+class DomainClass(SheetRow):
     class_: ClassEntity = Field(alias="Class")
     name: str | None = Field(alias="Name", default=None)
     description: str | None = Field(None, alias="Description")

--- a/cognite/neat/rules/models/entities/_single_value.py
+++ b/cognite/neat/rules/models/entities/_single_value.py
@@ -58,7 +58,7 @@ class Entity(BaseModel, extra="ignore"):
         elif isinstance(data, str) and data == str(Unknown):
             return UnknownEntity(prefix=Undefined, suffix=Unknown)
         if defaults and isinstance(defaults, dict):
-            # This is is a trick to pass in default values
+            # This is a trick to pass in default values
             return cls.model_validate({_PARSE: data, "defaults": defaults})
         else:
             return cls.model_validate(data)

--- a/cognite/neat/rules/models/information/_rules.py
+++ b/cognite/neat/rules/models/information/_rules.py
@@ -18,8 +18,8 @@ from cognite.neat.rules.models._base_rules import (
     MatchType,
     RoleTypes,
     SchemaCompleteness,
-    SheetEntity,
     SheetList,
+    SheetRow,
 )
 from cognite.neat.rules.models._rdfpath import (
     RDFPath,
@@ -115,7 +115,7 @@ class InformationMetadata(BaseMetadata):
         return self.prefix
 
 
-class InformationClass(SheetEntity):
+class InformationClass(SheetRow):
     """
     Class is a category of things that share a common set of attributes and relationships.
 
@@ -136,7 +136,7 @@ class InformationClass(SheetEntity):
     comment: str | None = Field(alias="Comment", default=None)
 
 
-class InformationProperty(SheetEntity):
+class InformationProperty(SheetRow):
     """
     A property is a characteristic of a class. It is a named attribute of a class that describes a range of values
     or a relationship to another class.

--- a/cognite/neat/rules/models/information/_serializer.py
+++ b/cognite/neat/rules/models/information/_serializer.py
@@ -41,9 +41,9 @@ class _InformationRulesSerializer:
     def clean(self, dumped: dict[str, Any], as_reference: bool) -> dict[str, Any]:
         # Sorting to get a deterministic order
         dumped[self.prop_name] = sorted(
-            dumped[self.prop_name]["data"], key=lambda p: (p[self.prop_class], p[self.prop_property])
+            dumped[self.prop_name], key=lambda p: (p[self.prop_class], p[self.prop_property])
         )
-        dumped[self.class_name] = sorted(dumped[self.class_name]["data"], key=lambda v: v[self.prop_class])
+        dumped[self.class_name] = sorted(dumped[self.class_name], key=lambda v: v[self.prop_class])
 
         for prop in dumped[self.prop_name]:
             if as_reference:

--- a/cognite/neat/rules/models/information/_validation.py
+++ b/cognite/neat/rules/models/information/_validation.py
@@ -151,7 +151,7 @@ class InformationPostValidation:
     def _class_parent_pairs(self) -> dict[ClassEntity, list[ClassEntity]]:
         class_subclass_pairs: dict[ClassEntity, list[ClassEntity]] = {}
 
-        classes = self.rules.model_copy(deep=True).classes.data
+        classes = self.rules.model_copy(deep=True).classes
 
         # USE CASE: Solution model being extended (user + last + reference = complete)
         if (
@@ -159,8 +159,8 @@ class InformationPostValidation:
             and self.metadata.data_model_type == DataModelType.solution
         ):
             classes += (
-                cast(InformationRules, self.rules.last).model_copy(deep=True).classes.data
-                + cast(InformationRules, self.rules.reference).model_copy(deep=True).classes.data
+                cast(InformationRules, self.rules.last).model_copy(deep=True).classes
+                + cast(InformationRules, self.rules.reference).model_copy(deep=True).classes
             )
 
         # USE CASE: Solution model being created from scratch (user + reference = complete)
@@ -168,14 +168,14 @@ class InformationPostValidation:
             self.metadata.schema_ == SchemaCompleteness.complete
             and self.metadata.data_model_type == DataModelType.solution
         ):
-            classes += cast(InformationRules, self.rules.reference).model_copy(deep=True).classes.data
+            classes += cast(InformationRules, self.rules.reference).model_copy(deep=True).classes
 
         # USE CASE: Enterprise model being extended (user + last = complete)
         elif (
             self.metadata.schema_ == SchemaCompleteness.extended
             and self.metadata.data_model_type == DataModelType.enterprise
         ):
-            classes += cast(InformationRules, self.rules.last).model_copy(deep=True).classes.data
+            classes += cast(InformationRules, self.rules.last).model_copy(deep=True).classes
 
         for class_ in classes:
             class_subclass_pairs[class_.class_] = []

--- a/cognite/neat/rules/transformers/_converters.py
+++ b/cognite/neat/rules/transformers/_converters.py
@@ -138,7 +138,7 @@ class _InformationRulesConverter:
         from cognite.neat.rules.models.asset._rules import AssetClass, AssetMetadata, AssetProperty, AssetRules
 
         classes: SheetList[AssetClass] = SheetList[AssetClass](
-            data=[AssetClass(**class_.model_dump()) for class_ in self.rules.classes]
+            [AssetClass(**class_.model_dump()) for class_ in self.rules.classes]
         )
         properties: SheetList[AssetProperty] = SheetList[AssetProperty]()
         for prop_ in self.rules.properties:

--- a/cognite/neat/rules/transformers/_converters.py
+++ b/cognite/neat/rules/transformers/_converters.py
@@ -227,11 +227,9 @@ class _InformationRulesConverter:
 
         return DMSRules(
             metadata=metadata,
-            properties=SheetList[DMSProperty](
-                data=[prop for prop_set in properties_by_class.values() for prop in prop_set]
-            ),
-            views=SheetList[DMSView](data=views),
-            containers=SheetList[DMSContainer](data=containers),
+            properties=SheetList[DMSProperty]([prop for prop_set in properties_by_class.values() for prop in prop_set]),
+            views=SheetList[DMSView](views),
+            containers=SheetList[DMSContainer](containers),
             last=last_dms_rules,
             reference=ref_dms_rules,
         )
@@ -481,8 +479,8 @@ class _DMSRulesConverter:
 
         return InformationRules(
             metadata=metadata,
-            properties=SheetList[InformationProperty](data=properties),
-            classes=SheetList[InformationClass](data=classes),
+            properties=SheetList[InformationProperty](properties),
+            classes=SheetList[InformationClass](classes),
             last=_DMSRulesConverter(self.dms.last).as_information_rules() if self.dms.last else None,
             reference=_DMSRulesConverter(self.dms.reference).as_information_rules() if self.dms.reference else None,
         )

--- a/cognite/neat/store/_base.py
+++ b/cognite/neat/store/_base.py
@@ -182,7 +182,7 @@ class NeatGraphStore:
 
         class_entity = ClassEntity(prefix=self.rules.metadata.prefix, suffix=class_)
 
-        if class_entity not in [definition.class_ for definition in self.rules.classes.data]:
+        if class_entity not in [definition.class_ for definition in self.rules.classes]:
             warnings.warn("Desired type not found in graph!", stacklevel=2)
             return None
 

--- a/tests/tests_integration/test_rules/test_exporters/test_dms_exporters.py
+++ b/tests/tests_integration/test_rules/test_exporters/test_dms_exporters.py
@@ -71,7 +71,7 @@ def table_example() -> InformationRules:
             creator=["Anders"],
         ),
         properties=SheetList[InformationProperty](
-            data=[
+            [
                 InformationProperty(
                     class_="Table",
                     property_="color",
@@ -117,7 +117,7 @@ def table_example() -> InformationRules:
             ]
         ),
         classes=SheetList[InformationClass](
-            data=[
+            [
                 InformationClass(class_="Table", name="Table"),
                 InformationClass(class_="Item", name="Item"),
             ]

--- a/tests/tests_unit/rules/test_analysis.py
+++ b/tests/tests_unit/rules/test_analysis.py
@@ -38,13 +38,10 @@ class TestInformationRulesAnalysis:
         assert len(InformationAnalysis(david_rules).symmetrically_connected_classes(consider_inheritance=False)) == 0
 
     def test_subset_rules(self, david_rules: InformationRules) -> None:
-        assert InformationAnalysis(david_rules).subset_rules({ClassEntity.load("power:GeoLocation")}).classes.data[
+        assert InformationAnalysis(david_rules).subset_rules({ClassEntity.load("power:GeoLocation")}).classes[
             0
         ].class_ == ClassEntity.load("power:GeoLocation")
-        assert (
-            len(InformationAnalysis(david_rules).subset_rules({ClassEntity.load("power:GeoLocation")}).classes.data)
-            == 1
-        )
+        assert len(InformationAnalysis(david_rules).subset_rules({ClassEntity.load("power:GeoLocation")}).classes) == 1
 
 
 class TestAssetRulesAnalysis:

--- a/tests/tests_unit/rules/test_exporters/test_rules2dms.py
+++ b/tests/tests_unit/rules/test_exporters/test_rules2dms.py
@@ -21,7 +21,7 @@ class TestDMSExporter:
 
         # purposely setting default value for connection that should not be
         # considered when exporting DMS rules to DMS schema
-        rules.properties.data[3].default = "Norway"
+        rules.properties[3].default = "Norway"
 
         exporter = DMSExporter()
         schema = exporter.export(rules)

--- a/tests/tests_unit/rules/test_importers/test_dms_importer.py
+++ b/tests/tests_unit/rules/test_importers/test_dms_importer.py
@@ -55,11 +55,11 @@ class TestDMSImporter:
         # This information is lost in the conversion to schema
         exclude = {
             "metadata": {"created", "updated"},
-            "properties": {"data": {"__all__": {"reference"}}},
+            "properties": {"__all__": {"reference"}},
             "reference": {"__all__"},
-            "views": {"data": {"__all__": {"reference"}}},
+            "views": {"__all__": {"reference"}},
             # The Exporter adds node types for each view
-            "nodes": "__all__",
+            "nodes": {"__all__"},
         }
         assert rules.dump(exclude=exclude) == dms_rules.dump(exclude=exclude)
 

--- a/tests/tests_unit/rules/test_models/test_asset_rules.py
+++ b/tests/tests_unit/rules/test_models/test_asset_rules.py
@@ -211,7 +211,7 @@ def parent_property_points_to_data_type():
 class TestAssetRules:
     @pytest.mark.parametrize("rules, expected_exception", list(case_asset_relationship()))
     def test_case_insensitivity(self, rules: dict[str, dict[str, Any]], expected_exception: DataType) -> None:
-        assert AssetRules.model_validate(rules).properties.data[0].implementation == expected_exception
+        assert AssetRules.model_validate(rules).properties[0].implementation == expected_exception
 
     def test_conversion_between_roles(self, david_rules: InformationRules) -> None:
         pipeline = RulesPipeline[InformationRules, InformationRules]([InformationToAsset(), AssetToInformation()])

--- a/tests/tests_unit/rules/test_models/test_dms_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_rules.py
@@ -1444,7 +1444,7 @@ class TestDMSRules:
         valid_rules = raw.as_rules()
         assert valid_rules.model_dump() == expected_rules.model_dump()
         # testing case insensitive value types
-        assert isinstance(valid_rules.properties.data[0].value_type, String)
+        assert isinstance(valid_rules.properties[0].value_type, String)
 
     @pytest.mark.parametrize("raw, expected_errors", list(invalid_container_definitions_test_cases()))
     def test_load_inconsistent_container_definitions(

--- a/tests/tests_unit/rules/test_models/test_dms_rules.py
+++ b/tests/tests_unit/rules/test_models/test_dms_rules.py
@@ -1470,9 +1470,9 @@ class TestDMSRules:
         exclude = {
             # This information is lost in the conversion
             "metadata": {"created", "updated"},
-            "properties": {"data": {"__all__": {"reference"}}},
+            "properties": {"__all__": {"reference"}},
             # The Exporter adds node types for each view as this is an Enterprise model.
-            "nodes": "__all__",
+            "nodes": {"__all__"},
         }
         assert recreated_rules.dump(exclude=exclude) == alice_rules.dump(exclude=exclude)
 

--- a/tests/tests_unit/rules/test_models/test_information_rules.py
+++ b/tests/tests_unit/rules/test_models/test_information_rules.py
@@ -192,7 +192,7 @@ class TestInformationRules:
 
     @pytest.mark.parametrize("rules, expected_exception", list(case_insensitive_value_types()))
     def test_case_insensitivity(self, rules: dict[str, dict[str, Any]], expected_exception: DataType) -> None:
-        assert InformationRules.model_validate(rules).properties.data[0].value_type == expected_exception
+        assert InformationRules.model_validate(rules).properties[0].value_type == expected_exception
 
     def test_david_as_dms(self, david_spreadsheet: dict[str, dict[str, Any]]) -> None:
         david_rules = InformationRules.model_validate(david_spreadsheet)
@@ -203,7 +203,7 @@ class TestInformationRules:
     def test_olav_as_dms(self, olav_rules: InformationRules) -> None:
         olav_rules_copy = olav_rules.model_copy(deep=True)
         # Todo: Remove this line when Olav's Information .xlsx file is available
-        new_classes = SheetList[InformationClass](data=[])
+        new_classes = SheetList[InformationClass]([])
         for cls_ in olav_rules_copy.classes:
             if cls_.class_.versioned_id == "power_analytics:GeoLocation":
                 continue

--- a/tests/tests_unit/rules/test_models/test_input_rules.py
+++ b/tests/tests_unit/rules/test_models/test_input_rules.py
@@ -81,8 +81,8 @@ def pydantic_to_parameters(verified_cls: type[BaseModel]) -> dict[str, set[str]]
             output[name] = set()
             continue
 
-        if issubclass(type_, SheetList):
-            type_ = type_.model_fields["data"].annotation.__args__[0]
+        if isinstance(type_, GenericAlias) and type_.__origin__ is SheetList:
+            type_ = get_args(type_)[0]
 
         if issubclass(type_, BaseModel):
             output[name] = {k for k in type_.model_fields.keys() if k != "validators_to_skip"}

--- a/tests/tests_unit/rules/test_models/test_partial_information_rules.py
+++ b/tests/tests_unit/rules/test_models/test_partial_information_rules.py
@@ -9,8 +9,8 @@ def test_partial_to_complete_mode():
     rules2 = ImporterPipeline.verify(importers.OWLImporter(PARTIAL_MODEL_TEST_DATA / "part2.ttl"))
     rules3 = ImporterPipeline.verify(importers.YAMLImporter.from_file(PARTIAL_MODEL_TEST_DATA / "part3.yaml"))
 
-    rules1.classes.data += rules2.classes.data + rules3.classes.data
-    rules1.properties.data += rules2.properties.data + rules3.properties.data
+    rules1.classes += rules2.classes + rules3.classes
+    rules1.properties += rules2.properties + rules3.properties
     rules1.metadata.schema_ = "complete"
     rules1.metadata.data_model_type = "enterprise"
 

--- a/tests/tests_unit/rules/test_models/test_wrapped_entities.py
+++ b/tests/tests_unit/rules/test_models/test_wrapped_entities.py
@@ -125,7 +125,7 @@ class TestWrappedEntities:
             importers.ExcelImporter(config.DOC_RULES / "dms-architect-rules-raw-filter-example.xlsx")
         )
 
-        assert rules.views.data[0].filter_ == RawFilter.load(
+        assert rules.views[0].filter_ == RawFilter.load(
             """rawFilter({"equals": {"property": ["node", "type"],
                 "value": {"space": "power", "externalId": "WindTurbine"}}})"""
         )


### PR DESCRIPTION
* Rename `SheetEntity` to `SheetRow` to more descriptive of what this is reprensenting.

* Rework `SheetList` this is now an actual Python list and thus gets all methods for free. Implemented custom `pydantic` schema such that it can be used with `pydantic`. This avoids the clumsy `data` property.

* Removed unused methods/functions I found in the process.