### PR TITLE
[NEAT-479] ☃ Frozen Instance bug

### DIFF
--- a/cognite/neat/issues/_base.py
+++ b/cognite/neat/issues/_base.py
@@ -60,7 +60,7 @@ ResourceType: TypeAlias = (
 
 
 @total_ordering
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NeatIssue:
     """This is the base class for all exceptions and warnings (issues) used in Neat."""
 
@@ -176,7 +176,7 @@ class NeatIssue:
         return (type(self).__name__, self.as_message()) == (type(other).__name__, other.as_message())
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NeatError(NeatIssue, Exception):
     """This is the base class for all exceptions (errors) used in Neat."""
 
@@ -238,7 +238,7 @@ class NeatError(NeatIssue, Exception):
                 object.__setattr__(caught_error, "row_number", new_row)
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class DefaultPydanticError(NeatError, ValueError):
     """{type}: {msg} [loc={loc}]"""
 
@@ -263,7 +263,7 @@ class DefaultPydanticError(NeatError, ValueError):
             return self.msg
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class RowError(NeatError, ValueError):
     """In {sheet_name}, row={row}, column={column}: {msg}. [type={type}, input_value={input}]"""
 
@@ -307,7 +307,7 @@ class RowError(NeatError, ValueError):
         return output
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NeatWarning(NeatIssue, UserWarning):
     """This is the base class for all warnings used in Neat."""
 
@@ -317,7 +317,7 @@ class NeatWarning(NeatIssue, UserWarning):
         return DefaultWarning.from_warning_message(warning)
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class DefaultWarning(NeatWarning):
     """{category}: {warning}"""
 

--- a/cognite/neat/issues/errors/_external.py
+++ b/cognite/neat/issues/errors/_external.py
@@ -6,7 +6,7 @@ from yaml import YAMLError
 from cognite.neat.issues import NeatError
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class AuthorizationError(NeatError, RuntimeError):
     """Missing authorization for {action}: {reason}"""
 
@@ -14,7 +14,7 @@ class AuthorizationError(NeatError, RuntimeError):
     reason: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class FileReadError(NeatError, RuntimeError):
     """Error when reading file, {filepath}: {reason}"""
 
@@ -23,7 +23,7 @@ class FileReadError(NeatError, RuntimeError):
     reason: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class FileNotFoundNeatError(NeatError, FileNotFoundError):
     """File {filepath} not found"""
 
@@ -31,7 +31,7 @@ class FileNotFoundNeatError(NeatError, FileNotFoundError):
     filepath: Path
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class FileMissingRequiredFieldError(NeatError, ValueError):
     """Missing required {field_name} in {filepath}: {field}"""
 
@@ -40,7 +40,7 @@ class FileMissingRequiredFieldError(NeatError, ValueError):
     field: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NeatYamlError(NeatError, YAMLError):
     """Invalid YAML: {reason}"""
 
@@ -51,7 +51,7 @@ class NeatYamlError(NeatError, YAMLError):
     expected_format: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class FileTypeUnexpectedError(NeatError, TypeError):
     """Unexpected file type: {filepath}. Expected format: {expected_format}"""
 
@@ -59,7 +59,7 @@ class FileTypeUnexpectedError(NeatError, TypeError):
     expected_format: frozenset[str]
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class FileNotAFileError(NeatError, FileNotFoundError):
     """{filepath} is not a file"""
 

--- a/cognite/neat/issues/errors/_general.py
+++ b/cognite/neat/issues/errors/_general.py
@@ -3,21 +3,21 @@ from dataclasses import dataclass
 from cognite.neat.issues import NeatError
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NeatValueError(NeatError, ValueError):
     """{raw_message}"""
 
     raw_message: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NeatTypeError(NeatError, TypeError):
     """{raw_message}"""
 
     raw_message: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class RegexViolationError(NeatError, ValueError):
     """Value, {value} failed regex, {regex}, validation. Make sure that the name follows the regex pattern."""
 
@@ -25,7 +25,7 @@ class RegexViolationError(NeatError, ValueError):
     regex: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NeatImportError(NeatError, ImportError):
     """The functionality requires {module}. You can include it
     in your neat installation with `pip install "cognite-neat[{neat_extra}]"`.

--- a/cognite/neat/issues/errors/_properties.py
+++ b/cognite/neat/issues/errors/_properties.py
@@ -6,14 +6,14 @@ from cognite.neat.issues._base import ResourceType
 from ._resources import ResourceError, T_Identifier, T_ReferenceIdentifier
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyError(ResourceError[T_Identifier]):
     """Base class for property errors {resource_type} with identifier {identifier}.{property_name}"""
 
     property_name: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyNotFoundError(PropertyError, Generic[T_Identifier, T_ReferenceIdentifier]):
     """The {resource_type} with identifier {identifier} does not have a property {property_name}"""
 
@@ -24,7 +24,7 @@ class PropertyNotFoundError(PropertyError, Generic[T_Identifier, T_ReferenceIden
     referred_type: ResourceType | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyTypeNotSupportedError(PropertyError[T_Identifier]):
     """The {resource_type} with identifier {identifier} has a property {property_name}
     of unsupported type {property_type}"""
@@ -33,14 +33,14 @@ class PropertyTypeNotSupportedError(PropertyError[T_Identifier]):
 
 
 # This is a generic error that should be used sparingly
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyDefinitionError(PropertyError[T_Identifier]):
     """Invalid property definition for {resource_type} {identifier}.{property_name}: {reason}"""
 
     reason: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyDefinitionDuplicatedError(PropertyError[T_Identifier]):
     """The {resource_type} with identifier {identifier} has multiple definitions for the property {property_name}
     with values {property_values}
@@ -53,7 +53,7 @@ class PropertyDefinitionDuplicatedError(PropertyError[T_Identifier]):
     location_name: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyMappingDuplicatedError(PropertyError[T_Identifier], Generic[T_Identifier, T_ReferenceIdentifier]):
     """The {resource_type} with identifier {identifier}.{property_name} is mapped to by: {mappings}. Ensure
     that only one {mapping_type} maps to {resource_type} {identifier}.{property_name}"""

--- a/cognite/neat/issues/errors/_resources.py
+++ b/cognite/neat/issues/errors/_resources.py
@@ -5,7 +5,7 @@ from cognite.neat.issues._base import NeatError, ResourceType, T_Identifier, T_R
 from cognite.neat.utils.text import humanize_collection
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceError(NeatError, Generic[T_Identifier], RuntimeError):
     """Base class for resource errors {resource_type} with identifier {identifier}"""
 
@@ -13,7 +13,7 @@ class ResourceError(NeatError, Generic[T_Identifier], RuntimeError):
     resource_type: ResourceType
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceDuplicatedError(ResourceError[T_Identifier]):
     """The {resource_type} with identifier {identifier} is duplicated in {location}"""
 
@@ -21,14 +21,14 @@ class ResourceDuplicatedError(ResourceError[T_Identifier]):
     location: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceRetrievalError(ResourceError[T_Identifier]):
     """Failed to retrieve {resource_type} with identifier {identifier}. The error was: {error}"""
 
     error: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceNotFoundError(ResourceError, Generic[T_Identifier, T_ReferenceIdentifier]):
     """The {resource_type} with identifier {identifier} does not exist"""
 
@@ -50,7 +50,7 @@ class ResourceNotFoundError(ResourceError, Generic[T_Identifier, T_ReferenceIden
         return msg
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceNotDefinedError(ResourceError[T_Identifier]):
     """The {resource_type} {identifier} is not defined in the {location}"""
 
@@ -63,7 +63,7 @@ class ResourceNotDefinedError(ResourceError[T_Identifier]):
     sheet_name: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceConvertionError(ResourceError, ValueError):
     """Failed to convert the {resource_type} {identifier} to {target_format}: {reason}"""
 
@@ -72,14 +72,14 @@ class ResourceConvertionError(ResourceError, ValueError):
     reason: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceCreationError(ResourceError[T_Identifier], ValueError):
     """Failed to create {resource_type} with identifier {identifier}. The error was: {error}"""
 
     error: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceMissingIdentifierError(NeatError, ValueError):
     """The {resource_type} with name {name} is missing an identifier."""
 
@@ -87,7 +87,7 @@ class ResourceMissingIdentifierError(NeatError, ValueError):
     name: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceChangedError(ResourceError[T_Identifier]):
     """The {resource_type} with identifier {identifier} has changed{changed}"""
 

--- a/cognite/neat/issues/errors/_workflow.py
+++ b/cognite/neat/issues/errors/_workflow.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from cognite.neat.issues import NeatError
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class WorkFlowMissingDataError(NeatError, ValueError):
     """In the workflow step {step_name} the following data is missing: {missing_data}."""
 
@@ -11,14 +11,14 @@ class WorkFlowMissingDataError(NeatError, ValueError):
     missing_data: frozenset[str]
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class WorkflowStepNotInitializedError(NeatError, RuntimeError):
     """Step {step_name} has not been initialized."""
 
     step_name: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class WorkflowConfigurationNotSetError(NeatError, RuntimeError):
     """The configuration variable '{config_variable}' is not set. Please set the configuration
     before running the workflow."""
@@ -26,7 +26,7 @@ class WorkflowConfigurationNotSetError(NeatError, RuntimeError):
     config_variable: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class WorkflowStepOutputError(NeatError, RuntimeError):
     """Object type {step_type} is not supported as step output.
 

--- a/cognite/neat/issues/warnings/_external.py
+++ b/cognite/neat/issues/warnings/_external.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from cognite.neat.issues import NeatWarning
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class FileReadWarning(NeatWarning):
     """Error when reading file, {filepath}: {reason}"""
 
@@ -12,7 +12,7 @@ class FileReadWarning(NeatWarning):
     reason: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class FileMissingRequiredFieldWarning(NeatWarning):
     """Missing required {field_name} in {filepath}: {field}. The file will be skipped"""
 
@@ -21,7 +21,7 @@ class FileMissingRequiredFieldWarning(NeatWarning):
     field: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class FileTypeUnexpectedWarning(NeatWarning):
     """Unexpected file type: {filepath}. Expected format: {expected_format}"""
 
@@ -32,7 +32,7 @@ class FileTypeUnexpectedWarning(NeatWarning):
     error_message: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class FileItemNotSupportedWarning(NeatWarning):
     """The item {item} in {filepath} is not supported. The item will be skipped"""
 

--- a/cognite/neat/issues/warnings/_general.py
+++ b/cognite/neat/issues/warnings/_general.py
@@ -3,21 +3,21 @@ from dataclasses import dataclass
 from cognite.neat.issues import NeatWarning
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NeatValueWarning(NeatWarning):
     """{value}"""
 
     value: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NotSupportedWarning(NeatWarning):
     """{feature} is not supported"""
 
     feature: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class RegexViolationWarning(NeatWarning):
     """The value '{value}' of {identifier} does not match the {pattern_name} pattern '{pattern}'"""
 

--- a/cognite/neat/issues/warnings/_models.py
+++ b/cognite/neat/issues/warnings/_models.py
@@ -10,7 +10,7 @@ from cognite.neat.issues import NeatWarning
 _BASE_URL = "https://cognite-neat.readthedocs-hosted.com/en/latest/data-modeling-principles.html"
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class BreakingModelingPrincipleWarning(NeatWarning, ABC):
     """{warning_class}: {specific} violates the {principle} principle.
     See {url} for more information."""
@@ -29,7 +29,7 @@ class BreakingModelingPrincipleWarning(NeatWarning, ABC):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PrincipleOneModelOneSpaceWarning(BreakingModelingPrincipleWarning):
     """{warning_class}: {specific} violates the {principle} principle.
     See {url} for more information."""
@@ -37,7 +37,7 @@ class PrincipleOneModelOneSpaceWarning(BreakingModelingPrincipleWarning):
     url = "all-data-models-are-kept-in-its-own-space"
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PrincipleMatchingSpaceAndVersionWarning(BreakingModelingPrincipleWarning):
     """{warning_class}: {specific} violates the {principle} principle.
     See {url} for more information."""
@@ -45,7 +45,7 @@ class PrincipleMatchingSpaceAndVersionWarning(BreakingModelingPrincipleWarning):
     url = "all-views-of-a-data-models-have-the-same-version-and-space-as-the-data-model"
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PrincipleSolutionBuildsOnEnterpriseWarning(BreakingModelingPrincipleWarning):
     """{warning_class}: {specific} violates the {principle} principle.
     See {url} for more information."""
@@ -53,7 +53,7 @@ class PrincipleSolutionBuildsOnEnterpriseWarning(BreakingModelingPrincipleWarnin
     url = "solution-data-models-should-always-be-referencing-the-enterprise-data-model"
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class UserModelingWarning(NeatWarning, ABC):
     """This is a generic warning for user modeling issues.
     These warnings will not cause the resulting model to be invalid, but
@@ -62,7 +62,7 @@ class UserModelingWarning(NeatWarning, ABC):
     ...
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class CDFNotSupportedWarning(NeatWarning, ABC):
     """This is a base class for warnings for modeling issues that will
     likely lead to the CDF API rejecting the model."""
@@ -70,7 +70,7 @@ class CDFNotSupportedWarning(NeatWarning, ABC):
     ...
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NotSupportedViewContainerLimitWarning(CDFNotSupportedWarning):
     """The view {view_id} maps, {count} containers, which is more than the limit {limit}."""
 
@@ -81,7 +81,7 @@ class NotSupportedViewContainerLimitWarning(CDFNotSupportedWarning):
     limit: int = DMS_VIEW_CONTAINER_SIZE_LIMIT
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NotSupportedHasDataFilterLimitWarning(CDFNotSupportedWarning):
     """The view {view_id} uses a hasData filter applied to {count} containers, which is more than the limit {limit}."""
 

--- a/cognite/neat/issues/warnings/_properties.py
+++ b/cognite/neat/issues/warnings/_properties.py
@@ -6,14 +6,14 @@ from cognite.neat.issues._base import ResourceType
 from ._resources import ResourceNeatWarning, T_Identifier, T_ReferenceIdentifier
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyWarning(ResourceNeatWarning[T_Identifier]):
     """Base class for property warnings {resource_type} with identifier {identifier}.{property_name}"""
 
     property_name: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyTypeNotSupportedWarning(PropertyWarning[T_Identifier]):
     """The {resource_type} with identifier {identifier} has a property {property_name}
     of unsupported type {property_type}. This will be ignored."""
@@ -21,7 +21,7 @@ class PropertyTypeNotSupportedWarning(PropertyWarning[T_Identifier]):
     property_type: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyNotFoundWarning(PropertyWarning, Generic[T_Identifier, T_ReferenceIdentifier]):
     """The {resource_type} with identifier {identifier} does not have a property {property_name} referred
     to by {referred_type} {referred_by} does not exist. This will be ignored.
@@ -32,7 +32,7 @@ class PropertyNotFoundWarning(PropertyWarning, Generic[T_Identifier, T_Reference
     referred_type: ResourceType
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyDefinitionDuplicatedWarning(PropertyWarning[T_Identifier]):
     """Got multiple values for the {resource_type} {identifier}.{property_name} {values}.
     {default_action}"""
@@ -44,7 +44,7 @@ class PropertyDefinitionDuplicatedWarning(PropertyWarning[T_Identifier]):
     recommended_action: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class PropertyValueTypeUndefinedWarning(PropertyWarning[T_Identifier]):
     """The {resource_type} with identifier {identifier} has a property {property_name}
     which has undefined value type. This may result in unexpected behavior when exporting rules.

--- a/cognite/neat/issues/warnings/_resources.py
+++ b/cognite/neat/issues/warnings/_resources.py
@@ -5,7 +5,7 @@ from cognite.neat.issues._base import NeatWarning, ResourceType, T_Identifier, T
 
 
 # Name ResourceNeatWarning to avoid conflicts with the built-in ResourceWarning
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceNeatWarning(NeatWarning, Generic[T_Identifier]):
     """Base class for resource warnings {resource_type} with identifier {identifier}"""
 
@@ -13,7 +13,7 @@ class ResourceNeatWarning(NeatWarning, Generic[T_Identifier]):
     resource_type: ResourceType
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceNotFoundWarning(ResourceNeatWarning, Generic[T_Identifier, T_ReferenceIdentifier]):
     """The {resource_type} with identifier {identifier} referred by {referred_type} {referred_by} does not exist.
     This will be ignored."""
@@ -24,7 +24,7 @@ class ResourceNotFoundWarning(ResourceNeatWarning, Generic[T_Identifier, T_Refer
     referred_type: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourcesDuplicatedWarning(NeatWarning, Generic[T_Identifier]):
     """Duplicated {resource_type} with identifiers {resources} were found. {default_action}"""
 
@@ -35,7 +35,7 @@ class ResourcesDuplicatedWarning(NeatWarning, Generic[T_Identifier]):
     default_action: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ResourceRetrievalWarning(NeatWarning, Generic[T_Identifier]):
     """Failed to retrieve {resource_type} with identifiers {resources}. Continuing without
     these resources."""

--- a/cognite/neat/issues/warnings/user_modeling.py
+++ b/cognite/neat/issues/warnings/user_modeling.py
@@ -23,7 +23,7 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class DirectRelationMissingSourceWarning(UserModelingWarning):
     """The view {view_id}.{prop_name} is a direct relation without a source.
     Direct relations in views should point to a single other view, if not, you end up
@@ -35,7 +35,7 @@ class DirectRelationMissingSourceWarning(UserModelingWarning):
     prop_name: str
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ParentInDifferentSpaceWarning(UserModelingWarning):
     """The view {view_id} has multiple parents in different spaces.
     Neat recommends maximum one implementation of a view from another space."""
@@ -45,7 +45,7 @@ class ParentInDifferentSpaceWarning(UserModelingWarning):
     view_id: ViewId
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class EmptyContainerWarning(UserModelingWarning):
     """Container {container_id} is empty and will be skipped.
     The container does not have any properties."""
@@ -55,7 +55,7 @@ class EmptyContainerWarning(UserModelingWarning):
     container_id: ContainerId
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class HasDataFilterOnNoPropertiesViewWarning(UserModelingWarning):
     """Cannot set hasData filter on view {view_id}.
     The view does not have properties in any containers.
@@ -66,7 +66,7 @@ class HasDataFilterOnNoPropertiesViewWarning(UserModelingWarning):
     view_id: ViewId
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NodeTypeFilterOnParentViewWarning(UserModelingWarning):
     """Setting a node type filter on parent view {view_id}.
     This is not recommended as parent views are typically used for multiple types of nodes."""
@@ -76,7 +76,7 @@ class NodeTypeFilterOnParentViewWarning(UserModelingWarning):
     view_id: ViewId
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class HasDataFilterOnViewWithReferencesWarning(UserModelingWarning):
     """Setting a hasData filter on view {view_id} which references other views {references}.
     This is not recommended as it will lead to no nodes being returned when querying the solution view.
@@ -88,7 +88,7 @@ class HasDataFilterOnViewWithReferencesWarning(UserModelingWarning):
     references: frozenset[ViewId]
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class ViewPropertyLimitWarning(UserModelingWarning):
     """The number of properties in the {view_id} view is {count} which
     is more than the API limit {limit} properties.
@@ -102,7 +102,7 @@ class ViewPropertyLimitWarning(UserModelingWarning):
     limit: int = DMS_CONTAINER_PROPERTY_SIZE_LIMIT
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class NotNeatSupportedFilterWarning(UserModelingWarning):
     """The view {view_id} uses a non-standard filter.
     This will not be validated by Neat, and is thus not recommended.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,9 @@ Changes are grouped as follows:
 ### Removed
 - State on DataType stored in `_dms_loaded` attribute
 
+### Changed
+- `NeatIssue` are no longer immutable. This is to comply with the expectation of Exceptions in Python.
+
 ## [0.92.3] - 17-09-24
 ### Fixed
 - Prefixes not being imported or exported to Excel

--- a/tests/tests_unit/test_issues/test_issue_behavior.py
+++ b/tests/tests_unit/test_issues/test_issue_behavior.py
@@ -1,0 +1,18 @@
+import pytest
+
+from cognite.neat.issues import IssueList
+from cognite.neat.issues.errors import ResourceCreationError
+from cognite.neat.rules.transformers._verification import _handle_issues
+
+
+class TestIssues:
+    def test_raise_issue_in_contextmanager(self) -> None:
+        """Test that an issue is raised in the context manager."""
+        my_error = ResourceCreationError(identifier="missing", resource_type="space", error="No CDF Connection")
+
+        errors = IssueList()
+        with pytest.raises(ResourceCreationError) as exc_info:
+            with _handle_issues(issues=errors):
+                raise my_error
+
+        assert exc_info.value == my_error


### PR DESCRIPTION
## User Screenshot

![image](https://github.com/user-attachments/assets/a693c723-ccc5-42a3-8e54-6b8a64429e85)

## Description

When you use a `contextmanager` to handle exceptions `RunTimeError` are mutated with setting the `__traceback__` attribute.

From the source code of the `contextlib` packages from the standard library
```python
           ....
            except RuntimeError as exc:
                # Don't re-raise the passed in exception. (issue27122)
                if exc is value:
                   
                    exc.__traceback__ = traceback # ⬅ This is causing the problem.
                    return False
            except BaseException as exc:
                if exc is not value:
                    raise
```
For example, all `ResourceError` in neat are `RunTimeError`s

## Solution(s)

1. We could avoid subclassing `RunTimeError` for all `NeatIssues`. 
2. Not make `NeatIssues` immutable.

I do not like solution 1 as it only solves this case. If the standard library of Python expects to mutate Exceptions, it seems very dangerous for us not to allow it. Thus, going with solution 2 means that since we have a hierarchy of `NeatIssues` -> `NeatErrors` and `NeatWarnings`, everything in the hierarchy needs to be mutable. We cannot make for example `NeatErrors` mutable while making `NeatWarnings` immutable. I think this is fine, my main motivation for immutable was to get Errors and Warnings to be hashable so you can for example easily removed duplicates. Thus even though this is an unsafe in terms of the lifetime of the Warning/Error I think it is ok to consider a mutated Warning/Error to no longer be the same warning as the original.

