### PR TITLE
[NEAT-439] 🐛Strip cells

### DIFF
--- a/cognite/neat/rules/models/_base_rules.py
+++ b/cognite/neat/rules/models/_base_rules.py
@@ -108,6 +108,14 @@ class SchemaModel(BaseModel):
         """Returns a set of mandatory fields for the model."""
         return _get_required_fields(cls, use_alias)
 
+    @field_validator("*", mode="before")
+    def strip_string(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip()
+        elif isinstance(value, list):
+            return [entry.strip() if isinstance(entry, str) else entry for entry in value]
+        return value
+
 
 class BaseMetadata(SchemaModel):
     """
@@ -279,12 +287,6 @@ class BaseRules(SchemaModel, ABC):
 
 
 class SheetRow(SchemaModel):
-    @field_validator("*", mode="before")
-    def strip_string(cls, value: Any) -> Any:
-        if isinstance(value, str):
-            return value.strip()
-        return value
-
     @abstractmethod
     def _identifier(self) -> tuple[Hashable, ...]:
         raise NotImplementedError()

--- a/cognite/neat/rules/models/dms/_rules.py
+++ b/cognite/neat/rules/models/dms/_rules.py
@@ -98,15 +98,15 @@ class DMSMetadata(BaseMetadata):
 
     @field_validator("schema_", mode="plain")
     def as_enum_schema(cls, value: str) -> SchemaCompleteness:
-        return SchemaCompleteness(value)
+        return SchemaCompleteness(value.strip())
 
     @field_validator("extension", mode="plain")
     def as_enum_extension(cls, value: str) -> ExtensionCategory:
-        return ExtensionCategory(value)
+        return ExtensionCategory(value.strip())
 
     @field_validator("data_model_type", mode="plain")
     def as_enum_model_type(cls, value: str) -> DataModelType:
-        return DataModelType(value)
+        return DataModelType(value.strip())
 
     @field_validator("description", mode="before")
     def nan_as_none(cls, value):

--- a/cognite/neat/rules/models/entities/_single_value.py
+++ b/cognite/neat/rules/models/entities/_single_value.py
@@ -17,6 +17,7 @@ from cognite.client.data_classes.data_modeling.ids import (
 from pydantic import (
     BaseModel,
     Field,
+    field_validator,
     model_serializer,
     model_validator,
 )
@@ -96,6 +97,14 @@ class Entity(BaseModel, extra="ignore"):
     @model_serializer(when_used="unless-none", return_type=str)
     def as_str(self) -> str:
         return str(self)
+
+    @field_validator("*", mode="before")
+    def strip_string(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip()
+        elif isinstance(value, list):
+            return [entry.strip() if isinstance(entry, str) else entry for entry in value]
+        return value
 
     @classmethod
     def _parse(cls, raw: str, defaults: dict) -> dict:

--- a/cognite/neat/rules/models/information/_rules.py
+++ b/cognite/neat/rules/models/information/_rules.py
@@ -98,15 +98,15 @@ class InformationMetadata(BaseMetadata):
             return self
         return self
 
-    @field_validator("schema_", mode="before")
+    @field_validator("schema_", mode="plain")
     def as_enum_schema(cls, value: str) -> SchemaCompleteness:
         return SchemaCompleteness(value.strip())
 
-    @field_validator("extension", mode="before")
+    @field_validator("extension", mode="plain")
     def as_enum_extension(cls, value: str) -> ExtensionCategory:
         return ExtensionCategory(value.strip())
 
-    @field_validator("data_model_type", mode="before")
+    @field_validator("data_model_type", mode="plain")
     def as_enum_model_type(cls, value: str) -> DataModelType:
         return DataModelType(value.strip())
 

--- a/cognite/neat/rules/models/information/_rules.py
+++ b/cognite/neat/rules/models/information/_rules.py
@@ -98,17 +98,17 @@ class InformationMetadata(BaseMetadata):
             return self
         return self
 
-    @field_validator("schema_", mode="plain")
+    @field_validator("schema_", mode="before")
     def as_enum_schema(cls, value: str) -> SchemaCompleteness:
-        return SchemaCompleteness(value)
+        return SchemaCompleteness(value.strip())
 
-    @field_validator("extension", mode="plain")
+    @field_validator("extension", mode="before")
     def as_enum_extension(cls, value: str) -> ExtensionCategory:
-        return ExtensionCategory(value)
+        return ExtensionCategory(value.strip())
 
-    @field_validator("data_model_type", mode="plain")
+    @field_validator("data_model_type", mode="before")
     def as_enum_model_type(cls, value: str) -> DataModelType:
-        return DataModelType(value)
+        return DataModelType(value.strip())
 
     def as_identifier(self) -> str:
         return f"{self.prefix}:{self.name}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes are grouped as follows:
 ### Fixed
 - NEAT can now run in a minimal environment without raising a `KeyError` when using the default
   configuration in NEAT importers.
+- NEAT now strips extra whitespace in all imported strings.
 
 
 ## [0.92.1] - 12-09-24

--- a/tests/tests_unit/rules/test_models/test_base_rules.py
+++ b/tests/tests_unit/rules/test_models/test_base_rules.py
@@ -1,0 +1,28 @@
+from cognite.neat.rules.models.information import InformationMetadata
+
+
+class TestBaseRules:
+    def test_strip_whitespace(
+        self,
+    ) -> None:
+        meta = InformationMetadata.model_validate(
+            {
+                "role": "  information architect  ",
+                "dataModelType": "  enterprise ",
+                "schema": "   partial   ",
+                "prefix": "  my-prefix  ",
+                "namespace": "http://purl.org/cognite/neat/",
+                "version": "  0.1.0  ",
+                "name": "  My Data Model  ",
+                "description": "  My Data Model Description  ",
+                "created": "  2022-07-01T00:00:00Z  ",
+                "updated": "  2022-07-01T00:00:00Z  ",
+                "creator": " Me, Myself, I  ",
+            }
+        )
+
+        assert meta.prefix == "my-prefix"
+        assert meta.schema_ == "partial"
+        assert meta.role == "information architect"
+        assert meta.dataModelType == "enterprise"
+        assert meta.creator == ["Me", "Myself", "I"]

--- a/tests/tests_unit/rules/test_models/test_base_rules.py
+++ b/tests/tests_unit/rules/test_models/test_base_rules.py
@@ -34,6 +34,6 @@ class TestBaseRules:
 
         class_ = InformationClass.model_validate(row.dump(default_prefix="neat"))
 
-        assert class_.class_.suffix == "MyClass"
+        assert class_.class_.suffix == "My Class"
         assert class_.name == "My Class Name"
         assert class_.description == "My Class Description"

--- a/tests/tests_unit/rules/test_models/test_base_rules.py
+++ b/tests/tests_unit/rules/test_models/test_base_rules.py
@@ -1,8 +1,8 @@
-from cognite.neat.rules.models.information import InformationMetadata
+from cognite.neat.rules.models.information import InformationClass, InformationInputClass, InformationMetadata
 
 
 class TestBaseRules:
-    def test_strip_whitespace(
+    def test_strip_whitespace_metadata(
         self,
     ) -> None:
         meta = InformationMetadata.model_validate(
@@ -26,3 +26,14 @@ class TestBaseRules:
         assert meta.role == "information architect"
         assert meta.data_model_type == "enterprise"
         assert meta.creator == ["Me", "Myself", "I"]
+
+    def test_strip_whitespace_input_class(self) -> None:
+        row = InformationInputClass(
+            class_="  My Class  ", name="  My Class Name  ", description="  My Class Description  "
+        )
+
+        class_ = InformationClass.model_validate(row.dump(default_prefix="neat"))
+
+        assert class_.class_.suffix == "MyClass"
+        assert class_.name == "My Class Name"
+        assert class_.description == "My Class Description"

--- a/tests/tests_unit/rules/test_models/test_base_rules.py
+++ b/tests/tests_unit/rules/test_models/test_base_rules.py
@@ -8,8 +8,8 @@ class TestBaseRules:
         meta = InformationMetadata.model_validate(
             {
                 "role": "  information architect  ",
-                "dataModelType": "  enterprise ",
-                "schema": "   partial   ",
+                "dataModelType": "   enterprise   ",
+                "schema": "     partial   ",
                 "prefix": "  my-prefix  ",
                 "namespace": "http://purl.org/cognite/neat/",
                 "version": "  0.1.0  ",
@@ -24,5 +24,5 @@ class TestBaseRules:
         assert meta.prefix == "my-prefix"
         assert meta.schema_ == "partial"
         assert meta.role == "information architect"
-        assert meta.dataModelType == "enterprise"
+        assert meta.data_model_type == "enterprise"
         assert meta.creator == ["Me", "Myself", "I"]


### PR DESCRIPTION
Multiple sources for the bug
1. In verified rules, only SheetRows were stripped not metadata sheets. Fixed by moving validator to appropriate location.
2. Input rules creates entities, and entities does not strip extra spaces. Fixed by stripping whitespace from entities.
3. Field validators in child classes have precedence over parent classes (new learning for me), so need to strip in the Enum conversion methods.