### PR TITLE
[NEAT-500] Update migration tutorial Part 1

### DIFF
--- a/cognite/neat/_session/_base.py
+++ b/cognite/neat/_session/_base.py
@@ -10,6 +10,7 @@ from cognite.neat._rules.models.information._rules import InformationRules
 from cognite.neat._rules.models.information._rules_input import InformationInputRules
 from cognite.neat._rules.transformers import ConvertToRules, VerifyAnyRules
 
+from ._inspect import InspectAPI
 from ._prepare import PrepareAPI
 from ._read import ReadAPI
 from ._show import ShowAPI
@@ -33,6 +34,7 @@ class NeatSession:
         self.to = ToAPI(self._state, client, verbose)
         self.prepare = PrepareAPI(self._state, verbose)
         self.show = ShowAPI(self._state)
+        self.inspect = InspectAPI(self._state)
 
     def verify(self) -> IssueList:
         output = VerifyAnyRules("continue").try_transform(self._state.input_rule)

--- a/cognite/neat/_session/_inspect.py
+++ b/cognite/neat/_session/_inspect.py
@@ -9,6 +9,7 @@ class InspectAPI:
     def __init__(self, state: SessionState) -> None:
         self._state = state
 
+    @property
     def properties(self) -> pd.DataFrame:
         """Returns the properties of the current data model."""
         return self._state.last_verified_rule.properties.to_pandas()

--- a/cognite/neat/_session/_inspect.py
+++ b/cognite/neat/_session/_inspect.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+from ._state import SessionState
+from .exceptions import intercept_session_exceptions
+
+
+@intercept_session_exceptions
+class InspectAPI:
+    def __init__(self, state: SessionState) -> None:
+        self._state = state
+
+    def properties(self) -> pd.DataFrame:
+        """Returns the properties of the current data model."""
+        return self._state.last_verified_rule.properties.to_pandas()

--- a/cognite/neat/_session/_read.py
+++ b/cognite/neat/_session/_read.py
@@ -7,6 +7,7 @@ from cognite.client.data_classes.data_modeling import DataModelIdentifier
 from cognite.neat._graph import examples as instances_examples
 from cognite.neat._graph import extractors
 from cognite.neat._issues import IssueList
+from cognite.neat._issues.errors import NeatValueError
 from cognite.neat._rules import importers
 from cognite.neat._rules._shared import ReadRules
 
@@ -47,7 +48,7 @@ class BaseReadAPI:
         elif isinstance(io, Path):
             return io
         else:
-            raise ValueError(f"Expected str or Path, got {type(io)}")
+            raise NeatValueError(f"Expected str or Path, got {type(io)}")
 
 
 @intercept_session_exceptions
@@ -59,7 +60,7 @@ class CDFReadAPI(BaseReadAPI):
     @property
     def _get_client(self) -> CogniteClient:
         if self._client is None:
-            raise ValueError("No client provided. Please provide a client to read a data model.")
+            raise NeatValueError("No client provided. Please provide a client to read a data model.")
         return self._client
 
     def data_model(self, data_model_id: DataModelIdentifier) -> IssueList:

--- a/cognite/neat/_session/_read.py
+++ b/cognite/neat/_session/_read.py
@@ -70,7 +70,13 @@ class CDFReadAPI(BaseReadAPI):
 
 
 @intercept_session_exceptions
-class CDFClassicAPI(CDFReadAPI):
+class CDFClassicAPI(BaseReadAPI):
+    @property
+    def _get_client(self) -> CogniteClient:
+        if self._client is None:
+            raise ValueError("No client provided. Please provide a client to read a data model.")
+        return self._client
+
     def assets(self, root_asset_external_id: str) -> None:
         extractor = extractors.AssetsExtractor.from_hierarchy(self._get_client, root_asset_external_id)
         self._state.store.write(extractor)

--- a/cognite/neat/_session/_read.py
+++ b/cognite/neat/_session/_read.py
@@ -52,14 +52,30 @@ class BaseReadAPI:
 
 @intercept_session_exceptions
 class CDFReadAPI(BaseReadAPI):
-    def data_model(self, data_model_id: DataModelIdentifier) -> IssueList:
+    def __init__(self, state: SessionState, client: CogniteClient | None, verbose: bool) -> None:
+        super().__init__(state, client, verbose)
+        self.classic = CDFClassicAPI(state, client, verbose)
+
+    @property
+    def _get_client(self) -> CogniteClient:
         if self._client is None:
             raise ValueError("No client provided. Please provide a client to read a data model.")
+        return self._client
 
-        importer = importers.DMSImporter.from_data_model_id(self._client, data_model_id)
+    def data_model(self, data_model_id: DataModelIdentifier) -> IssueList:
+        importer = importers.DMSImporter.from_data_model_id(self._get_client, data_model_id)
         input_rules = importer.to_rules()
         self._store_rules(data_model_id, input_rules, "CDF")
         return input_rules.issues
+
+
+@intercept_session_exceptions
+class CDFClassicAPI(CDFReadAPI):
+    def assets(self, root_asset_external_id: str) -> None:
+        extractor = extractors.AssetsExtractor.from_hierarchy(self._get_client, root_asset_external_id)
+        self._state.store.write(extractor)
+        if self._verbose:
+            print(f"Asset hierarchy {root_asset_external_id} read successfully")
 
 
 @intercept_session_exceptions

--- a/cognite/neat/_store/_base.py
+++ b/cognite/neat/_store/_base.py
@@ -367,20 +367,23 @@ class NeatGraphStore:
     def _shorten_summary(self, summary: pd.DataFrame) -> pd.DataFrame:
         """Shorten summary to top 5 types by occurrence."""
         top_5_rows = summary.head(5)
-        last_row = summary.tail(1)
 
         indexes = [
             *top_5_rows.index.tolist(),
-            "...",
-            *last_row.index.tolist(),
         ]
+        data = [
+            top_5_rows,
+        ]
+        if len(summary) > 6:
+            last_row = summary.tail(1)
+            indexes += [
+                "...",
+                *last_row.index.tolist(),
+            ]
+            data.extend([pd.DataFrame([["..."] * summary.shape[1]], columns=summary.columns), last_row])
 
         shorter_summary = pd.concat(
-            [
-                top_5_rows,
-                pd.DataFrame([["..."] * summary.shape[1]], columns=summary.columns),
-                last_row,
-            ],
+            data,
             ignore_index=True,
         )
         shorter_summary.index = cast(Index, indexes)

--- a/docs/tutorials/data-onboarding/asset_hierarchy_migration.ipynb
+++ b/docs/tutorials/data-onboarding/asset_hierarchy_migration.ipynb
@@ -67,17 +67,21 @@
      ]
     },
     {
-     "data": {
-      "text/html": [
-       "<strong>Empty session</strong>. Get started by reading something with the <em>.read</em> attribute."
-      ],
-      "text/plain": [
-       "<cognite.neat._session._base.NeatSession at 0x25ef81a6180>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "RecursionError",
+     "evalue": "maximum recursion depth exceeded",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mRecursionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[2], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m neat \u001b[38;5;241m=\u001b[39m \u001b[43mNeatSession\u001b[49m\u001b[43m(\u001b[49m\u001b[43mget_cognite_client\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m.env\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m      2\u001b[0m neat\n",
+      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_base.py:32\u001b[0m, in \u001b[0;36mNeatSession.__init__\u001b[1;34m(self, client, storage, verbose)\u001b[0m\n\u001b[0;32m     30\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_verbose \u001b[38;5;241m=\u001b[39m verbose\n\u001b[0;32m     31\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_state \u001b[38;5;241m=\u001b[39m SessionState(store_type\u001b[38;5;241m=\u001b[39mstorage)\n\u001b[1;32m---> 32\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mread \u001b[38;5;241m=\u001b[39m \u001b[43mReadAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_state\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     33\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mto \u001b[38;5;241m=\u001b[39m ToAPI(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_state, client, verbose)\n\u001b[0;32m     34\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprepare \u001b[38;5;241m=\u001b[39m PrepareAPI(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_state, verbose)\n",
+      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_read.py:23\u001b[0m, in \u001b[0;36mReadAPI.__init__\u001b[1;34m(self, state, client, verbose)\u001b[0m\n\u001b[0;32m     21\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_state \u001b[38;5;241m=\u001b[39m state\n\u001b[0;32m     22\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_verbose \u001b[38;5;241m=\u001b[39m verbose\n\u001b[1;32m---> 23\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcdf \u001b[38;5;241m=\u001b[39m \u001b[43mCDFReadAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     24\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrdf \u001b[38;5;241m=\u001b[39m RDFReadAPI(state, client, verbose)\n\u001b[0;32m     25\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mexcel \u001b[38;5;241m=\u001b[39m ExcelReadAPI(state, client, verbose)\n",
+      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_read.py:57\u001b[0m, in \u001b[0;36mCDFReadAPI.__init__\u001b[1;34m(self, state, client, verbose)\u001b[0m\n\u001b[0;32m     55\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, state: SessionState, client: CogniteClient \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, verbose: \u001b[38;5;28mbool\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m     56\u001b[0m     \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(state, client, verbose)\n\u001b[1;32m---> 57\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclassic \u001b[38;5;241m=\u001b[39m \u001b[43mCDFClassicAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_read.py:57\u001b[0m, in \u001b[0;36mCDFReadAPI.__init__\u001b[1;34m(self, state, client, verbose)\u001b[0m\n\u001b[0;32m     55\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, state: SessionState, client: CogniteClient \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, verbose: \u001b[38;5;28mbool\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m     56\u001b[0m     \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(state, client, verbose)\n\u001b[1;32m---> 57\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclassic \u001b[38;5;241m=\u001b[39m \u001b[43mCDFClassicAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n",
+      "    \u001b[1;31m[... skipping similar frames: CDFReadAPI.__init__ at line 57 (489 times)]\u001b[0m\n",
+      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_read.py:57\u001b[0m, in \u001b[0;36mCDFReadAPI.__init__\u001b[1;34m(self, state, client, verbose)\u001b[0m\n\u001b[0;32m     55\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, state: SessionState, client: CogniteClient \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, verbose: \u001b[38;5;28mbool\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m     56\u001b[0m     \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(state, client, verbose)\n\u001b[1;32m---> 57\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclassic \u001b[38;5;241m=\u001b[39m \u001b[43mCDFClassicAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[1;31mRecursionError\u001b[0m: maximum recursion depth exceeded"
+     ]
     }
    ],
    "source": [
@@ -87,42 +91,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "d5c652c4-a3a3-4763-b26e-4f8da4ebdf82",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ca7a6549ca8440be94021e2015d20ff6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Asset hierarchy lift_pump_stations:root read successfully\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "neat.read.cdf.classic_assets(root_asset_external_id=\"lift_pump_stations:root\")"
    ]
@@ -137,64 +109,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "297cb3ee-f8a1-4358-a944-cc5cd3135413",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<H2>Instances</H2> <br /><strong>Overview</strong>:<ul><li>1 types</strong></li><li>245 instances</strong></li></ul><div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Type</th>\n",
-       "      <th>Occurrence</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Asset</td>\n",
-       "      <td>245</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Asset</td>\n",
-       "      <td>245</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div><br /><strong>Provenance</strong>:<ul><li>Initialize graph store as Memory</li><li>Extracted triples to graph store using AssetsExtractor</li></ul>"
-      ],
-      "text/plain": [
-       "<cognite.neat._session._base.NeatSession at 0x25ef81a6180>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "neat"
    ]

--- a/docs/tutorials/data-onboarding/asset_hierarchy_migration.ipynb
+++ b/docs/tutorials/data-onboarding/asset_hierarchy_migration.ipynb
@@ -67,21 +67,17 @@
      ]
     },
     {
-     "ename": "RecursionError",
-     "evalue": "maximum recursion depth exceeded",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mRecursionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[2], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m neat \u001b[38;5;241m=\u001b[39m \u001b[43mNeatSession\u001b[49m\u001b[43m(\u001b[49m\u001b[43mget_cognite_client\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m.env\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m      2\u001b[0m neat\n",
-      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_base.py:32\u001b[0m, in \u001b[0;36mNeatSession.__init__\u001b[1;34m(self, client, storage, verbose)\u001b[0m\n\u001b[0;32m     30\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_verbose \u001b[38;5;241m=\u001b[39m verbose\n\u001b[0;32m     31\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_state \u001b[38;5;241m=\u001b[39m SessionState(store_type\u001b[38;5;241m=\u001b[39mstorage)\n\u001b[1;32m---> 32\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mread \u001b[38;5;241m=\u001b[39m \u001b[43mReadAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_state\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     33\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mto \u001b[38;5;241m=\u001b[39m ToAPI(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_state, client, verbose)\n\u001b[0;32m     34\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprepare \u001b[38;5;241m=\u001b[39m PrepareAPI(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_state, verbose)\n",
-      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_read.py:23\u001b[0m, in \u001b[0;36mReadAPI.__init__\u001b[1;34m(self, state, client, verbose)\u001b[0m\n\u001b[0;32m     21\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_state \u001b[38;5;241m=\u001b[39m state\n\u001b[0;32m     22\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_verbose \u001b[38;5;241m=\u001b[39m verbose\n\u001b[1;32m---> 23\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcdf \u001b[38;5;241m=\u001b[39m \u001b[43mCDFReadAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     24\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrdf \u001b[38;5;241m=\u001b[39m RDFReadAPI(state, client, verbose)\n\u001b[0;32m     25\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mexcel \u001b[38;5;241m=\u001b[39m ExcelReadAPI(state, client, verbose)\n",
-      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_read.py:57\u001b[0m, in \u001b[0;36mCDFReadAPI.__init__\u001b[1;34m(self, state, client, verbose)\u001b[0m\n\u001b[0;32m     55\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, state: SessionState, client: CogniteClient \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, verbose: \u001b[38;5;28mbool\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m     56\u001b[0m     \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(state, client, verbose)\n\u001b[1;32m---> 57\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclassic \u001b[38;5;241m=\u001b[39m \u001b[43mCDFClassicAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_read.py:57\u001b[0m, in \u001b[0;36mCDFReadAPI.__init__\u001b[1;34m(self, state, client, verbose)\u001b[0m\n\u001b[0;32m     55\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, state: SessionState, client: CogniteClient \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, verbose: \u001b[38;5;28mbool\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m     56\u001b[0m     \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(state, client, verbose)\n\u001b[1;32m---> 57\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclassic \u001b[38;5;241m=\u001b[39m \u001b[43mCDFClassicAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n",
-      "    \u001b[1;31m[... skipping similar frames: CDFReadAPI.__init__ at line 57 (489 times)]\u001b[0m\n",
-      "File \u001b[1;32m~\\Projects\\internal\\neat\\cognite\\neat\\_session\\_read.py:57\u001b[0m, in \u001b[0;36mCDFReadAPI.__init__\u001b[1;34m(self, state, client, verbose)\u001b[0m\n\u001b[0;32m     55\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, state: SessionState, client: CogniteClient \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, verbose: \u001b[38;5;28mbool\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m     56\u001b[0m     \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(state, client, verbose)\n\u001b[1;32m---> 57\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclassic \u001b[38;5;241m=\u001b[39m \u001b[43mCDFClassicAPI\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[1;31mRecursionError\u001b[0m: maximum recursion depth exceeded"
-     ]
+     "data": {
+      "text/html": [
+       "<strong>Empty session</strong>. Get started by reading something with the <em>.read</em> attribute."
+      ],
+      "text/plain": [
+       "<cognite.neat._session._base.NeatSession at 0x201950d02f0>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -91,28 +87,106 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "d5c652c4-a3a3-4763-b26e-4f8da4ebdf82",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "008245f277d14057b5ff2742a430f6f0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Asset hierarchy lift_pump_stations:root read successfully\n"
+     ]
+    }
+   ],
    "source": [
-    "neat.read.cdf.classic_assets(root_asset_external_id=\"lift_pump_stations:root\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8e3bd2e1-0571-4119-9e1e-b842fcfa18a6",
-   "metadata": {},
-   "source": [
-    "We can check the status of the `NeatSession` "
+    "neat.read.cdf.classic.assets(root_asset_external_id=\"lift_pump_stations:root\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "297cb3ee-f8a1-4358-a944-cc5cd3135413",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<H2>Instances</H2> <br /><strong>Overview</strong>:<ul><li>1 types</strong></li><li>245 instances</strong></li></ul><div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Type</th>\n",
+       "      <th>Occurrence</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Asset</td>\n",
+       "      <td>245</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Asset</td>\n",
+       "      <td>245</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div><br /><strong>Provenance</strong>:<ul><li>Initialize graph store as Memory</li><li>Extracted triples to graph store using AssetsExtractor</li></ul>"
+      ],
+      "text/plain": [
+       "<cognite.neat._session._base.NeatSession at 0x201950d02f0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "neat"
    ]

--- a/docs/tutorials/data-onboarding/asset_hierarchy_migration.ipynb
+++ b/docs/tutorials/data-onboarding/asset_hierarchy_migration.ipynb
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f63c5b57-5402-42e9-af1e-3afd909a345c",
+   "id": "32ab99b9-fe20-48ce-be1f-56e28efc572d",
    "metadata": {},
    "outputs": [
     {
@@ -65,36 +65,47 @@
      "text": [
       "Found .env file in repository root. Loaded variables from .env file.\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "client = get_cognite_client(\".env\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f63c5b57-5402-42e9-af1e-3afd909a345c",
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "text/html": [
        "<strong>Empty session</strong>. Get started by reading something with the <em>.read</em> attribute."
       ],
       "text/plain": [
-       "<cognite.neat._session._base.NeatSession at 0x201950d02f0>"
+       "<cognite.neat._session._base.NeatSession at 0x1a276127bc0>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "neat = NeatSession(get_cognite_client(\".env\"))\n",
+    "neat = NeatSession(client, storage=\"memory\")\n",
     "neat"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "d5c652c4-a3a3-4763-b26e-4f8da4ebdf82",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "008245f277d14057b5ff2742a430f6f0",
+       "model_id": "80c10342ed1c435d90f569e0c8f74966",
        "version_major": 2,
        "version_minor": 0
       },
@@ -129,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "297cb3ee-f8a1-4358-a944-cc5cd3135413",
    "metadata": {},
    "outputs": [
@@ -164,25 +175,15 @@
        "      <td>Asset</td>\n",
        "      <td>245</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Asset</td>\n",
-       "      <td>245</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div><br /><strong>Provenance</strong>:<ul><li>Initialize graph store as Memory</li><li>Extracted triples to graph store using AssetsExtractor</li></ul>"
       ],
       "text/plain": [
-       "<cognite.neat._session._base.NeatSession at 0x201950d02f0>"
+       "<cognite.neat._session._base.NeatSession at 0x1a276127bc0>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -209,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "7cdc0d7e-14e8-4882-9a68-67030d41b39b",
    "metadata": {},
    "outputs": [
@@ -217,7 +218,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data Model Inference <class 'cognite.neat._store._base.NeatGraphStore'> <cognite.neat._store._base.NeatGraphStore object at 0x0000025EFEC257F0> read successfully\n"
+      "Data Model Inference <class 'cognite.neat._store._base.NeatGraphStore'> <cognite.neat._store._base.NeatGraphStore object at 0x000001A27613CCE0> read successfully\n"
      ]
     },
     {
@@ -267,7 +268,7 @@
        "[PropertyValueTypeUndefinedWarning(identifier='Asset:dataset', resource_type='Property', property_name='dataset', default_action='Remove the property from the rules', recommended_action='Make sure that graph is complete')]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -282,12 +283,12 @@
    "id": "4bd0aaea-6c5b-455b-8d93-f374544a3168",
    "metadata": {},
    "source": [
-    "We see in the inference that there is a DataSet type we do not know about. However, this is just a warning we can thus continue."
+    "We see in the inference that there is a DataSet type we do not know about. However, this is just a warning we can  continue."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "02ff718a-5e18-4f8b-9e7b-db075b163db4",
    "metadata": {},
    "outputs": [
@@ -357,7 +358,7 @@
        " RegexViolationWarning(value='Shape__Length', pattern='^(\\\\*)|(?!^(Property|property)$)(^[a-zA-Z][a-zA-Z0-9._-]{0,253}[a-zA-Z0-9]?$)', identifier='property', pattern_name='MoreThanOneNonAlphanumeric', motivation=None)]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -377,9 +378,530 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d9c04324-145b-4d4c-af20-0800e0cef149",
+   "metadata": {},
+   "source": [
+    "We can inspect the properies that has been inferred. "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "2fd658a1-9ee4-4ab0-ad95-e4fb4f6dc7b5",
+   "execution_count": 9,
+   "id": "9f2cb4f8-4c20-400b-b35b-c766b23845af",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>class_</th>\n",
+       "      <th>property_</th>\n",
+       "      <th>value_type</th>\n",
+       "      <th>max_count</th>\n",
+       "      <th>reference</th>\n",
+       "      <th>transformation</th>\n",
+       "      <th>comment</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>name</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#name</td>\n",
+       "      <td>inferred:Asset(inferred:name)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;name&gt; with value t...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>external_id</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#external_id</td>\n",
+       "      <td>inferred:Asset(inferred:external_id)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;external_id&gt; with ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>created_time</td>\n",
+       "      <td>dateTime</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#created_time</td>\n",
+       "      <td>inferred:Asset(inferred:created_time)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;created_time&gt; with...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>last_updated_time</td>\n",
+       "      <td>dateTime</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#last_updated_time</td>\n",
+       "      <td>inferred:Asset(inferred:last_updated_time)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;last_updated_time&gt;...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>parent</td>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#parent</td>\n",
+       "      <td>inferred:Asset(inferred:parent)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;parent&gt; with value...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>root</td>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#root</td>\n",
+       "      <td>inferred:Asset(inferred:root)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;root&gt; with value t...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>dataset</td>\n",
+       "      <td>anyURI</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#dataset</td>\n",
+       "      <td>inferred:Asset(inferred:dataset)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;dataset&gt; with valu...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>description</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#description</td>\n",
+       "      <td>inferred:Asset(inferred:description)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;description&gt; with ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>DesignPointFlowGPM</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#DesignPointFlowGPM</td>\n",
+       "      <td>inferred:Asset(inferred:DesignPointFlowGPM)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;DesignPointFlowGPM...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>DesignPointHeadFT</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#DesignPointHeadFT</td>\n",
+       "      <td>inferred:Asset(inferred:DesignPointHeadFT)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;DesignPointHeadFT&gt;...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>Enabled</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#Enabled</td>\n",
+       "      <td>inferred:Asset(inferred:Enabled)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;Enabled&gt; with valu...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>FacilityID</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#FacilityID</td>\n",
+       "      <td>inferred:Asset(inferred:FacilityID)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;FacilityID&gt; with v...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>HighHeadShutOff</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#HighHeadShutOff</td>\n",
+       "      <td>inferred:Asset(inferred:HighHeadShutOff)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;HighHeadShutOff&gt; w...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>InstallDate</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#InstallDate</td>\n",
+       "      <td>inferred:Asset(inferred:InstallDate)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;InstallDate&gt; with ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>LifeCycleStatus</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#LifeCycleStatus</td>\n",
+       "      <td>inferred:Asset(inferred:LifeCycleStatus)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;LifeCycleStatus&gt; w...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>LiftStationID</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#LiftStationID</td>\n",
+       "      <td>inferred:Asset(inferred:LiftStationID)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;LiftStationID&gt; wit...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>LocationDescription</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#LocationDescription</td>\n",
+       "      <td>inferred:Asset(inferred:LocationDescription)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;LocationDescriptio...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>LowHeadFT</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#LowHeadFT</td>\n",
+       "      <td>inferred:Asset(inferred:LowHeadFT)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;LowHeadFT&gt; with va...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>LowHeadFlowGPM</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#LowHeadFlowGPM</td>\n",
+       "      <td>inferred:Asset(inferred:LowHeadFlowGPM)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;LowHeadFlowGPM&gt; wi...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>Position</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#Position</td>\n",
+       "      <td>inferred:Asset(inferred:Position)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;Position&gt; with val...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>PumpHP</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#PumpHP</td>\n",
+       "      <td>inferred:Asset(inferred:PumpHP)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;PumpHP&gt; with value...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>PumpModel</td>\n",
+       "      <td>integer | string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#PumpModel</td>\n",
+       "      <td>inferred:Asset(inferred:PumpModel)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;PumpModel&gt; with va...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>PumpOff</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#PumpOff</td>\n",
+       "      <td>inferred:Asset(inferred:PumpOff)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;PumpOff&gt; with valu...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>PumpOn</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#PumpOn</td>\n",
+       "      <td>inferred:Asset(inferred:PumpOn)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;PumpOn&gt; with value...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>Shape__Length</td>\n",
+       "      <td>double</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#Shape__Length</td>\n",
+       "      <td>inferred:Asset(inferred:Shape__Length)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;Shape__Length&gt; wit...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>inference_space:Asset</td>\n",
+       "      <td>VFD</td>\n",
+       "      <td>string</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://purl.org/cognite/neat#VFD</td>\n",
+       "      <td>inferred:Asset(inferred:VFD)</td>\n",
+       "      <td>Class &lt;Asset&gt; has property &lt;VFD&gt; with value ty...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   class_            property_             value_type  \\\n",
+       "0   inference_space:Asset                 name                 string   \n",
+       "1   inference_space:Asset          external_id                 string   \n",
+       "2   inference_space:Asset         created_time               dateTime   \n",
+       "3   inference_space:Asset    last_updated_time               dateTime   \n",
+       "4   inference_space:Asset               parent  inference_space:Asset   \n",
+       "5   inference_space:Asset                 root  inference_space:Asset   \n",
+       "6   inference_space:Asset              dataset                 anyURI   \n",
+       "7   inference_space:Asset          description                 string   \n",
+       "8   inference_space:Asset   DesignPointFlowGPM                 double   \n",
+       "9   inference_space:Asset    DesignPointHeadFT                 double   \n",
+       "10  inference_space:Asset              Enabled                 double   \n",
+       "11  inference_space:Asset           FacilityID                 string   \n",
+       "12  inference_space:Asset      HighHeadShutOff                 double   \n",
+       "13  inference_space:Asset          InstallDate                 string   \n",
+       "14  inference_space:Asset      LifeCycleStatus                 string   \n",
+       "15  inference_space:Asset        LiftStationID                 string   \n",
+       "16  inference_space:Asset  LocationDescription                 string   \n",
+       "17  inference_space:Asset            LowHeadFT                 double   \n",
+       "18  inference_space:Asset       LowHeadFlowGPM                 double   \n",
+       "19  inference_space:Asset             Position                 string   \n",
+       "20  inference_space:Asset               PumpHP                 double   \n",
+       "21  inference_space:Asset            PumpModel       integer | string   \n",
+       "22  inference_space:Asset              PumpOff                 double   \n",
+       "23  inference_space:Asset               PumpOn                 double   \n",
+       "24  inference_space:Asset        Shape__Length                 double   \n",
+       "25  inference_space:Asset                  VFD                 string   \n",
+       "\n",
+       "    max_count                                         reference  \\\n",
+       "0           1                 http://purl.org/cognite/neat#name   \n",
+       "1           1          http://purl.org/cognite/neat#external_id   \n",
+       "2           1         http://purl.org/cognite/neat#created_time   \n",
+       "3           1    http://purl.org/cognite/neat#last_updated_time   \n",
+       "4           1               http://purl.org/cognite/neat#parent   \n",
+       "5           1                 http://purl.org/cognite/neat#root   \n",
+       "6           1              http://purl.org/cognite/neat#dataset   \n",
+       "7           1          http://purl.org/cognite/neat#description   \n",
+       "8           1   http://purl.org/cognite/neat#DesignPointFlowGPM   \n",
+       "9           1    http://purl.org/cognite/neat#DesignPointHeadFT   \n",
+       "10          1              http://purl.org/cognite/neat#Enabled   \n",
+       "11          1           http://purl.org/cognite/neat#FacilityID   \n",
+       "12          1      http://purl.org/cognite/neat#HighHeadShutOff   \n",
+       "13          1          http://purl.org/cognite/neat#InstallDate   \n",
+       "14          1      http://purl.org/cognite/neat#LifeCycleStatus   \n",
+       "15          1        http://purl.org/cognite/neat#LiftStationID   \n",
+       "16          1  http://purl.org/cognite/neat#LocationDescription   \n",
+       "17          1            http://purl.org/cognite/neat#LowHeadFT   \n",
+       "18          1       http://purl.org/cognite/neat#LowHeadFlowGPM   \n",
+       "19          1             http://purl.org/cognite/neat#Position   \n",
+       "20          1               http://purl.org/cognite/neat#PumpHP   \n",
+       "21          1            http://purl.org/cognite/neat#PumpModel   \n",
+       "22          1              http://purl.org/cognite/neat#PumpOff   \n",
+       "23          1               http://purl.org/cognite/neat#PumpOn   \n",
+       "24          1        http://purl.org/cognite/neat#Shape__Length   \n",
+       "25          1                  http://purl.org/cognite/neat#VFD   \n",
+       "\n",
+       "                                  transformation  \\\n",
+       "0                  inferred:Asset(inferred:name)   \n",
+       "1           inferred:Asset(inferred:external_id)   \n",
+       "2          inferred:Asset(inferred:created_time)   \n",
+       "3     inferred:Asset(inferred:last_updated_time)   \n",
+       "4                inferred:Asset(inferred:parent)   \n",
+       "5                  inferred:Asset(inferred:root)   \n",
+       "6               inferred:Asset(inferred:dataset)   \n",
+       "7           inferred:Asset(inferred:description)   \n",
+       "8    inferred:Asset(inferred:DesignPointFlowGPM)   \n",
+       "9     inferred:Asset(inferred:DesignPointHeadFT)   \n",
+       "10              inferred:Asset(inferred:Enabled)   \n",
+       "11           inferred:Asset(inferred:FacilityID)   \n",
+       "12      inferred:Asset(inferred:HighHeadShutOff)   \n",
+       "13          inferred:Asset(inferred:InstallDate)   \n",
+       "14      inferred:Asset(inferred:LifeCycleStatus)   \n",
+       "15        inferred:Asset(inferred:LiftStationID)   \n",
+       "16  inferred:Asset(inferred:LocationDescription)   \n",
+       "17            inferred:Asset(inferred:LowHeadFT)   \n",
+       "18       inferred:Asset(inferred:LowHeadFlowGPM)   \n",
+       "19             inferred:Asset(inferred:Position)   \n",
+       "20               inferred:Asset(inferred:PumpHP)   \n",
+       "21            inferred:Asset(inferred:PumpModel)   \n",
+       "22              inferred:Asset(inferred:PumpOff)   \n",
+       "23               inferred:Asset(inferred:PumpOn)   \n",
+       "24        inferred:Asset(inferred:Shape__Length)   \n",
+       "25                  inferred:Asset(inferred:VFD)   \n",
+       "\n",
+       "                                              comment  \n",
+       "0   Class <Asset> has property <name> with value t...  \n",
+       "1   Class <Asset> has property <external_id> with ...  \n",
+       "2   Class <Asset> has property <created_time> with...  \n",
+       "3   Class <Asset> has property <last_updated_time>...  \n",
+       "4   Class <Asset> has property <parent> with value...  \n",
+       "5   Class <Asset> has property <root> with value t...  \n",
+       "6   Class <Asset> has property <dataset> with valu...  \n",
+       "7   Class <Asset> has property <description> with ...  \n",
+       "8   Class <Asset> has property <DesignPointFlowGPM...  \n",
+       "9   Class <Asset> has property <DesignPointHeadFT>...  \n",
+       "10  Class <Asset> has property <Enabled> with valu...  \n",
+       "11  Class <Asset> has property <FacilityID> with v...  \n",
+       "12  Class <Asset> has property <HighHeadShutOff> w...  \n",
+       "13  Class <Asset> has property <InstallDate> with ...  \n",
+       "14  Class <Asset> has property <LifeCycleStatus> w...  \n",
+       "15  Class <Asset> has property <LiftStationID> wit...  \n",
+       "16  Class <Asset> has property <LocationDescriptio...  \n",
+       "17  Class <Asset> has property <LowHeadFT> with va...  \n",
+       "18  Class <Asset> has property <LowHeadFlowGPM> wi...  \n",
+       "19  Class <Asset> has property <Position> with val...  \n",
+       "20  Class <Asset> has property <PumpHP> with value...  \n",
+       "21  Class <Asset> has property <PumpModel> with va...  \n",
+       "22  Class <Asset> has property <PumpOff> with valu...  \n",
+       "23  Class <Asset> has property <PumpOn> with value...  \n",
+       "24  Class <Asset> has property <Shape__Length> wit...  \n",
+       "25  Class <Asset> has property <VFD> with value ty...  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "neat.inspect.properties"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caf0044a-4fc5-4590-af61-700d360961d1",
+   "metadata": {},
+   "source": [
+    "We notice that for example the `PumpModel` is both an integer and a string, as the `Inference` found data of both types."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bf193ef-d0bc-4d7c-93a7-fed157127700",
+   "metadata": {},
+   "source": [
+    "We can inspect the comment from the `Inference` type:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "91515d15-b28a-4b6c-83fc-092f56d1532c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Class <Asset> has property <PumpModel> with value types <string> which occurs <140> times and <integer> which occurs <6> times in the graph'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "neat.inspect.properties.loc[21, \"comment\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "771d808e-74a2-469f-a7cd-8d64182fd8d1",
+   "metadata": {},
+   "source": [
+    "And we see that this is most likely a string as that occured much more for this field in the graph than the integer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b97340-90b2-4c79-9a97-326113721ee8",
+   "metadata": {},
+   "source": [
+    "## Exporting Data Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ca8d5c2-333d-4ff3-8ee6-e27058c730fb",
+   "metadata": {},
+   "source": [
+    "Lets export our newly created data model to CDF. First, we need to convert it to an phsycial format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "01031b7f-0707-4818-90de-c406132dd56c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rules converted to dms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\AndersAlbert\\AppData\\Local\\pypoetry\\Cache\\virtualenvs\\cognite-neat-WszCo0Uu-py3.12\\Lib\\site-packages\\pydantic\\main.py:212: RegexViolationWarning: ('Shape__Length', '(?!^(property|space|externalId|createdTime|lastUpdatedTime|deletedTime|edge_id|node_id|project_id|property_group|seq|tg_table_name|extensions)$)(^[a-zA-Z][a-zA-Z0-9_]{0,253}[a-zA-Z0-9]?$)', 'property', 'MoreThanOneNonAlphanumeric')\n",
+      "  validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)\n",
+      "C:\\Users\\AndersAlbert\\AppData\\Local\\pypoetry\\Cache\\virtualenvs\\cognite-neat-WszCo0Uu-py3.12\\Lib\\site-packages\\pydantic\\main.py:212: RegexViolationWarning: ('Shape__Length', '^(\\\\*)|(?!^(Property|property)$)(^[a-zA-Z][a-zA-Z0-9._-]{0,253}[a-zA-Z0-9]?$)', 'property', 'MoreThanOneNonAlphanumeric')\n",
+      "  validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)\n"
+     ]
+    }
+   ],
+   "source": [
+    "neat.convert(\"dms\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "eabc33ff-b178-48be-b1f1-6569c1fdd860",
    "metadata": {},
    "outputs": [
     {
@@ -409,26 +931,34 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>type</th>\n",
-       "      <td>Logical Data Model</td>\n",
+       "      <td>Physical Data Model</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>intended for</th>\n",
-       "      <td>Information Architect</td>\n",
+       "      <td>DMS Architect</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>name</th>\n",
        "      <td>InferredDataModel</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>external_id</th>\n",
+       "      <th>space</th>\n",
        "      <td>inference_space</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>external_id</th>\n",
+       "      <td>inferreddatamodel</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>version</th>\n",
        "      <td>v1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>classes</th>\n",
+       "      <th>views</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>containers</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -465,25 +995,15 @@
        "      <td>Asset</td>\n",
        "      <td>245</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Asset</td>\n",
-       "      <td>245</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div><br /><strong>Provenance</strong>:<ul><li>Initialize graph store as Memory</li><li>Extracted triples to graph store using AssetsExtractor</li><li>Added rules to graph store as InformationRules</li><li>Upsert prefixes to graph store</li></ul>"
       ],
       "text/plain": [
-       "<cognite.neat._session._base.NeatSession at 0x25ef81a6180>"
+       "<cognite.neat._session._base.NeatSession at 0x1a276127bc0>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -494,518 +1014,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "9f2cb4f8-4c20-400b-b35b-c766b23845af",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "'NeatSession' object has no attribute 'inspect'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[11], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[43mneat\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minspect\u001b[49m\u001b[38;5;241m.\u001b[39mproperties\n",
-      "\u001b[1;31mAttributeError\u001b[0m: 'NeatSession' object has no attribute 'inspect'"
-     ]
-    }
-   ],
-   "source": [
-    "neat.inspect.properties"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "caf0044a-4fc5-4590-af61-700d360961d1",
-   "metadata": {},
-   "source": [
-    "We notice that for example the `PumpModel` is both an integer and a string, as the `Inference` found data of both types."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7bf193ef-d0bc-4d7c-93a7-fed157127700",
-   "metadata": {},
-   "source": [
-    "We can inspect the comment from the `Inference` type:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "91515d15-b28a-4b6c-83fc-092f56d1532c",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'rules' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[8], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[43mrules\u001b[49m\u001b[38;5;241m.\u001b[39mproperties\u001b[38;5;241m.\u001b[39mdata[\u001b[38;5;241m24\u001b[39m]\u001b[38;5;241m.\u001b[39mcomment\n",
-      "\u001b[1;31mNameError\u001b[0m: name 'rules' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "rules.properties.data[24].comment"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "771d808e-74a2-469f-a7cd-8d64182fd8d1",
-   "metadata": {},
-   "source": [
-    "And we see that this is most likely a string as that occured much more for this field in the graph than the integer."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "80b97340-90b2-4c79-9a97-326113721ee8",
-   "metadata": {},
-   "source": [
-    "## Exporting Data Model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9ca8d5c2-333d-4ff3-8ee6-e27058c730fb",
-   "metadata": {},
-   "source": [
-    "Lets export our newly created data model to CDF"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "5a7b83b4-2046-4954-b249-dbc9da57ad5e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from cognite.neat.rules import exporters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "18281755-5ccc-408c-ba69-eedfacc0ff27",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong>Exporter</strong> An exporter converts Neat's representation of a data model called <em>Rules</em> into a schema/data model for a target format.<br /><div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Exporter</th>\n",
-       "      <th>Description</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>DMSExporter</td>\n",
-       "      <td>Export rules to Cognite Data Fusion's Data Mod...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>SemanticDataModelExporter</td>\n",
-       "      <td>Exports rules to a semantic data model.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>OWLExporter</td>\n",
-       "      <td>Exports rules to an OWL ontology.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>SHACLExporter</td>\n",
-       "      <td>Exports rules to a SHACL graph.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>ExcelExporter</td>\n",
-       "      <td>Export rules to Excel.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>YAMLExporter</td>\n",
-       "      <td>Export rules to YAML.</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "<module 'cognite.neat.rules.exporters' from 'C:\\\\Users\\\\AndersAlbert\\\\Projects\\\\internal\\\\neat\\\\cognite\\\\neat\\\\rules\\\\exporters\\\\__init__.py'>"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "exporters"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4fff34f4-7bc3-459f-bdd8-f13b4d401cd7",
-   "metadata": {},
-   "source": [
-    "To export the data model we use the `DMSExporter`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "f12fa605-90d7-4794-95ee-8d2cad1b0531",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<h3>DMSExporter</h3><p>Export rules to Cognite Data Fusion's Data Model Storage (DMS) service.</p>"
-      ],
-      "text/plain": [
-       "cognite.neat.rules.exporters._rules2dms.DMSExporter"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "exporters.DMSExporter"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "03c04ae9-48b1-4eee-96d5-7e409d6b6b0a",
-   "metadata": {},
-   "source": [
-    "To export the rules, we need them in the DMS format, however, the `rules` we have are in Information format."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "83250eaf-035f-4d35-94dd-48755196c745",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "cognite.neat.rules.models.information._rules.InformationRules"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(rules)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e7c2c698-9c72-4d60-8ec7-3cf9a35f839b",
-   "metadata": {},
-   "source": [
-    "The information rules is used to model the information, while the DMS format is one of the implementation formats that Neat supports.\n",
-    "\n",
-    "Neat has an out-of-the box conversion from Information to DMS formats, however, it does not, for example, set indexes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "2c3c1934-a9f0-4107-b8ad-7ed59bf311bc",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\AndersAlbert\\AppData\\Local\\pypoetry\\Cache\\virtualenvs\\cognite-neat-WszCo0Uu-py3.12\\Lib\\site-packages\\pydantic\\main.py:176: MoreThanOneNonAlphanumericCharacterWarning: ('property', 'Shape__Length')\n",
-      "  self.__pydantic_validator__.validate_python(data, self_instance=self)\n"
-     ]
-    }
-   ],
-   "source": [
-    "dms_rules = rules.as_dms_rules()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "323c12ce-7d07-454a-af0f-54b11233d884",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>value</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>role</th>\n",
-       "      <td>DMS Architect</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>data_model_type</th>\n",
-       "      <td>enterprise</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>schema_</th>\n",
-       "      <td>partial</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>extension</th>\n",
-       "      <td>addition</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>space</th>\n",
-       "      <td>inferred</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>name</th>\n",
-       "      <td>Inferred Model</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>description</th>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>external_id</th>\n",
-       "      <td>inferred_model</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>version</th>\n",
-       "      <td>inferred</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>creator</th>\n",
-       "      <td>NEAT</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>created</th>\n",
-       "      <td>2024-07-09 07:30:24.429571</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>updated</th>\n",
-       "      <td>2024-07-09 07:30:24.429571</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "DMSMetadata(validators_to_skip=set(), data_model_type=<DataModelType.enterprise: 'enterprise'>, schema_=<SchemaCompleteness.partial: 'partial'>, extension=<ExtensionCategory.addition: 'addition'>, space='inferred', name='Inferred Model', description=None, external_id='inferred_model', version='inferred', creator=['NEAT'], created=datetime.datetime(2024, 7, 9, 7, 30, 24, 429571), updated=datetime.datetime(2024, 7, 9, 7, 30, 24, 429571))"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dms_rules.metadata"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "88c2de5f-3a01-49ad-acf3-9b4a63259b28",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>view</th>\n",
-       "      <th>reference</th>\n",
-       "      <th>in_model</th>\n",
-       "      <th>class_</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>inferred:Asset(version=inferred)</td>\n",
-       "      <td>http://purl.org/cognite/neat#Asset</td>\n",
-       "      <td>True</td>\n",
-       "      <td>inferred:Asset</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "SheetList[DMSView](data=[DMSView(validators_to_skip=set(), view=view(prefix=inferred,suffix=Asset,version=inferred), name=None, description=None, implements=[], reference=Url('http://purl.org/cognite/neat#Asset'), filter_=None, in_model=True, class_=class(prefix=inferred,suffix=Asset))])"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dms_rules.views"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "977b4058-4c85-46a6-914e-4cb7713fe276",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>container</th>\n",
-       "      <th>class_</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>inferred:Asset</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "SheetList[DMSContainer](data=[DMSContainer(validators_to_skip=set(), container=container(prefix=inferred,suffix=Asset), name=None, description=None, reference=None, constraint=None, class_=class(prefix=inferred,suffix=Asset))])"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dms_rules.containers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "00ff8604-ba68-4bd7-a9f7-86cc4e9aab06",
-   "metadata": {},
-   "source": [
-    "If you want to modify the DMS rules it is recommented that you export them using the `ExcelExporter`, modify the resulting spreadsheet\n",
-    "and import it using the `ExcelImporter`. For this tutorial, we are happy with the out-of-the-box DMS rules, so we just pass\n",
-    "the `InformationRules` into the DMS exporter which will automatically do the conversion."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "5730c4c9-1244-4c7d-aa92-6ae8eb776921",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "exporter = exporters.DMSExporter()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "id": "3b80bf89-bb8e-4b2b-923f-dd15fc003278",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\AndersAlbert\\AppData\\Local\\pypoetry\\Cache\\virtualenvs\\cognite-neat-WszCo0Uu-py3.12\\Lib\\site-packages\\pydantic\\main.py:176: MoreThanOneNonAlphanumericCharacterWarning: ('property', 'Shape__Length')\n",
-      "  self.__pydantic_validator__.validate_python(data, self_instance=self)\n"
-     ]
-    }
-   ],
-   "source": [
-    "result = exporter.export_to_cdf(rules, client)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "id": "2942f2bf-a5d8-49e4-bc44-9b77109ebdbb",
+   "execution_count": 12,
+   "id": "7b8a9743-796b-4537-8b71-89c8f1b3a5fc",
    "metadata": {},
    "outputs": [
     {
@@ -1059,19 +1069,19 @@
        "</div>"
       ],
       "text/plain": [
-       "[UploadResult(name='spaces', error_messages=[], issues=[], created={'inferred'}, deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set()),\n",
-       " UploadResult(name='containers', error_messages=[], issues=[], created={ContainerId(space='inferred', external_id='Asset')}, deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set()),\n",
-       " UploadResult(name='views', error_messages=[], issues=[], created={ViewId(space='inferred', external_id='Asset', version='inferred')}, deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set()),\n",
-       " UploadResult(name='data_models', error_messages=[], issues=[], created={DataModelId(space='inferred', external_id='inferred_model', version='inferred')}, deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set())]"
+       "[UploadResult(name='spaces', error_messages=[], issues=[], created={'inference_space'}, upserted=set(), deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set()),\n",
+       " UploadResult(name='containers', error_messages=[], issues=[], created={ContainerId(space='inference_space', external_id='Asset')}, upserted=set(), deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set()),\n",
+       " UploadResult(name='views', error_messages=[], issues=[], created={ViewId(space='inference_space', external_id='Asset', version='v1')}, upserted=set(), deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set()),\n",
+       " UploadResult(name='data_models', error_messages=[], issues=[], created={DataModelId(space='inference_space', external_id='inferreddatamodel', version='v1')}, upserted=set(), deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set())]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "result"
+    "neat.to.cdf.data_model()"
    ]
   },
   {
@@ -1095,201 +1105,7 @@
    "id": "13f6ebad-367e-4f3f-907f-d51c4f233091",
    "metadata": {},
    "source": [
-    "To populate the data model in CDF, we use a loader."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "id": "9a067f7c-7c4a-4520-99ff-a962111b85b2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from cognite.neat.graph import loaders"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "id": "f6bffb1a-43c5-450c-bdd3-beef9640c3a9",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong>Loader</strong> A loader writes data from Neat's triple storage into a target system<br /><div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Loader</th>\n",
-       "      <th>Description</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>DMSLoader</td>\n",
-       "      <td>Load data from Cognite Data Fusions Data Model...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "<module 'cognite.neat.graph.loaders' from 'C:\\\\Users\\\\AndersAlbert\\\\Projects\\\\internal\\\\neat\\\\cognite\\\\neat\\\\graph\\\\loaders\\\\__init__.py'>"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "loaders"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "ddeaedf6-8ed6-4a67-84e1-d591798ace56",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<h3>DMSLoader</h3><p>Load data from Cognite Data Fusions Data Modeling Service (DMS) into Neat.<br /><strong>Available factory methods:</strong><br /><ul style=\"list-style-type:circle;\"><li><em>.from_data_model_id</em></li><li><em>.from_rules</em></li></ul></p>"
-      ],
-      "text/plain": [
-       "cognite.neat.graph.loaders._rdf2dms.DMSLoader"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "loaders.DMSLoader"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bc0badfa-7827-4c0f-af0b-1434302f121e",
-   "metadata": {},
-   "source": [
-    "To load the data from the graph store, we add the rules to the store"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "id": "f325db09-25e1-45bf-86d8-c061c089647e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "store.add_rules(rules)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "id": "5ce26036-0311-4222-bd8d-72a892ec1dee",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong>NeatGraphStore</strong> A graph store is a container for storing triples. It can be queried and transformed to extract information.<br /><strong>Provenance</strong> Provenance is a record of changes that have occurred in the graph store.<br /><div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Agent</th>\n",
-       "      <th>Activity</th>\n",
-       "      <th>Entity</th>\n",
-       "      <th>Description</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>http://purl.org/cognite/neat#agent</td>\n",
-       "      <td>http://purl.org/cognite/neat#activity-b2c2ee23...</td>\n",
-       "      <td>http://purl.org/cognite/neat#graph-store</td>\n",
-       "      <td>Initialize graph store as Memory</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>http://purl.org/cognite/neat#agent</td>\n",
-       "      <td>http://purl.org/cognite/neat#activity-b2c2ee23...</td>\n",
-       "      <td>http://purl.org/cognite/neat#graph-store</td>\n",
-       "      <td>Extracted triples to graph store using AssetsE...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>http://purl.org/cognite/neat#agent</td>\n",
-       "      <td>http://purl.org/cognite/neat#activity-b2c2ee23...</td>\n",
-       "      <td>http://purl.org/cognite/neat#graph-store</td>\n",
-       "      <td>Added rules to graph store as InformationRules</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>http://purl.org/cognite/neat#agent</td>\n",
-       "      <td>http://purl.org/cognite/neat#activity-b2c2ee23...</td>\n",
-       "      <td>http://purl.org/cognite/neat#graph-store</td>\n",
-       "      <td>Upsert prefixes to graph store</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "<cognite.neat.graph.stores._base.NeatGraphStore at 0x246c0130590>"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "store"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6459b0c0-3843-4bcc-9f17-fd675de160f4",
-   "metadata": {},
-   "source": [
-    "This is necessary for the store to be ready to load data to an extrenal system. Note that by adding the `rules` to the store\n",
-    "the prefixes has been updated to match the rules object. This is how the loader knows which triples to fetch from the store."
+    "As the data model is ready, we can move the instances to CDF "
    ]
   },
   {
@@ -1302,7 +1118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 14,
    "id": "8ebacc8b-11c6-458b-ad72-3dd582aefbdf",
    "metadata": {},
    "outputs": [],
@@ -1312,7 +1128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 15,
    "id": "23c53e60-98e3-4de2-8874-83b8c618c2fc",
    "metadata": {},
    "outputs": [
@@ -1362,10 +1178,10 @@
        "</div>"
       ],
       "text/plain": [
-       "<Space(space='sp_pump_station') at 0x246db9a5c10>"
+       "<Space(space='sp_pump_station') at 0x1a27b982540>"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1384,39 +1200,9 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "8a4b48ff-95d9-4fd5-82e0-69b8686e1c8e",
-   "metadata": {},
-   "source": [
-    "Note that the `DMSLoader` requires that we have the `DMSRules` format, so we pass in the DMS rules we created above.\n",
-    "\n",
-    "Alternatively, we can create the loader by passing in a data model ID."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 36,
-   "id": "8e171577-e0f0-4f68-941f-261eb77315d7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "loader = loaders.DMSLoader.from_rules(dms_rules, store, instance_space=\"sp_pump_station\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "id": "9780e893-d6a3-4d4c-bf80-8e145d454bee",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result = loader.load_into_cdf(client)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "id": "da14fb04-b6f2-40aa-b549-d19abfe7247d",
+   "execution_count": 16,
+   "id": "824790ec-205d-4905-a746-9076b22401c6",
    "metadata": {},
    "outputs": [
     {
@@ -1441,7 +1227,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>name</th>\n",
-       "      <th>created</th>\n",
+       "      <th>changed</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1460,17 +1246,17 @@
        "</div>"
       ],
       "text/plain": [
-       "[UploadResult(name='Nodes', error_messages=[], issues=[], created={NodeId(space='sp_pump_station', external_id='Asset_1599542126336595'), NodeId(space='sp_pump_station', external_id='Asset_1328367249298685'), NodeId(space='sp_pump_station', external_id='Asset_8536226378041620'), NodeId(space='sp_pump_station', external_id='Asset_5687470951999200'), NodeId(space='sp_pump_station', external_id='Asset_2738034707487198'), NodeId(space='sp_pump_station', external_id='Asset_2011390888860506'), NodeId(space='sp_pump_station', external_id='Asset_1717136324291166'), NodeId(space='sp_pump_station', external_id='Asset_673071391885663'), NodeId(space='sp_pump_station', external_id='Asset_3009457875737229'), NodeId(space='sp_pump_station', external_id='Asset_3253702221176761'), NodeId(space='sp_pump_station', external_id='Asset_2041897821048926'), NodeId(space='sp_pump_station', external_id='Asset_5773835011768211'), NodeId(space='sp_pump_station', external_id='Asset_791284880355712'), NodeId(space='sp_pump_station', external_id='Asset_720243198469901'), NodeId(space='sp_pump_station', external_id='Asset_6276047304545772'), NodeId(space='sp_pump_station', external_id='Asset_779363703909879'), NodeId(space='sp_pump_station', external_id='Asset_765927258989033'), NodeId(space='sp_pump_station', external_id='Asset_8149656736332002'), NodeId(space='sp_pump_station', external_id='Asset_3912512319616642'), NodeId(space='sp_pump_station', external_id='Asset_2614391887415841'), NodeId(space='sp_pump_station', external_id='Asset_2622548696369535'), NodeId(space='sp_pump_station', external_id='Asset_4030282795820257'), NodeId(space='sp_pump_station', external_id='Asset_597713956124653'), NodeId(space='sp_pump_station', external_id='Asset_1036635642295968'), NodeId(space='sp_pump_station', external_id='Asset_6264128498357271'), NodeId(space='sp_pump_station', external_id='Asset_4487513710880340'), NodeId(space='sp_pump_station', external_id='Asset_690992856868092'), NodeId(space='sp_pump_station', external_id='Asset_4356678455013717'), NodeId(space='sp_pump_station', external_id='Asset_4139420867004251'), NodeId(space='sp_pump_station', external_id='Asset_3718586005996830'), NodeId(space='sp_pump_station', external_id='Asset_7412273070008116'), NodeId(space='sp_pump_station', external_id='Asset_2534347363555646'), NodeId(space='sp_pump_station', external_id='Asset_8906381697072008'), NodeId(space='sp_pump_station', external_id='Asset_2648639705661733'), NodeId(space='sp_pump_station', external_id='Asset_8786769086021865'), NodeId(space='sp_pump_station', external_id='Asset_8855980446983123'), NodeId(space='sp_pump_station', external_id='Asset_6996457070033380'), NodeId(space='sp_pump_station', external_id='Asset_5991677408633367'), NodeId(space='sp_pump_station', external_id='Asset_1424210982323954'), NodeId(space='sp_pump_station', external_id='Asset_1304177008138755'), NodeId(space='sp_pump_station', external_id='Asset_413299123404753'), NodeId(space='sp_pump_station', external_id='Asset_8724043116543799'), NodeId(space='sp_pump_station', external_id='Asset_3543366413287754'), NodeId(space='sp_pump_station', external_id='Asset_2383890056251078'), NodeId(space='sp_pump_station', external_id='Asset_3322086940842206'), NodeId(space='sp_pump_station', external_id='Asset_862846106956486'), NodeId(space='sp_pump_station', external_id='Asset_3282403756294926'), NodeId(space='sp_pump_station', external_id='Asset_1602743241841442'), NodeId(space='sp_pump_station', external_id='Asset_6499093917037259'), NodeId(space='sp_pump_station', external_id='Asset_7062323820650437'), NodeId(space='sp_pump_station', external_id='Asset_2109398666822135'), NodeId(space='sp_pump_station', external_id='Asset_8808794232286601'), NodeId(space='sp_pump_station', external_id='Asset_8628246215971298'), NodeId(space='sp_pump_station', external_id='Asset_6781772664404616'), NodeId(space='sp_pump_station', external_id='Asset_4161802645953289'), NodeId(space='sp_pump_station', external_id='Asset_6643904356520272'), NodeId(space='sp_pump_station', external_id='Asset_5087293594250586'), NodeId(space='sp_pump_station', external_id='Asset_8058069339001352'), NodeId(space='sp_pump_station', external_id='Asset_1324043696796177'), NodeId(space='sp_pump_station', external_id='Asset_2479470568519150'), NodeId(space='sp_pump_station', external_id='Asset_2046186730180729'), NodeId(space='sp_pump_station', external_id='Asset_8222636825254386'), NodeId(space='sp_pump_station', external_id='Asset_8553994241961892'), NodeId(space='sp_pump_station', external_id='Asset_1037825783121772'), NodeId(space='sp_pump_station', external_id='Asset_4611308323382841'), NodeId(space='sp_pump_station', external_id='Asset_8796025392183616'), NodeId(space='sp_pump_station', external_id='Asset_3742073732470345'), NodeId(space='sp_pump_station', external_id='Asset_269634716915797'), NodeId(space='sp_pump_station', external_id='Asset_1864313623913141'), NodeId(space='sp_pump_station', external_id='Asset_4198593876687587'), NodeId(space='sp_pump_station', external_id='Asset_1774832114371582'), NodeId(space='sp_pump_station', external_id='Asset_4891974892606772'), NodeId(space='sp_pump_station', external_id='Asset_127734001123260'), NodeId(space='sp_pump_station', external_id='Asset_8233413405577277'), NodeId(space='sp_pump_station', external_id='Asset_2023737592746820'), NodeId(space='sp_pump_station', external_id='Asset_7894177745270490'), NodeId(space='sp_pump_station', external_id='Asset_8319154213336032'), NodeId(space='sp_pump_station', external_id='Asset_2094973082337502'), NodeId(space='sp_pump_station', external_id='Asset_5547362797792188'), NodeId(space='sp_pump_station', external_id='Asset_7267922459333514'), NodeId(space='sp_pump_station', external_id='Asset_7203345045002373'), NodeId(space='sp_pump_station', external_id='Asset_5135123609065026'), NodeId(space='sp_pump_station', external_id='Asset_285703678588887'), NodeId(space='sp_pump_station', external_id='Asset_6004900365929538'), NodeId(space='sp_pump_station', external_id='Asset_7850022972804616'), NodeId(space='sp_pump_station', external_id='Asset_7528927086455056'), NodeId(space='sp_pump_station', external_id='Asset_5041263389346470'), NodeId(space='sp_pump_station', external_id='Asset_5019118534073978'), NodeId(space='sp_pump_station', external_id='Asset_1251681124138604'), NodeId(space='sp_pump_station', external_id='Asset_2511536057605256'), NodeId(space='sp_pump_station', external_id='Asset_3555954990835329'), NodeId(space='sp_pump_station', external_id='Asset_8504798483669198'), NodeId(space='sp_pump_station', external_id='Asset_6819169398550305'), NodeId(space='sp_pump_station', external_id='Asset_6664824877870138'), NodeId(space='sp_pump_station', external_id='Asset_996835369435603'), NodeId(space='sp_pump_station', external_id='Asset_1575285876968678'), NodeId(space='sp_pump_station', external_id='Asset_1225335557735852'), NodeId(space='sp_pump_station', external_id='Asset_8481426694002548'), NodeId(space='sp_pump_station', external_id='Asset_3280739856601792'), NodeId(space='sp_pump_station', external_id='Asset_5545507452452289'), NodeId(space='sp_pump_station', external_id='Asset_2336737113812249'), NodeId(space='sp_pump_station', external_id='Asset_81467243787762'), NodeId(space='sp_pump_station', external_id='Asset_3659337637509008'), NodeId(space='sp_pump_station', external_id='Asset_8523137874354911'), NodeId(space='sp_pump_station', external_id='Asset_4712097420257305'), NodeId(space='sp_pump_station', external_id='Asset_4827422846791984'), NodeId(space='sp_pump_station', external_id='Asset_4776644471418856'), NodeId(space='sp_pump_station', external_id='Asset_7266418315229309'), NodeId(space='sp_pump_station', external_id='Asset_6641759103584656'), NodeId(space='sp_pump_station', external_id='Asset_1038381373070659'), NodeId(space='sp_pump_station', external_id='Asset_8706147153757321'), NodeId(space='sp_pump_station', external_id='Asset_7892354435770575'), NodeId(space='sp_pump_station', external_id='Asset_1249607927059004'), NodeId(space='sp_pump_station', external_id='Asset_8878199396116383'), NodeId(space='sp_pump_station', external_id='Asset_8064479308748326'), NodeId(space='sp_pump_station', external_id='Asset_5281038386138027'), NodeId(space='sp_pump_station', external_id='Asset_8146710551744753'), NodeId(space='sp_pump_station', external_id='Asset_8786745865150192'), NodeId(space='sp_pump_station', external_id='Asset_7836353321625289'), NodeId(space='sp_pump_station', external_id='Asset_6564758760526211'), NodeId(space='sp_pump_station', external_id='Asset_6779172796182945'), NodeId(space='sp_pump_station', external_id='Asset_227176319156396'), NodeId(space='sp_pump_station', external_id='Asset_8925755907669641'), NodeId(space='sp_pump_station', external_id='Asset_2084401469825731'), NodeId(space='sp_pump_station', external_id='Asset_7047173837936574'), NodeId(space='sp_pump_station', external_id='Asset_6717164076357170'), NodeId(space='sp_pump_station', external_id='Asset_8858634333103219'), NodeId(space='sp_pump_station', external_id='Asset_2990577136288617'), NodeId(space='sp_pump_station', external_id='Asset_4232408171704947'), NodeId(space='sp_pump_station', external_id='Asset_2736664555336384'), NodeId(space='sp_pump_station', external_id='Asset_1194729803680100'), NodeId(space='sp_pump_station', external_id='Asset_4282637232083446'), NodeId(space='sp_pump_station', external_id='Asset_7004541113243114'), NodeId(space='sp_pump_station', external_id='Asset_1432498771938483'), NodeId(space='sp_pump_station', external_id='Asset_8174955310442028'), NodeId(space='sp_pump_station', external_id='Asset_6451825071660398'), NodeId(space='sp_pump_station', external_id='Asset_165156832820784'), NodeId(space='sp_pump_station', external_id='Asset_7478288481786780'), NodeId(space='sp_pump_station', external_id='Asset_2086072639670581'), NodeId(space='sp_pump_station', external_id='Asset_5168608124271064'), NodeId(space='sp_pump_station', external_id='Asset_323324050354647'), NodeId(space='sp_pump_station', external_id='Asset_5130211688970126'), NodeId(space='sp_pump_station', external_id='Asset_3586569534260203'), NodeId(space='sp_pump_station', external_id='Asset_4982518105700769'), NodeId(space='sp_pump_station', external_id='Asset_7516256968258946'), NodeId(space='sp_pump_station', external_id='Asset_3814858014848944'), NodeId(space='sp_pump_station', external_id='Asset_4552624840004426'), NodeId(space='sp_pump_station', external_id='Asset_5007277578782055'), NodeId(space='sp_pump_station', external_id='Asset_5131927739646770'), NodeId(space='sp_pump_station', external_id='Asset_2508670135160060'), NodeId(space='sp_pump_station', external_id='Asset_4752540074534822'), NodeId(space='sp_pump_station', external_id='Asset_4072884896428048'), NodeId(space='sp_pump_station', external_id='Asset_3202643099427992'), NodeId(space='sp_pump_station', external_id='Asset_1994529305403431'), NodeId(space='sp_pump_station', external_id='Asset_5333316208400622'), NodeId(space='sp_pump_station', external_id='Asset_2252447920800496'), NodeId(space='sp_pump_station', external_id='Asset_3790466002578495'), NodeId(space='sp_pump_station', external_id='Asset_836522380797694'), NodeId(space='sp_pump_station', external_id='Asset_2879000772727558'), NodeId(space='sp_pump_station', external_id='Asset_3886073802761259'), NodeId(space='sp_pump_station', external_id='Asset_522426732998405'), NodeId(space='sp_pump_station', external_id='Asset_4822096456178490'), NodeId(space='sp_pump_station', external_id='Asset_8236357046250336'), NodeId(space='sp_pump_station', external_id='Asset_813431221291430'), NodeId(space='sp_pump_station', external_id='Asset_771688114151184'), NodeId(space='sp_pump_station', external_id='Asset_3927731196795261'), NodeId(space='sp_pump_station', external_id='Asset_3281981391093912'), NodeId(space='sp_pump_station', external_id='Asset_520686293117320'), NodeId(space='sp_pump_station', external_id='Asset_1648354084107813'), NodeId(space='sp_pump_station', external_id='Asset_3167103698462272'), NodeId(space='sp_pump_station', external_id='Asset_7946696422000355'), NodeId(space='sp_pump_station', external_id='Asset_6841838289417335'), NodeId(space='sp_pump_station', external_id='Asset_3452092217821423'), NodeId(space='sp_pump_station', external_id='Asset_5715782298837748'), NodeId(space='sp_pump_station', external_id='Asset_3192880850822919'), NodeId(space='sp_pump_station', external_id='Asset_663950299702707'), NodeId(space='sp_pump_station', external_id='Asset_449616738664544'), NodeId(space='sp_pump_station', external_id='Asset_5413774089595059'), NodeId(space='sp_pump_station', external_id='Asset_8210406762466554'), NodeId(space='sp_pump_station', external_id='Asset_3925087570184060'), NodeId(space='sp_pump_station', external_id='Asset_3543745228672494'), NodeId(space='sp_pump_station', external_id='Asset_8056653045323204'), NodeId(space='sp_pump_station', external_id='Asset_5328233515028106'), NodeId(space='sp_pump_station', external_id='Asset_2460227122870007'), NodeId(space='sp_pump_station', external_id='Asset_6495798019337129'), NodeId(space='sp_pump_station', external_id='Asset_7098679359189829'), NodeId(space='sp_pump_station', external_id='Asset_8465364910017703'), NodeId(space='sp_pump_station', external_id='Asset_2395276745188968'), NodeId(space='sp_pump_station', external_id='Asset_6410548171595891'), NodeId(space='sp_pump_station', external_id='Asset_6037474207471867'), NodeId(space='sp_pump_station', external_id='Asset_409408085016912'), NodeId(space='sp_pump_station', external_id='Asset_6391337840888778'), NodeId(space='sp_pump_station', external_id='Asset_8393774212294989'), NodeId(space='sp_pump_station', external_id='Asset_1179620013510534'), NodeId(space='sp_pump_station', external_id='Asset_3947736878768533'), NodeId(space='sp_pump_station', external_id='Asset_962578142683188'), NodeId(space='sp_pump_station', external_id='Asset_8279593367922084'), NodeId(space='sp_pump_station', external_id='Asset_1350559385255241'), NodeId(space='sp_pump_station', external_id='Asset_4582156459236482'), NodeId(space='sp_pump_station', external_id='Asset_6700162977207830'), NodeId(space='sp_pump_station', external_id='Asset_7434639041955664'), NodeId(space='sp_pump_station', external_id='Asset_756443337825960'), NodeId(space='sp_pump_station', external_id='Asset_3966852611906380'), NodeId(space='sp_pump_station', external_id='Asset_8890997887425292'), NodeId(space='sp_pump_station', external_id='Asset_1869006072570857'), NodeId(space='sp_pump_station', external_id='Asset_5155311610956039'), NodeId(space='sp_pump_station', external_id='Asset_7478847799313763'), NodeId(space='sp_pump_station', external_id='Asset_782919551178381'), NodeId(space='sp_pump_station', external_id='Asset_5076110772903317'), NodeId(space='sp_pump_station', external_id='Asset_1496076023751088'), NodeId(space='sp_pump_station', external_id='Asset_23921452012034'), NodeId(space='sp_pump_station', external_id='Asset_385619558573894'), NodeId(space='sp_pump_station', external_id='Asset_7136850922305786'), NodeId(space='sp_pump_station', external_id='Asset_8068837493233743'), NodeId(space='sp_pump_station', external_id='Asset_2659669230977122'), NodeId(space='sp_pump_station', external_id='Asset_3515282769165525'), NodeId(space='sp_pump_station', external_id='Asset_2332136792376110'), NodeId(space='sp_pump_station', external_id='Asset_682395660264665'), NodeId(space='sp_pump_station', external_id='Asset_8770242167137269'), NodeId(space='sp_pump_station', external_id='Asset_2798673936255507'), NodeId(space='sp_pump_station', external_id='Asset_6416891387482527'), NodeId(space='sp_pump_station', external_id='Asset_5428549865274207'), NodeId(space='sp_pump_station', external_id='Asset_8526018147369023'), NodeId(space='sp_pump_station', external_id='Asset_1336187237481974'), NodeId(space='sp_pump_station', external_id='Asset_111670655968193'), NodeId(space='sp_pump_station', external_id='Asset_1357508377455386'), NodeId(space='sp_pump_station', external_id='Asset_7523396261491280'), NodeId(space='sp_pump_station', external_id='Asset_4093409240484544'), NodeId(space='sp_pump_station', external_id='Asset_7245358762439012'), NodeId(space='sp_pump_station', external_id='Asset_8677060254799529'), NodeId(space='sp_pump_station', external_id='Asset_6614542201323700'), NodeId(space='sp_pump_station', external_id='Asset_7858499984800024'), NodeId(space='sp_pump_station', external_id='Asset_1062857167709404'), NodeId(space='sp_pump_station', external_id='Asset_8349112794292547'), NodeId(space='sp_pump_station', external_id='Asset_465559698381891'), NodeId(space='sp_pump_station', external_id='Asset_3309648858394308'), NodeId(space='sp_pump_station', external_id='Asset_2849528494272170'), NodeId(space='sp_pump_station', external_id='Asset_3183377929919962'), NodeId(space='sp_pump_station', external_id='Asset_777675583540505'), NodeId(space='sp_pump_station', external_id='Asset_7806404385295025'), NodeId(space='sp_pump_station', external_id='Asset_8843530297877179'), NodeId(space='sp_pump_station', external_id='Asset_4226675102638478'), NodeId(space='sp_pump_station', external_id='Asset_4261713708156963'), NodeId(space='sp_pump_station', external_id='Asset_6480569031884264'), NodeId(space='sp_pump_station', external_id='Asset_3015520698705176')}, deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set()),\n",
-       " UploadResult(name='Edges', error_messages=[], issues=[], created=set(), deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set())]"
+       "[UploadResult(name='Nodes', error_messages=[], issues=[], created=set(), upserted=set(), deleted=set(), changed={NodeId(space='sp_pump_station', external_id='Asset_4552624840004426'), NodeId(space='sp_pump_station', external_id='Asset_6416891387482527'), NodeId(space='sp_pump_station', external_id='Asset_1249607927059004'), NodeId(space='sp_pump_station', external_id='Asset_3280739856601792'), NodeId(space='sp_pump_station', external_id='Asset_7478847799313763'), NodeId(space='sp_pump_station', external_id='Asset_7412273070008116'), NodeId(space='sp_pump_station', external_id='Asset_8146710551744753'), NodeId(space='sp_pump_station', external_id='Asset_1357508377455386'), NodeId(space='sp_pump_station', external_id='Asset_7203345045002373'), NodeId(space='sp_pump_station', external_id='Asset_690992856868092'), NodeId(space='sp_pump_station', external_id='Asset_782919551178381'), NodeId(space='sp_pump_station', external_id='Asset_8149656736332002'), NodeId(space='sp_pump_station', external_id='Asset_7892354435770575'), NodeId(space='sp_pump_station', external_id='Asset_409408085016912'), NodeId(space='sp_pump_station', external_id='Asset_5007277578782055'), NodeId(space='sp_pump_station', external_id='Asset_520686293117320'), NodeId(space='sp_pump_station', external_id='Asset_7478288481786780'), NodeId(space='sp_pump_station', external_id='Asset_6451825071660398'), NodeId(space='sp_pump_station', external_id='Asset_3790466002578495'), NodeId(space='sp_pump_station', external_id='Asset_663950299702707'), NodeId(space='sp_pump_station', external_id='Asset_1432498771938483'), NodeId(space='sp_pump_station', external_id='Asset_777675583540505'), NodeId(space='sp_pump_station', external_id='Asset_8628246215971298'), NodeId(space='sp_pump_station', external_id='Asset_4982518105700769'), NodeId(space='sp_pump_station', external_id='Asset_3167103698462272'), NodeId(space='sp_pump_station', external_id='Asset_4827422846791984'), NodeId(space='sp_pump_station', external_id='Asset_2332136792376110'), NodeId(space='sp_pump_station', external_id='Asset_3586569534260203'), NodeId(space='sp_pump_station', external_id='Asset_4198593876687587'), NodeId(space='sp_pump_station', external_id='Asset_1575285876968678'), NodeId(space='sp_pump_station', external_id='Asset_4356678455013717'), NodeId(space='sp_pump_station', external_id='Asset_323324050354647'), NodeId(space='sp_pump_station', external_id='Asset_7858499984800024'), NodeId(space='sp_pump_station', external_id='Asset_5991677408633367'), NodeId(space='sp_pump_station', external_id='Asset_1869006072570857'), NodeId(space='sp_pump_station', external_id='Asset_8843530297877179'), NodeId(space='sp_pump_station', external_id='Asset_3309648858394308'), NodeId(space='sp_pump_station', external_id='Asset_7894177745270490'), NodeId(space='sp_pump_station', external_id='Asset_8858634333103219'), NodeId(space='sp_pump_station', external_id='Asset_1648354084107813'), NodeId(space='sp_pump_station', external_id='Asset_3659337637509008'), NodeId(space='sp_pump_station', external_id='Asset_2798673936255507'), NodeId(space='sp_pump_station', external_id='Asset_4822096456178490'), NodeId(space='sp_pump_station', external_id='Asset_5087293594250586'), NodeId(space='sp_pump_station', external_id='Asset_6664824877870138'), NodeId(space='sp_pump_station', external_id='Asset_5428549865274207'), NodeId(space='sp_pump_station', external_id='Asset_1324043696796177'), NodeId(space='sp_pump_station', external_id='Asset_5130211688970126'), NodeId(space='sp_pump_station', external_id='Asset_962578142683188'), NodeId(space='sp_pump_station', external_id='Asset_5131927739646770'), NodeId(space='sp_pump_station', external_id='Asset_7850022972804616'), NodeId(space='sp_pump_station', external_id='Asset_8210406762466554'), NodeId(space='sp_pump_station', external_id='Asset_3253702221176761'), NodeId(space='sp_pump_station', external_id='Asset_8319154213336032'), NodeId(space='sp_pump_station', external_id='Asset_2738034707487198'), NodeId(space='sp_pump_station', external_id='Asset_1599542126336595'), NodeId(space='sp_pump_station', external_id='Asset_597713956124653'), NodeId(space='sp_pump_station', external_id='Asset_3009457875737229'), NodeId(space='sp_pump_station', external_id='Asset_6841838289417335'), NodeId(space='sp_pump_station', external_id='Asset_4226675102638478'), NodeId(space='sp_pump_station', external_id='Asset_4582156459236482'), NodeId(space='sp_pump_station', external_id='Asset_3555954990835329'), NodeId(space='sp_pump_station', external_id='Asset_2383890056251078'), NodeId(space='sp_pump_station', external_id='Asset_6700162977207830'), NodeId(space='sp_pump_station', external_id='Asset_3718586005996830'), NodeId(space='sp_pump_station', external_id='Asset_7136850922305786'), NodeId(space='sp_pump_station', external_id='Asset_3202643099427992'), NodeId(space='sp_pump_station', external_id='Asset_7098679359189829'), NodeId(space='sp_pump_station', external_id='Asset_6717164076357170'), NodeId(space='sp_pump_station', external_id='Asset_5168608124271064'), NodeId(space='sp_pump_station', external_id='Asset_4712097420257305'), NodeId(space='sp_pump_station', external_id='Asset_449616738664544'), NodeId(space='sp_pump_station', external_id='Asset_6264128498357271'), NodeId(space='sp_pump_station', external_id='Asset_7946696422000355'), NodeId(space='sp_pump_station', external_id='Asset_1036635642295968'), NodeId(space='sp_pump_station', external_id='Asset_2648639705661733'), NodeId(space='sp_pump_station', external_id='Asset_862846106956486'), NodeId(space='sp_pump_station', external_id='Asset_522426732998405'), NodeId(space='sp_pump_station', external_id='Asset_8523137874354911'), NodeId(space='sp_pump_station', external_id='Asset_1194729803680100'), NodeId(space='sp_pump_station', external_id='Asset_5547362797792188'), NodeId(space='sp_pump_station', external_id='Asset_6410548171595891'), NodeId(space='sp_pump_station', external_id='Asset_6643904356520272'), NodeId(space='sp_pump_station', external_id='Asset_5687470951999200'), NodeId(space='sp_pump_station', external_id='Asset_2534347363555646'), NodeId(space='sp_pump_station', external_id='Asset_4611308323382841'), NodeId(space='sp_pump_station', external_id='Asset_5155311610956039'), NodeId(space='sp_pump_station', external_id='Asset_1038381373070659'), NodeId(space='sp_pump_station', external_id='Asset_8796025392183616'), NodeId(space='sp_pump_station', external_id='Asset_1251681124138604'), NodeId(space='sp_pump_station', external_id='Asset_2252447920800496'), NodeId(space='sp_pump_station', external_id='Asset_4282637232083446'), NodeId(space='sp_pump_station', external_id='Asset_3927731196795261'), NodeId(space='sp_pump_station', external_id='Asset_7528927086455056'), NodeId(space='sp_pump_station', external_id='Asset_5413774089595059'), NodeId(space='sp_pump_station', external_id='Asset_3282403756294926'), NodeId(space='sp_pump_station', external_id='Asset_7245358762439012'), NodeId(space='sp_pump_station', external_id='Asset_3947736878768533'), NodeId(space='sp_pump_station', external_id='Asset_23921452012034'), NodeId(space='sp_pump_station', external_id='Asset_2094973082337502'), NodeId(space='sp_pump_station', external_id='Asset_3742073732470345'), NodeId(space='sp_pump_station', external_id='Asset_3281981391093912'), NodeId(space='sp_pump_station', external_id='Asset_5135123609065026'), NodeId(space='sp_pump_station', external_id='Asset_7806404385295025'), NodeId(space='sp_pump_station', external_id='Asset_2879000772727558'), NodeId(space='sp_pump_station', external_id='Asset_5328233515028106'), NodeId(space='sp_pump_station', external_id='Asset_3183377929919962'), NodeId(space='sp_pump_station', external_id='Asset_2041897821048926'), NodeId(space='sp_pump_station', external_id='Asset_791284880355712'), NodeId(space='sp_pump_station', external_id='Asset_8855980446983123'), NodeId(space='sp_pump_station', external_id='Asset_2086072639670581'), NodeId(space='sp_pump_station', external_id='Asset_8222636825254386'), NodeId(space='sp_pump_station', external_id='Asset_127734001123260'), NodeId(space='sp_pump_station', external_id='Asset_8058069339001352'), NodeId(space='sp_pump_station', external_id='Asset_4891974892606772'), NodeId(space='sp_pump_station', external_id='Asset_6564758760526211'), NodeId(space='sp_pump_station', external_id='Asset_2508670135160060'), NodeId(space='sp_pump_station', external_id='Asset_6819169398550305'), NodeId(space='sp_pump_station', external_id='Asset_4161802645953289'), NodeId(space='sp_pump_station', external_id='Asset_771688114151184'), NodeId(space='sp_pump_station', external_id='Asset_1328367249298685'), NodeId(space='sp_pump_station', external_id='Asset_673071391885663'), NodeId(space='sp_pump_station', external_id='Asset_3192880850822919'), NodeId(space='sp_pump_station', external_id='Asset_2990577136288617'), NodeId(space='sp_pump_station', external_id='Asset_7267922459333514'), NodeId(space='sp_pump_station', external_id='Asset_1225335557735852'), NodeId(space='sp_pump_station', external_id='Asset_2109398666822135'), NodeId(space='sp_pump_station', external_id='Asset_2460227122870007'), NodeId(space='sp_pump_station', external_id='Asset_8724043116543799'), NodeId(space='sp_pump_station', external_id='Asset_5333316208400622'), NodeId(space='sp_pump_station', external_id='Asset_4072884896428048'), NodeId(space='sp_pump_station', external_id='Asset_1304177008138755'), NodeId(space='sp_pump_station', external_id='Asset_765927258989033'), NodeId(space='sp_pump_station', external_id='Asset_5715782298837748'), NodeId(space='sp_pump_station', external_id='Asset_227176319156396'), NodeId(space='sp_pump_station', external_id='Asset_7004541113243114'), NodeId(space='sp_pump_station', external_id='Asset_3322086940842206'), NodeId(space='sp_pump_station', external_id='Asset_3515282769165525'), NodeId(space='sp_pump_station', external_id='Asset_6276047304545772'), NodeId(space='sp_pump_station', external_id='Asset_8553994241961892'), NodeId(space='sp_pump_station', external_id='Asset_2511536057605256'), NodeId(space='sp_pump_station', external_id='Asset_3814858014848944'), NodeId(space='sp_pump_station', external_id='Asset_8504798483669198'), NodeId(space='sp_pump_station', external_id='Asset_8526018147369023'), NodeId(space='sp_pump_station', external_id='Asset_996835369435603'), NodeId(space='sp_pump_station', external_id='Asset_3912512319616642'), NodeId(space='sp_pump_station', external_id='Asset_8236357046250336'), NodeId(space='sp_pump_station', external_id='Asset_8786745865150192'), NodeId(space='sp_pump_station', external_id='Asset_5019118534073978'), NodeId(space='sp_pump_station', external_id='Asset_8349112794292547'), NodeId(space='sp_pump_station', external_id='Asset_7062323820650437'), NodeId(space='sp_pump_station', external_id='Asset_1350559385255241'), NodeId(space='sp_pump_station', external_id='Asset_4776644471418856'), NodeId(space='sp_pump_station', external_id='Asset_4139420867004251'), NodeId(space='sp_pump_station', external_id='Asset_8786769086021865'), NodeId(space='sp_pump_station', external_id='Asset_813431221291430'), NodeId(space='sp_pump_station', external_id='Asset_8393774212294989'), NodeId(space='sp_pump_station', external_id='Asset_720243198469901'), NodeId(space='sp_pump_station', external_id='Asset_6037474207471867'), NodeId(space='sp_pump_station', external_id='Asset_1864313623913141'), NodeId(space='sp_pump_station', external_id='Asset_8056653045323204'), NodeId(space='sp_pump_station', external_id='Asset_8706147153757321'), NodeId(space='sp_pump_station', external_id='Asset_8068837493233743'), NodeId(space='sp_pump_station', external_id='Asset_1062857167709404'), NodeId(space='sp_pump_station', external_id='Asset_3543366413287754'), NodeId(space='sp_pump_station', external_id='Asset_1717136324291166'), NodeId(space='sp_pump_station', external_id='Asset_5076110772903317'), NodeId(space='sp_pump_station', external_id='Asset_6499093917037259'), NodeId(space='sp_pump_station', external_id='Asset_8677060254799529'), NodeId(space='sp_pump_station', external_id='Asset_4232408171704947'), NodeId(space='sp_pump_station', external_id='Asset_1336187237481974'), NodeId(space='sp_pump_station', external_id='Asset_7266418315229309'), NodeId(space='sp_pump_station', external_id='Asset_3543745228672494'), NodeId(space='sp_pump_station', external_id='Asset_5773835011768211'), NodeId(space='sp_pump_station', external_id='Asset_4093409240484544'), NodeId(space='sp_pump_station', external_id='Asset_2084401469825731'), NodeId(space='sp_pump_station', external_id='Asset_111670655968193'), NodeId(space='sp_pump_station', external_id='Asset_2622548696369535'), NodeId(space='sp_pump_station', external_id='Asset_1994529305403431'), NodeId(space='sp_pump_station', external_id='Asset_8233413405577277'), NodeId(space='sp_pump_station', external_id='Asset_3452092217821423'), NodeId(space='sp_pump_station', external_id='Asset_3925087570184060'), NodeId(space='sp_pump_station', external_id='Asset_165156832820784'), NodeId(space='sp_pump_station', external_id='Asset_836522380797694'), NodeId(space='sp_pump_station', external_id='Asset_682395660264665'), NodeId(space='sp_pump_station', external_id='Asset_2023737592746820'), NodeId(space='sp_pump_station', external_id='Asset_6495798019337129'), NodeId(space='sp_pump_station', external_id='Asset_413299123404753'), NodeId(space='sp_pump_station', external_id='Asset_385619558573894'), NodeId(space='sp_pump_station', external_id='Asset_6779172796182945'), NodeId(space='sp_pump_station', external_id='Asset_2479470568519150'), NodeId(space='sp_pump_station', external_id='Asset_8536226378041620'), NodeId(space='sp_pump_station', external_id='Asset_6641759103584656'), NodeId(space='sp_pump_station', external_id='Asset_6614542201323700'), NodeId(space='sp_pump_station', external_id='Asset_8279593367922084'), NodeId(space='sp_pump_station', external_id='Asset_2395276745188968'), NodeId(space='sp_pump_station', external_id='Asset_465559698381891'), NodeId(space='sp_pump_station', external_id='Asset_8878199396116383'), NodeId(space='sp_pump_station', external_id='Asset_5545507452452289'), NodeId(space='sp_pump_station', external_id='Asset_7047173837936574'), NodeId(space='sp_pump_station', external_id='Asset_8925755907669641'), NodeId(space='sp_pump_station', external_id='Asset_3015520698705176'), NodeId(space='sp_pump_station', external_id='Asset_1424210982323954'), NodeId(space='sp_pump_station', external_id='Asset_2011390888860506'), NodeId(space='sp_pump_station', external_id='Asset_6391337840888778'), NodeId(space='sp_pump_station', external_id='Asset_8465364910017703'), NodeId(space='sp_pump_station', external_id='Asset_1179620013510534'), NodeId(space='sp_pump_station', external_id='Asset_4030282795820257'), NodeId(space='sp_pump_station', external_id='Asset_4752540074534822'), NodeId(space='sp_pump_station', external_id='Asset_3886073802761259'), NodeId(space='sp_pump_station', external_id='Asset_2046186730180729'), NodeId(space='sp_pump_station', external_id='Asset_8064479308748326'), NodeId(space='sp_pump_station', external_id='Asset_1774832114371582'), NodeId(space='sp_pump_station', external_id='Asset_7434639041955664'), NodeId(space='sp_pump_station', external_id='Asset_4261713708156963'), NodeId(space='sp_pump_station', external_id='Asset_8906381697072008'), NodeId(space='sp_pump_station', external_id='Asset_2336737113812249'), NodeId(space='sp_pump_station', external_id='Asset_6480569031884264'), NodeId(space='sp_pump_station', external_id='Asset_8890997887425292'), NodeId(space='sp_pump_station', external_id='Asset_5041263389346470'), NodeId(space='sp_pump_station', external_id='Asset_2614391887415841'), NodeId(space='sp_pump_station', external_id='Asset_756443337825960'), NodeId(space='sp_pump_station', external_id='Asset_1037825783121772'), NodeId(space='sp_pump_station', external_id='Asset_6781772664404616'), NodeId(space='sp_pump_station', external_id='Asset_7523396261491280'), NodeId(space='sp_pump_station', external_id='Asset_2736664555336384'), NodeId(space='sp_pump_station', external_id='Asset_779363703909879'), NodeId(space='sp_pump_station', external_id='Asset_8808794232286601'), NodeId(space='sp_pump_station', external_id='Asset_2659669230977122'), NodeId(space='sp_pump_station', external_id='Asset_6996457070033380'), NodeId(space='sp_pump_station', external_id='Asset_7836353321625289'), NodeId(space='sp_pump_station', external_id='Asset_5281038386138027'), NodeId(space='sp_pump_station', external_id='Asset_1602743241841442'), NodeId(space='sp_pump_station', external_id='Asset_1496076023751088'), NodeId(space='sp_pump_station', external_id='Asset_6004900365929538'), NodeId(space='sp_pump_station', external_id='Asset_4487513710880340'), NodeId(space='sp_pump_station', external_id='Asset_7516256968258946'), NodeId(space='sp_pump_station', external_id='Asset_8174955310442028'), NodeId(space='sp_pump_station', external_id='Asset_8481426694002548'), NodeId(space='sp_pump_station', external_id='Asset_8770242167137269'), NodeId(space='sp_pump_station', external_id='Asset_285703678588887'), NodeId(space='sp_pump_station', external_id='Asset_3966852611906380'), NodeId(space='sp_pump_station', external_id='Asset_81467243787762'), NodeId(space='sp_pump_station', external_id='Asset_269634716915797'), NodeId(space='sp_pump_station', external_id='Asset_2849528494272170')}, unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set()),\n",
+       " UploadResult(name='Edges', error_messages=[], issues=[], created=set(), upserted=set(), deleted=set(), changed=set(), unchanged=set(), skipped=set(), failed_created=set(), failed_upserted=set(), failed_changed=set(), failed_deleted=set())]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "result"
+    "neat.to.cdf.instances(created.space)"
    ]
   },
   {

--- a/docs/tutorials/data-onboarding/asset_hierarchy_migration.ipynb
+++ b/docs/tutorials/data-onboarding/asset_hierarchy_migration.ipynb
@@ -42,8 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cognite.neat import get_cognite_client\n",
-    "from cognite.neat.graph import extractors, NeatGraphStore"
+    "from cognite.neat import get_cognite_client, NeatSession"
    ]
   },
   {
@@ -51,174 +50,13 @@
    "id": "ecb953ac-5bd4-4de9-9efa-17319d9f2eba",
    "metadata": {},
    "source": [
-    "We start by importing the neat extractors, NeatGraphStore, and a utility method for getting a neat client."
+    "We start by instansiating a new NeatSession"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "id": "f63c5b57-5402-42e9-af1e-3afd909a345c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "store = NeatGraphStore.from_memory_store()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cb9dec6f-051c-4b32-a190-80d5db8fe168",
-   "metadata": {},
-   "source": [
-    "The NeatGraphStore is a triple store that can store both data as well as schemas/data-models.\n",
-    "\n",
-    "This store we can populate by extracting from one of the supported sources for neat. \n",
-    "\n",
-    "To see which extractors are available we print the `extractors` module."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "bd94dac9-856e-45ca-b384-191b85df72ce",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong>Extractor</strong> An extractor is used to read data from a source into Neat's internal triple storage. <br /><div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Extractor</th>\n",
-       "      <th>Description</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>AssetsExtractor</td>\n",
-       "      <td>Extract data from Cognite Data Fusions Assets ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>MockGraphGenerator</td>\n",
-       "      <td>Class used to generate mock graph data for pur...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>RelationshipsExtractor</td>\n",
-       "      <td>Extract data from Cognite Data Fusions Relatio...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>TimeSeriesExtractor</td>\n",
-       "      <td>Extract data from Cognite Data Fusions TimeSer...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>SequencesExtractor</td>\n",
-       "      <td>Extract data from Cognite Data Fusions Sequenc...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>EventsExtractor</td>\n",
-       "      <td>Extract data from Cognite Data Fusions Events ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>FilesExtractor</td>\n",
-       "      <td>Extract data from Cognite Data Fusions files m...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>LabelsExtractor</td>\n",
-       "      <td>Extract data from Cognite Data Fusions Labels ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>RdfFileExtractor</td>\n",
-       "      <td>Extract data from RDF files into Neat.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>DexpiExtractor</td>\n",
-       "      <td>DEXPI-XML extractor of RDF triples</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "<module 'cognite.neat.graph.extractors' from 'C:\\\\Users\\\\AndersAlbert\\\\Projects\\\\internal\\\\neat\\\\cognite\\\\neat\\\\graph\\\\extractors\\\\__init__.py'>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "extractors"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2f39d8f7-e3a0-461d-ba1f-039b824f31d1",
-   "metadata": {},
-   "source": [
-    "At the top of the list we see the AssetsExtractor which is what we are looking for"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "aa7cef10-2f11-4182-a910-2bfc70d2ed2d",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<h3>AssetsExtractor</h3><p>Extract data from Cognite Data Fusions Assets into Neat.<br /><strong>Available factory methods:</strong><br /><ul style=\"list-style-type:circle;\"><li><em>.from_dataset</em></li><li><em>.from_file</em></li><li><em>.from_hierarchy</em></li></ul></p>"
-      ],
-      "text/plain": [
-       "cognite.neat.graph.extractors._classic_cdf._assets.AssetsExtractor"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "extractors.AssetsExtractor"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "925f0523-fcea-4e75-a16b-6ed9d2cbaf50",
-   "metadata": {},
-   "source": [
-    "We see that there is a `.from_hierarchy` fatory method that fits well with what we want to do"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "196b5d39-ea23-4ff3-a6f4-5899bda7d6ad",
    "metadata": {},
    "outputs": [
     {
@@ -227,66 +65,86 @@
      "text": [
       "Found .env file in repository root. Loaded variables from .env file.\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<strong>Empty session</strong>. Get started by reading something with the <em>.read</em> attribute."
+      ],
+      "text/plain": [
+       "<cognite.neat._session._base.NeatSession at 0x25ef81a6180>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "client = get_cognite_client()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "422ba872-a6a9-42e2-99c2-949ab2b35620",
-   "metadata": {},
-   "source": [
-    "Note that the utility function `get_cognite_client` will prompt us for credentials if it doesn't find a `.env` file in the repo root."
+    "neat = NeatSession(get_cognite_client(\".env\"))\n",
+    "neat"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "fbe6658c-4c8c-434a-b862-80c0aa89754a",
+   "execution_count": 3,
+   "id": "d5c652c4-a3a3-4763-b26e-4f8da4ebdf82",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ca7a6549ca8440be94021e2015d20ff6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Asset hierarchy lift_pump_stations:root read successfully\n"
+     ]
+    }
+   ],
    "source": [
-    "asset_extractor = extractors.AssetsExtractor.from_hierarchy(client, root_asset_external_id=\"lift_pump_stations:root\")"
+    "neat.read.cdf.classic_assets(root_asset_external_id=\"lift_pump_stations:root\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "97bbba75-74fb-4bf3-b6ec-fcb0e3c40e06",
+   "id": "8e3bd2e1-0571-4119-9e1e-b842fcfa18a6",
    "metadata": {},
    "source": [
-    "The asset extractor is now ready and can be written to the store."
+    "We can check the status of the `NeatSession` "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "aae9e76d-ad13-4a04-84cb-e0f89515d37c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "store.write(asset_extractor)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "20e47b2a-2c3f-4741-9101-f85798090ee2",
-   "metadata": {},
-   "source": [
-    "We can inspect the store to see what changes have been applied to it:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "cd28f619-3de5-4a84-8ba6-2d6eaa3df1b0",
+   "execution_count": 4,
+   "id": "297cb3ee-f8a1-4358-a944-cc5cd3135413",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<strong>NeatGraphStore</strong> A graph store is a container for storing triples. It can be queried and transformed to extract information.<br /><strong>Provenance</strong> Provenance is a record of changes that have occurred in the graph store.<br /><div>\n",
+       "<H2>Instances</H2> <br /><strong>Overview</strong>:<ul><li>1 types</strong></li><li>245 instances</strong></li></ul><div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -304,42 +162,41 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>Agent</th>\n",
-       "      <th>Activity</th>\n",
-       "      <th>Entity</th>\n",
-       "      <th>Description</th>\n",
+       "      <th>Type</th>\n",
+       "      <th>Occurrence</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>http://purl.org/cognite/neat#agent</td>\n",
-       "      <td>http://purl.org/cognite/neat#activity-b2c2ee23...</td>\n",
-       "      <td>http://purl.org/cognite/neat#graph-store</td>\n",
-       "      <td>Initialize graph store as Memory</td>\n",
+       "      <td>Asset</td>\n",
+       "      <td>245</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>http://purl.org/cognite/neat#agent</td>\n",
-       "      <td>http://purl.org/cognite/neat#activity-b2c2ee23...</td>\n",
-       "      <td>http://purl.org/cognite/neat#graph-store</td>\n",
-       "      <td>Extracted triples to graph store using AssetsE...</td>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Asset</td>\n",
+       "      <td>245</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "</div>"
+       "</div><br /><strong>Provenance</strong>:<ul><li>Initialize graph store as Memory</li><li>Extracted triples to graph store using AssetsExtractor</li></ul>"
       ],
       "text/plain": [
-       "<cognite.neat.graph.stores._base.NeatGraphStore at 0x246c0130590>"
+       "<cognite.neat._session._base.NeatSession at 0x25ef81a6180>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "store"
+    "neat"
    ]
   },
   {
@@ -355,29 +212,26 @@
    "id": "2134c28e-3c7c-430e-92af-21758f3fb03f",
    "metadata": {},
    "source": [
-    "To infer a data model from the data we will use an importer"
+    "With the asset data in the store, we can now infer the data model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "871e3c87-7447-4adc-9de1-5bedfa5901ad",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from cognite.neat.rules import importers"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "eed889b8-9449-4c61-b5b1-45c8bb227fb3",
+   "execution_count": 5,
+   "id": "7cdc0d7e-14e8-4882-9a68-67030d41b39b",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data Model Inference <class 'cognite.neat._store._base.NeatGraphStore'> <cognite.neat._store._base.NeatGraphStore object at 0x0000025EFEC257F0> read successfully\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
-       "<strong>Importer</strong> An importer reads data/schema/data model from a source and converts it into Neat's representation of a data model called <em>Rules</em>.<br /><div>\n",
+       "<div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -395,121 +249,40 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>Importer</th>\n",
-       "      <th>Description</th>\n",
+       "      <th>identifier</th>\n",
+       "      <th>resourceType</th>\n",
+       "      <th>propertyName</th>\n",
+       "      <th>defaultAction</th>\n",
+       "      <th>recommendedAction</th>\n",
+       "      <th>NeatIssue</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>OWLImporter</td>\n",
-       "      <td>Convert OWL ontology to tables/ transformation...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>DMSImporter</td>\n",
-       "      <td>Imports a Data Model from Cognite Data Fusion.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>ExcelImporter</td>\n",
-       "      <td>Import rules from an Excel file.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>GoogleSheetImporter</td>\n",
-       "      <td>Import rules from a Google Sheet.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>DTDLImporter</td>\n",
-       "      <td>Importer from Azure Digital Twin - DTDL (Digit...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>YAMLImporter</td>\n",
-       "      <td>Imports the rules from a YAML file.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>InferenceImporter</td>\n",
-       "      <td>Infers rules from a triple store.</td>\n",
+       "      <td>Asset:dataset</td>\n",
+       "      <td>Property</td>\n",
+       "      <td>dataset</td>\n",
+       "      <td>Remove the property from the rules</td>\n",
+       "      <td>Make sure that graph is complete</td>\n",
+       "      <td>PropertyValueTypeUndefinedWarning</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "<module 'cognite.neat.rules.importers' from 'C:\\\\Users\\\\AndersAlbert\\\\Projects\\\\internal\\\\neat\\\\cognite\\\\neat\\\\rules\\\\importers\\\\__init__.py'>"
+       "[PropertyValueTypeUndefinedWarning(identifier='Asset:dataset', resource_type='Property', property_name='dataset', default_action='Remove the property from the rules', recommended_action='Make sure that graph is complete')]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "importers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3808a99b-ffbd-4a96-b656-aaae1d9ebcae",
-   "metadata": {},
-   "source": [
-    "We see that there are multiple importers availabe, but we will use the `InferenceImporter`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "4fcab172-c8d0-478b-95c6-dcc2aa1ff1fa",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<h3>InferenceImporter</h3><p>Infers rules from a triple store.<br /><br />    Rules inference through analysis of knowledge graph provided in various formats.<br />    Use the factory methods to create an triples store from sources such as<br />    RDF files, JSON files, YAML files, XML files, or directly from a graph store.<br /><strong>Available factory methods:</strong><br /><ul style=\"list-style-type:circle;\"><li><em>.from_graph_store</em></li><li><em>.from_json_file</em></li><li><em>.from_rdf_file</em></li><li><em>.from_xml_file</em></li><li><em>.from_yaml_file</em></li></ul></p>"
-      ],
-      "text/plain": [
-       "cognite.neat.rules.importers._inference2rules.InferenceImporter"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "importers.InferenceImporter"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "fc3eff2a-bd19-4336-b321-38a989d7cda8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "importer = importers.InferenceImporter.from_graph_store(store)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "32893008-e984-49f1-8e04-a94f40400a94",
-   "metadata": {},
-   "source": [
-    "Then we use the `.to_rules` method to convert the data into `Rules` which is `Neat`'s format for data models."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "130be0d2-72c9-4f9c-9374-d71c3d9a361e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rules, issues = importer.to_rules()"
+    "issues = neat.infer()\n",
+    "issues"
    ]
   },
   {
@@ -517,15 +290,13 @@
    "id": "4bd0aaea-6c5b-455b-8d93-f374544a3168",
    "metadata": {},
    "source": [
-    "First we check if there were any issues with creating the rules, and we find one warning. This warning \n",
-    "is that there is a property, `Shape__Length`, with a double underscore which is not recommended. However,\n",
-    "wecan continue."
+    "We see in the inference that there is a DataSet type we do not know about. However, this is just a warning we can thus continue."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "cfbebeaa-f297-4110-8fb5-8fc6ed46aa78",
+   "execution_count": 6,
+   "id": "02ff718a-5e18-4f8b-9e7b-db075b163db4",
    "metadata": {},
    "outputs": [
     {
@@ -549,51 +320,80 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>field_name</th>\n",
+       "      <th>identifier</th>\n",
+       "      <th>resourceType</th>\n",
+       "      <th>propertyName</th>\n",
+       "      <th>defaultAction</th>\n",
+       "      <th>recommendedAction</th>\n",
+       "      <th>NeatIssue</th>\n",
        "      <th>value</th>\n",
+       "      <th>pattern</th>\n",
+       "      <th>patternName</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>Asset:dataset</td>\n",
+       "      <td>Property</td>\n",
+       "      <td>dataset</td>\n",
+       "      <td>Remove the property from the rules</td>\n",
+       "      <td>Make sure that graph is complete</td>\n",
+       "      <td>PropertyValueTypeUndefinedWarning</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
        "      <td>property</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>RegexViolationWarning</td>\n",
        "      <td>Shape__Length</td>\n",
+       "      <td>^(\\*)|(?!^(Property|property)$)(^[a-zA-Z][a-zA...</td>\n",
+       "      <td>MoreThanOneNonAlphanumeric</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "IssueList([MoreThanOneNonAlphanumericCharacterWarning(field_name='property', value='Shape__Length')])"
+       "[PropertyValueTypeUndefinedWarning(identifier='Asset:dataset', resource_type='Property', property_name='dataset', default_action='Remove the property from the rules', recommended_action='Make sure that graph is complete'),\n",
+       " RegexViolationWarning(value='Shape__Length', pattern='^(\\\\*)|(?!^(Property|property)$)(^[a-zA-Z][a-zA-Z0-9._-]{0,253}[a-zA-Z0-9]?$)', identifier='property', pattern_name='MoreThanOneNonAlphanumeric', motivation=None)]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "issues"
+    "neat.verify()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4ab723c5-b67f-40d5-9ce0-085c89137a1e",
+   "id": "ebb385e2-a7ff-4f97-b57e-98a21e5482a1",
    "metadata": {},
    "source": [
-    "Then, we inspect the classes found along with the properties"
+    "First we check if there were any issues with creating the rules, and we find one warning. This warning \n",
+    "is that there is a property, `Shape__Length`, with a double underscore which is not recommended. However,\n",
+    "we can continue."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "78c8a0f3-64c4-4c6c-8924-888d36aad6ce",
+   "execution_count": 7,
+   "id": "2fd658a1-9ee4-4ab0-ad95-e4fb4f6dc7b5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div>\n",
+       "<H2>Data Model</H2><br /><div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -611,47 +411,41 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>class_</th>\n",
-       "      <th>reference</th>\n",
-       "      <th>match_type</th>\n",
-       "      <th>comment</th>\n",
+       "      <th></th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>http://purl.org/cognite/neat#Asset</td>\n",
-       "      <td>exact</td>\n",
-       "      <td>Inferred from knowledge graph, where this clas...</td>\n",
+       "      <th>type</th>\n",
+       "      <td>Logical Data Model</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>intended for</th>\n",
+       "      <td>Information Architect</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>name</th>\n",
+       "      <td>InferredDataModel</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>external_id</th>\n",
+       "      <td>inference_space</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>version</th>\n",
+       "      <td>v1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>classes</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>properties</th>\n",
+       "      <td>26</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "SheetList[InformationClass](data=[InformationClass(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), name=None, description=None, parent=None, reference=Url('http://purl.org/cognite/neat#Asset'), match_type='exact', comment='Inferred from knowledge graph, where this class has <245> instances')])"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "rules.classes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "7a07e396-b1f5-4f21-b03a-02febf639ee9",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
+       "</div><br /><H2>Instances</H2> <br /><strong>Overview</strong>:<ul><li>1 types</strong></li><li>245 instances</strong></li></ul><div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -669,318 +463,63 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>class_</th>\n",
-       "      <th>property_</th>\n",
-       "      <th>value_type</th>\n",
-       "      <th>max_count</th>\n",
-       "      <th>reference</th>\n",
-       "      <th>transformation</th>\n",
-       "      <th>comment</th>\n",
-       "      <th>inherited</th>\n",
+       "      <th>Type</th>\n",
+       "      <th>Occurrence</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>name</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#name</td>\n",
-       "      <td>inferred:Asset(inferred:name)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;name&gt; with value t...</td>\n",
-       "      <td>False</td>\n",
+       "      <td>Asset</td>\n",
+       "      <td>245</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>external_id</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#external_id</td>\n",
-       "      <td>inferred:Asset(inferred:external_id)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;external_id&gt; with ...</td>\n",
-       "      <td>False</td>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>created_time</td>\n",
-       "      <td>dateTime</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#created_time</td>\n",
-       "      <td>inferred:Asset(inferred:created_time)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;created_time&gt; with...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>last_updated_time</td>\n",
-       "      <td>dateTime</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#last_updated_time</td>\n",
-       "      <td>inferred:Asset(inferred:last_updated_time)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;last_updated_time&gt;...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>DesignPointFlowGPM</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#DesignPointFlowGPM</td>\n",
-       "      <td>inferred:Asset(inferred:DesignPointFlowGPM)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;DesignPointFlowGPM...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>DesignPointHeadFT</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#DesignPointHeadFT</td>\n",
-       "      <td>inferred:Asset(inferred:DesignPointHeadFT)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;DesignPointHeadFT&gt;...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>Enabled</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#Enabled</td>\n",
-       "      <td>inferred:Asset(inferred:Enabled)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;Enabled&gt; with valu...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>HighHeadShutOff</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#HighHeadShutOff</td>\n",
-       "      <td>inferred:Asset(inferred:HighHeadShutOff)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;HighHeadShutOff&gt; w...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>LowHeadFT</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#LowHeadFT</td>\n",
-       "      <td>inferred:Asset(inferred:LowHeadFT)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;LowHeadFT&gt; with va...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>LowHeadFlowGPM</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#LowHeadFlowGPM</td>\n",
-       "      <td>inferred:Asset(inferred:LowHeadFlowGPM)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;LowHeadFlowGPM&gt; wi...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>PumpHP</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#PumpHP</td>\n",
-       "      <td>inferred:Asset(inferred:PumpHP)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;PumpHP&gt; with value...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>PumpOff</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#PumpOff</td>\n",
-       "      <td>inferred:Asset(inferred:PumpOff)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;PumpOff&gt; with valu...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>PumpOn</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#PumpOn</td>\n",
-       "      <td>inferred:Asset(inferred:PumpOn)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;PumpOn&gt; with value...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>Shape__Length</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#Shape__Length</td>\n",
-       "      <td>inferred:Asset(inferred:Shape__Length)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;Shape__Length&gt; wit...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>VFDSetting</td>\n",
-       "      <td>double</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#VFDSetting</td>\n",
-       "      <td>inferred:Asset(inferred:VFDSetting)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;VFDSetting&gt; with v...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>parent</td>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#parent</td>\n",
-       "      <td>inferred:Asset(inferred:parent)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;parent&gt; with value...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>root</td>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#root</td>\n",
-       "      <td>inferred:Asset(inferred:root)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;root&gt; with value t...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>description</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#description</td>\n",
-       "      <td>inferred:Asset(inferred:description)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;description&gt; with ...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>FacilityID</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#FacilityID</td>\n",
-       "      <td>inferred:Asset(inferred:FacilityID)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;FacilityID&gt; with v...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>InstallDate</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#InstallDate</td>\n",
-       "      <td>inferred:Asset(inferred:InstallDate)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;InstallDate&gt; with ...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>LifeCycleStatus</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#LifeCycleStatus</td>\n",
-       "      <td>inferred:Asset(inferred:LifeCycleStatus)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;LifeCycleStatus&gt; w...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>LiftStationID</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#LiftStationID</td>\n",
-       "      <td>inferred:Asset(inferred:LiftStationID)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;LiftStationID&gt; wit...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>LocationDescription</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#LocationDescription</td>\n",
-       "      <td>inferred:Asset(inferred:LocationDescription)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;LocationDescriptio...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>23</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>Position</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#Position</td>\n",
-       "      <td>inferred:Asset(inferred:Position)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;Position&gt; with val...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>PumpModel</td>\n",
-       "      <td>integer | string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#PumpModel</td>\n",
-       "      <td>inferred:Asset(inferred:PumpModel)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;PumpModel&gt; with va...</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>inferred:Asset</td>\n",
-       "      <td>VFD</td>\n",
-       "      <td>string</td>\n",
-       "      <td>1</td>\n",
-       "      <td>http://purl.org/cognite/neat#VFD</td>\n",
-       "      <td>inferred:Asset(inferred:VFD)</td>\n",
-       "      <td>Class &lt;Asset&gt; has property &lt;VFD&gt; with value ty...</td>\n",
-       "      <td>False</td>\n",
+       "      <th>0</th>\n",
+       "      <td>Asset</td>\n",
+       "      <td>245</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "</div>"
+       "</div><br /><strong>Provenance</strong>:<ul><li>Initialize graph store as Memory</li><li>Extracted triples to graph store using AssetsExtractor</li><li>Added rules to graph store as InformationRules</li><li>Upsert prefixes to graph store</li></ul>"
       ],
       "text/plain": [
-       "SheetList[InformationProperty](data=[InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='name', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#name'), match_type=None, transformation=inferred:Asset(inferred:name), comment='Class <Asset> has property <name> with value type <string> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='external_id', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#external_id'), match_type=None, transformation=inferred:Asset(inferred:external_id), comment='Class <Asset> has property <external_id> with value type <string> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='created_time', name=None, description=None, value_type=DateTime(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#created_time'), match_type=None, transformation=inferred:Asset(inferred:created_time), comment='Class <Asset> has property <created_time> with value type <dateTime> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='last_updated_time', name=None, description=None, value_type=DateTime(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#last_updated_time'), match_type=None, transformation=inferred:Asset(inferred:last_updated_time), comment='Class <Asset> has property <last_updated_time> with value type <dateTime> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='DesignPointFlowGPM', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#DesignPointFlowGPM'), match_type=None, transformation=inferred:Asset(inferred:DesignPointFlowGPM), comment='Class <Asset> has property <DesignPointFlowGPM> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='DesignPointHeadFT', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#DesignPointHeadFT'), match_type=None, transformation=inferred:Asset(inferred:DesignPointHeadFT), comment='Class <Asset> has property <DesignPointHeadFT> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='Enabled', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#Enabled'), match_type=None, transformation=inferred:Asset(inferred:Enabled), comment='Class <Asset> has property <Enabled> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='HighHeadShutOff', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#HighHeadShutOff'), match_type=None, transformation=inferred:Asset(inferred:HighHeadShutOff), comment='Class <Asset> has property <HighHeadShutOff> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='LowHeadFT', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#LowHeadFT'), match_type=None, transformation=inferred:Asset(inferred:LowHeadFT), comment='Class <Asset> has property <LowHeadFT> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='LowHeadFlowGPM', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#LowHeadFlowGPM'), match_type=None, transformation=inferred:Asset(inferred:LowHeadFlowGPM), comment='Class <Asset> has property <LowHeadFlowGPM> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='PumpHP', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#PumpHP'), match_type=None, transformation=inferred:Asset(inferred:PumpHP), comment='Class <Asset> has property <PumpHP> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='PumpOff', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#PumpOff'), match_type=None, transformation=inferred:Asset(inferred:PumpOff), comment='Class <Asset> has property <PumpOff> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='PumpOn', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#PumpOn'), match_type=None, transformation=inferred:Asset(inferred:PumpOn), comment='Class <Asset> has property <PumpOn> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='Shape__Length', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#Shape__Length'), match_type=None, transformation=inferred:Asset(inferred:Shape__Length), comment='Class <Asset> has property <Shape__Length> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='VFDSetting', name=None, description=None, value_type=Double(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#VFDSetting'), match_type=None, transformation=inferred:Asset(inferred:VFDSetting), comment='Class <Asset> has property <VFDSetting> with value type <double> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='parent', name=None, description=None, value_type=class(prefix=inferred,suffix=Asset), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#parent'), match_type=None, transformation=inferred:Asset(inferred:parent), comment='Class <Asset> has property <parent> with value type <Asset> which occurs <244> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='root', name=None, description=None, value_type=class(prefix=inferred,suffix=Asset), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#root'), match_type=None, transformation=inferred:Asset(inferred:root), comment='Class <Asset> has property <root> with value type <Asset> which occurs <245> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='description', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#description'), match_type=None, transformation=inferred:Asset(inferred:description), comment='Class <Asset> has property <description> with value type <string> which occurs <152> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='FacilityID', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#FacilityID'), match_type=None, transformation=inferred:Asset(inferred:FacilityID), comment='Class <Asset> has property <FacilityID> with value type <string> which occurs <162> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='InstallDate', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#InstallDate'), match_type=None, transformation=inferred:Asset(inferred:InstallDate), comment='Class <Asset> has property <InstallDate> with value type <string> which occurs <160> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='LifeCycleStatus', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#LifeCycleStatus'), match_type=None, transformation=inferred:Asset(inferred:LifeCycleStatus), comment='Class <Asset> has property <LifeCycleStatus> with value type <string> which occurs <160> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='LiftStationID', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#LiftStationID'), match_type=None, transformation=inferred:Asset(inferred:LiftStationID), comment='Class <Asset> has property <LiftStationID> with value type <string> which occurs <160> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='LocationDescription', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#LocationDescription'), match_type=None, transformation=inferred:Asset(inferred:LocationDescription), comment='Class <Asset> has property <LocationDescription> with value type <string> which occurs <160> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='Position', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#Position'), match_type=None, transformation=inferred:Asset(inferred:Position), comment='Class <Asset> has property <Position> with value type <string> which occurs <147> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='PumpModel', name=None, description=None, value_type=MultiValueTypeInfo(types=[Integer(), String()]), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#PumpModel'), match_type=None, transformation=inferred:Asset(inferred:PumpModel), comment='Class <Asset> has property <PumpModel> with value type <integer> which occurs <6> times in the graph, with value type <string> which occurs <140> times in the graph', inherited=False), InformationProperty(validators_to_skip=set(), class_=class(prefix=inferred,suffix=Asset), property_='VFD', name=None, description=None, value_type=String(), min_count=None, max_count=1, default=None, reference=Url('http://purl.org/cognite/neat#VFD'), match_type=None, transformation=inferred:Asset(inferred:VFD), comment='Class <Asset> has property <VFD> with value type <string> which occurs <41> times in the graph', inherited=False)])"
+       "<cognite.neat._session._base.NeatSession at 0x25ef81a6180>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "rules.properties"
+    "neat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9f2cb4f8-4c20-400b-b35b-c766b23845af",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'NeatSession' object has no attribute 'inspect'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[11], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[43mneat\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minspect\u001b[49m\u001b[38;5;241m.\u001b[39mproperties\n",
+      "\u001b[1;31mAttributeError\u001b[0m: 'NeatSession' object has no attribute 'inspect'"
+     ]
+    }
+   ],
+   "source": [
+    "neat.inspect.properties"
    ]
   },
   {
@@ -1001,19 +540,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 8,
    "id": "91515d15-b28a-4b6c-83fc-092f56d1532c",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'Class <Asset> has property <PumpModel> with value type <integer> which occurs <6> times in the graph, with value type <string> which occurs <140> times in the graph'"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "NameError",
+     "evalue": "name 'rules' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[8], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[43mrules\u001b[49m\u001b[38;5;241m.\u001b[39mproperties\u001b[38;5;241m.\u001b[39mdata[\u001b[38;5;241m24\u001b[39m]\u001b[38;5;241m.\u001b[39mcomment\n",
+      "\u001b[1;31mNameError\u001b[0m: name 'rules' is not defined"
+     ]
     }
    ],
    "source": [

--- a/poetry.lock
+++ b/poetry.lock
@@ -287,21 +287,20 @@ lxml = ["lxml"]
 
 [[package]]
 name = "bleach"
-version = "6.1.0"
+version = "6.2.0"
 description = "An easy safelist-based HTML-sanitizing tool."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "bleach-6.1.0-py3-none-any.whl", hash = "sha256:3225f354cfc436b9789c66c4ee030194bee0568fbf9cbdad3bc8b5c26c5f12b6"},
-    {file = "bleach-6.1.0.tar.gz", hash = "sha256:0a31f1837963c41d46bbf1331b8778e1308ea0791db03cc4e7357b97cf42a8fe"},
+    {file = "bleach-6.2.0-py3-none-any.whl", hash = "sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e"},
+    {file = "bleach-6.2.0.tar.gz", hash = "sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f"},
 ]
 
 [package.dependencies]
-six = ">=1.9.0"
 webencodings = "*"
 
 [package.extras]
-css = ["tinycss2 (>=1.1.0,<1.3)"]
+css = ["tinycss2 (>=1.1.0,<1.5)"]
 
 [[package]]
 name = "cachetools"
@@ -589,13 +588,13 @@ python-json-logger = ">=2.0.7,<3.0.0"
 
 [[package]]
 name = "cognite-sdk"
-version = "7.64.0"
+version = "7.64.1"
 description = "Cognite Python SDK"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "cognite_sdk-7.64.0-py3-none-any.whl", hash = "sha256:37a34a76efc18debb5918f22b65b1f14f283e392d77999ea3e46b25f41968e3d"},
-    {file = "cognite_sdk-7.64.0.tar.gz", hash = "sha256:0203b856f17e5fe322c2abd00d7cb0fb3868bd46b0af207aebde77d3d04f5263"},
+    {file = "cognite_sdk-7.64.1-py3-none-any.whl", hash = "sha256:2ba844ccb802d0b3a377b59ecb33bdd10d0de8d713642f00e485baa0526743c5"},
+    {file = "cognite_sdk-7.64.1.tar.gz", hash = "sha256:69c114d9ecf4dce6044ebe565091303da54d82785cca949ccca57db22c36a300"},
 ]
 
 [package.dependencies]
@@ -668,6 +667,90 @@ traitlets = ">=4"
 
 [package.extras]
 test = ["pytest"]
+
+[[package]]
+name = "contourpy"
+version = "1.3.0"
+description = "Python library for calculating contours of 2D quadrilateral grids"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "contourpy-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:880ea32e5c774634f9fcd46504bf9f080a41ad855f4fef54f5380f5133d343c7"},
+    {file = "contourpy-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:76c905ef940a4474a6289c71d53122a4f77766eef23c03cd57016ce19d0f7b42"},
+    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92f8557cbb07415a4d6fa191f20fd9d2d9eb9c0b61d1b2f52a8926e43c6e9af7"},
+    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:36f965570cff02b874773c49bfe85562b47030805d7d8360748f3eca570f4cab"},
+    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cacd81e2d4b6f89c9f8a5b69b86490152ff39afc58a95af002a398273e5ce589"},
+    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69375194457ad0fad3a839b9e29aa0b0ed53bb54db1bfb6c3ae43d111c31ce41"},
+    {file = "contourpy-1.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a52040312b1a858b5e31ef28c2e865376a386c60c0e248370bbea2d3f3b760d"},
+    {file = "contourpy-1.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3faeb2998e4fcb256542e8a926d08da08977f7f5e62cf733f3c211c2a5586223"},
+    {file = "contourpy-1.3.0-cp310-cp310-win32.whl", hash = "sha256:36e0cff201bcb17a0a8ecc7f454fe078437fa6bda730e695a92f2d9932bd507f"},
+    {file = "contourpy-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:87ddffef1dbe5e669b5c2440b643d3fdd8622a348fe1983fad7a0f0ccb1cd67b"},
+    {file = "contourpy-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0fa4c02abe6c446ba70d96ece336e621efa4aecae43eaa9b030ae5fb92b309ad"},
+    {file = "contourpy-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:834e0cfe17ba12f79963861e0f908556b2cedd52e1f75e6578801febcc6a9f49"},
+    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbc4c3217eee163fa3984fd1567632b48d6dfd29216da3ded3d7b844a8014a66"},
+    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4865cd1d419e0c7a7bf6de1777b185eebdc51470800a9f42b9e9decf17762081"},
+    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:303c252947ab4b14c08afeb52375b26781ccd6a5ccd81abcdfc1fafd14cf93c1"},
+    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637f674226be46f6ba372fd29d9523dd977a291f66ab2a74fbeb5530bb3f445d"},
+    {file = "contourpy-1.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:76a896b2f195b57db25d6b44e7e03f221d32fe318d03ede41f8b4d9ba1bff53c"},
+    {file = "contourpy-1.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e1fd23e9d01591bab45546c089ae89d926917a66dceb3abcf01f6105d927e2cb"},
+    {file = "contourpy-1.3.0-cp311-cp311-win32.whl", hash = "sha256:d402880b84df3bec6eab53cd0cf802cae6a2ef9537e70cf75e91618a3801c20c"},
+    {file = "contourpy-1.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:6cb6cc968059db9c62cb35fbf70248f40994dfcd7aa10444bbf8b3faeb7c2d67"},
+    {file = "contourpy-1.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:570ef7cf892f0afbe5b2ee410c507ce12e15a5fa91017a0009f79f7d93a1268f"},
+    {file = "contourpy-1.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:da84c537cb8b97d153e9fb208c221c45605f73147bd4cadd23bdae915042aad6"},
+    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0be4d8425bfa755e0fd76ee1e019636ccc7c29f77a7c86b4328a9eb6a26d0639"},
+    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9c0da700bf58f6e0b65312d0a5e695179a71d0163957fa381bb3c1f72972537c"},
+    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb8b141bb00fa977d9122636b16aa67d37fd40a3d8b52dd837e536d64b9a4d06"},
+    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3634b5385c6716c258d0419c46d05c8aa7dc8cb70326c9a4fb66b69ad2b52e09"},
+    {file = "contourpy-1.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0dce35502151b6bd35027ac39ba6e5a44be13a68f55735c3612c568cac3805fd"},
+    {file = "contourpy-1.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aea348f053c645100612b333adc5983d87be69acdc6d77d3169c090d3b01dc35"},
+    {file = "contourpy-1.3.0-cp312-cp312-win32.whl", hash = "sha256:90f73a5116ad1ba7174341ef3ea5c3150ddf20b024b98fb0c3b29034752c8aeb"},
+    {file = "contourpy-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b11b39aea6be6764f84360fce6c82211a9db32a7c7de8fa6dd5397cf1d079c3b"},
+    {file = "contourpy-1.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3e1c7fa44aaae40a2247e2e8e0627f4bea3dd257014764aa644f319a5f8600e3"},
+    {file = "contourpy-1.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:364174c2a76057feef647c802652f00953b575723062560498dc7930fc9b1cb7"},
+    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32b238b3b3b649e09ce9aaf51f0c261d38644bdfa35cbaf7b263457850957a84"},
+    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d51fca85f9f7ad0b65b4b9fe800406d0d77017d7270d31ec3fb1cc07358fdea0"},
+    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:732896af21716b29ab3e988d4ce14bc5133733b85956316fb0c56355f398099b"},
+    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d73f659398a0904e125280836ae6f88ba9b178b2fed6884f3b1f95b989d2c8da"},
+    {file = "contourpy-1.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c6c7c2408b7048082932cf4e641fa3b8ca848259212f51c8c59c45aa7ac18f14"},
+    {file = "contourpy-1.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f317576606de89da6b7e0861cf6061f6146ead3528acabff9236458a6ba467f8"},
+    {file = "contourpy-1.3.0-cp313-cp313-win32.whl", hash = "sha256:31cd3a85dbdf1fc002280c65caa7e2b5f65e4a973fcdf70dd2fdcb9868069294"},
+    {file = "contourpy-1.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:4553c421929ec95fb07b3aaca0fae668b2eb5a5203d1217ca7c34c063c53d087"},
+    {file = "contourpy-1.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:345af746d7766821d05d72cb8f3845dfd08dd137101a2cb9b24de277d716def8"},
+    {file = "contourpy-1.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3bb3808858a9dc68f6f03d319acd5f1b8a337e6cdda197f02f4b8ff67ad2057b"},
+    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:420d39daa61aab1221567b42eecb01112908b2cab7f1b4106a52caaec8d36973"},
+    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d63ee447261e963af02642ffcb864e5a2ee4cbfd78080657a9880b8b1868e18"},
+    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:167d6c890815e1dac9536dca00828b445d5d0df4d6a8c6adb4a7ec3166812fa8"},
+    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:710a26b3dc80c0e4febf04555de66f5fd17e9cf7170a7b08000601a10570bda6"},
+    {file = "contourpy-1.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:75ee7cb1a14c617f34a51d11fa7524173e56551646828353c4af859c56b766e2"},
+    {file = "contourpy-1.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:33c92cdae89ec5135d036e7218e69b0bb2851206077251f04a6c4e0e21f03927"},
+    {file = "contourpy-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a11077e395f67ffc2c44ec2418cfebed032cd6da3022a94fc227b6faf8e2acb8"},
+    {file = "contourpy-1.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e8134301d7e204c88ed7ab50028ba06c683000040ede1d617298611f9dc6240c"},
+    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e12968fdfd5bb45ffdf6192a590bd8ddd3ba9e58360b29683c6bb71a7b41edca"},
+    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fd2a0fc506eccaaa7595b7e1418951f213cf8255be2600f1ea1b61e46a60c55f"},
+    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4cfb5c62ce023dfc410d6059c936dcf96442ba40814aefbfa575425a3a7f19dc"},
+    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68a32389b06b82c2fdd68276148d7b9275b5f5cf13e5417e4252f6d1a34f72a2"},
+    {file = "contourpy-1.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:94e848a6b83da10898cbf1311a815f770acc9b6a3f2d646f330d57eb4e87592e"},
+    {file = "contourpy-1.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d78ab28a03c854a873787a0a42254a0ccb3cb133c672f645c9f9c8f3ae9d0800"},
+    {file = "contourpy-1.3.0-cp39-cp39-win32.whl", hash = "sha256:81cb5ed4952aae6014bc9d0421dec7c5835c9c8c31cdf51910b708f548cf58e5"},
+    {file = "contourpy-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:14e262f67bd7e6eb6880bc564dcda30b15e351a594657e55b7eec94b6ef72843"},
+    {file = "contourpy-1.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:fe41b41505a5a33aeaed2a613dccaeaa74e0e3ead6dd6fd3a118fb471644fd6c"},
+    {file = "contourpy-1.3.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eca7e17a65f72a5133bdbec9ecf22401c62bcf4821361ef7811faee695799779"},
+    {file = "contourpy-1.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:1ec4dc6bf570f5b22ed0d7efba0dfa9c5b9e0431aeea7581aa217542d9e809a4"},
+    {file = "contourpy-1.3.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:00ccd0dbaad6d804ab259820fa7cb0b8036bda0686ef844d24125d8287178ce0"},
+    {file = "contourpy-1.3.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ca947601224119117f7c19c9cdf6b3ab54c5726ef1d906aa4a69dfb6dd58102"},
+    {file = "contourpy-1.3.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c6ec93afeb848a0845a18989da3beca3eec2c0f852322efe21af1931147d12cb"},
+    {file = "contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4"},
+]
+
+[package.dependencies]
+numpy = ">=1.23"
+
+[package.extras]
+bokeh = ["bokeh", "selenium"]
+docs = ["furo", "sphinx (>=7.2)", "sphinx-copybutton"]
+mypy = ["contourpy[bokeh,docs]", "docutils-stubs", "mypy (==1.11.1)", "types-Pillow"]
+test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
+test-no-images = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "wurlitzer"]
 
 [[package]]
 name = "coverage"
@@ -2420,57 +2503,66 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.5.2"
+version = "3.9.2"
 description = "Python plotting package"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 files = [
-    {file = "matplotlib-3.5.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:03bbb3f5f78836855e127b5dab228d99551ad0642918ccbf3067fcd52ac7ac5e"},
-    {file = "matplotlib-3.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:49a5938ed6ef9dda560f26ea930a2baae11ea99e1c2080c8714341ecfda72a89"},
-    {file = "matplotlib-3.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:77157be0fc4469cbfb901270c205e7d8adb3607af23cef8bd11419600647ceed"},
-    {file = "matplotlib-3.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5844cea45d804174bf0fac219b4ab50774e504bef477fc10f8f730ce2d623441"},
-    {file = "matplotlib-3.5.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c87973ddec10812bddc6c286b88fdd654a666080fbe846a1f7a3b4ba7b11ab78"},
-    {file = "matplotlib-3.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a05f2b37222319753a5d43c0a4fd97ed4ff15ab502113e3f2625c26728040cf"},
-    {file = "matplotlib-3.5.2-cp310-cp310-win32.whl", hash = "sha256:9776e1a10636ee5f06ca8efe0122c6de57ffe7e8c843e0fb6e001e9d9256ec95"},
-    {file = "matplotlib-3.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:b4fedaa5a9aa9ce14001541812849ed1713112651295fdddd640ea6620e6cf98"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ee175a571e692fc8ae8e41ac353c0e07259113f4cb063b0ec769eff9717e84bb"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e8bda1088b941ead50caabd682601bece983cadb2283cafff56e8fcddbf7d7f"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9480842d5aadb6e754f0b8f4ebeb73065ac8be1855baa93cd082e46e770591e9"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6c623b355d605a81c661546af7f24414165a8a2022cddbe7380a31a4170fa2e9"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-win32.whl", hash = "sha256:a91426ae910819383d337ba0dc7971c7cefdaa38599868476d94389a329e599b"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:c4b82c2ae6d305fcbeb0eb9c93df2602ebd2f174f6e8c8a5d92f9445baa0c1d3"},
-    {file = "matplotlib-3.5.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ebc27ad11df3c1661f4677a7762e57a8a91dd41b466c3605e90717c9a5f90c82"},
-    {file = "matplotlib-3.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5a32ea6e12e80dedaca2d4795d9ed40f97bfa56e6011e14f31502fdd528b9c89"},
-    {file = "matplotlib-3.5.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2a0967d4156adbd0d46db06bc1a877f0370bce28d10206a5071f9ecd6dc60b79"},
-    {file = "matplotlib-3.5.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2b696699386766ef171a259d72b203a3c75d99d03ec383b97fc2054f52e15cf"},
-    {file = "matplotlib-3.5.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7f409716119fa39b03da3d9602bd9b41142fab7a0568758cd136cd80b1bf36c8"},
-    {file = "matplotlib-3.5.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b8d3f4e71e26307e8c120b72c16671d70c5cd08ae412355c11254aa8254fb87f"},
-    {file = "matplotlib-3.5.2-cp38-cp38-win32.whl", hash = "sha256:b6c63cd01cad0ea8704f1fd586e9dc5777ccedcd42f63cbbaa3eae8dd41172a1"},
-    {file = "matplotlib-3.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:75c406c527a3aa07638689586343f4b344fcc7ab1f79c396699eb550cd2b91f7"},
-    {file = "matplotlib-3.5.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:4a44cdfdb9d1b2f18b1e7d315eb3843abb097869cd1ef89cfce6a488cd1b5182"},
-    {file = "matplotlib-3.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3d8e129af95b156b41cb3be0d9a7512cc6d73e2b2109f82108f566dbabdbf377"},
-    {file = "matplotlib-3.5.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:364e6bca34edc10a96aa3b1d7cd76eb2eea19a4097198c1b19e89bee47ed5781"},
-    {file = "matplotlib-3.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea75df8e567743207e2b479ba3d8843537be1c146d4b1e3e395319a4e1a77fe9"},
-    {file = "matplotlib-3.5.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:44c6436868186564450df8fd2fc20ed9daaef5caad699aa04069e87099f9b5a8"},
-    {file = "matplotlib-3.5.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7d7705022df2c42bb02937a2a824f4ec3cca915700dd80dc23916af47ff05f1a"},
-    {file = "matplotlib-3.5.2-cp39-cp39-win32.whl", hash = "sha256:ee0b8e586ac07f83bb2950717e66cb305e2859baf6f00a9c39cc576e0ce9629c"},
-    {file = "matplotlib-3.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:c772264631e5ae61f0bd41313bbe48e1b9bcc95b974033e1118c9caa1a84d5c6"},
-    {file = "matplotlib-3.5.2-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:751d3815b555dcd6187ad35b21736dc12ce6925fc3fa363bbc6dc0f86f16484f"},
-    {file = "matplotlib-3.5.2-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:31fbc2af27ebb820763f077ec7adc79b5a031c2f3f7af446bd7909674cd59460"},
-    {file = "matplotlib-3.5.2-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4fa28ca76ac5c2b2d54bc058b3dad8e22ee85d26d1ee1b116a6fd4d2277b6a04"},
-    {file = "matplotlib-3.5.2-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:24173c23d1bcbaed5bf47b8785d27933a1ac26a5d772200a0f3e0e38f471b001"},
-    {file = "matplotlib-3.5.2.tar.gz", hash = "sha256:48cf850ce14fa18067f2d9e0d646763681948487a8080ec0af2686468b4607a2"},
+    {file = "matplotlib-3.9.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:9d78bbc0cbc891ad55b4f39a48c22182e9bdaea7fc0e5dbd364f49f729ca1bbb"},
+    {file = "matplotlib-3.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c375cc72229614632c87355366bdf2570c2dac01ac66b8ad048d2dabadf2d0d4"},
+    {file = "matplotlib-3.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d94ff717eb2bd0b58fe66380bd8b14ac35f48a98e7c6765117fe67fb7684e64"},
+    {file = "matplotlib-3.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab68d50c06938ef28681073327795c5db99bb4666214d2d5f880ed11aeaded66"},
+    {file = "matplotlib-3.9.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:65aacf95b62272d568044531e41de26285d54aec8cb859031f511f84bd8b495a"},
+    {file = "matplotlib-3.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:3fd595f34aa8a55b7fc8bf9ebea8aa665a84c82d275190a61118d33fbc82ccae"},
+    {file = "matplotlib-3.9.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d8dd059447824eec055e829258ab092b56bb0579fc3164fa09c64f3acd478772"},
+    {file = "matplotlib-3.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c797dac8bb9c7a3fd3382b16fe8f215b4cf0f22adccea36f1545a6d7be310b41"},
+    {file = "matplotlib-3.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d719465db13267bcef19ea8954a971db03b9f48b4647e3860e4bc8e6ed86610f"},
+    {file = "matplotlib-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8912ef7c2362f7193b5819d17dae8629b34a95c58603d781329712ada83f9447"},
+    {file = "matplotlib-3.9.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7741f26a58a240f43bee74965c4882b6c93df3e7eb3de160126d8c8f53a6ae6e"},
+    {file = "matplotlib-3.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:ae82a14dab96fbfad7965403c643cafe6515e386de723e498cf3eeb1e0b70cc7"},
+    {file = "matplotlib-3.9.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ac43031375a65c3196bee99f6001e7fa5bdfb00ddf43379d3c0609bdca042df9"},
+    {file = "matplotlib-3.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be0fc24a5e4531ae4d8e858a1a548c1fe33b176bb13eff7f9d0d38ce5112a27d"},
+    {file = "matplotlib-3.9.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf81de2926c2db243c9b2cbc3917619a0fc85796c6ba4e58f541df814bbf83c7"},
+    {file = "matplotlib-3.9.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6ee45bc4245533111ced13f1f2cace1e7f89d1c793390392a80c139d6cf0e6c"},
+    {file = "matplotlib-3.9.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:306c8dfc73239f0e72ac50e5a9cf19cc4e8e331dd0c54f5e69ca8758550f1e1e"},
+    {file = "matplotlib-3.9.2-cp312-cp312-win_amd64.whl", hash = "sha256:5413401594cfaff0052f9d8b1aafc6d305b4bd7c4331dccd18f561ff7e1d3bd3"},
+    {file = "matplotlib-3.9.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:18128cc08f0d3cfff10b76baa2f296fc28c4607368a8402de61bb3f2eb33c7d9"},
+    {file = "matplotlib-3.9.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4876d7d40219e8ae8bb70f9263bcbe5714415acfdf781086601211335e24f8aa"},
+    {file = "matplotlib-3.9.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d9f07a80deab4bb0b82858a9e9ad53d1382fd122be8cde11080f4e7dfedb38b"},
+    {file = "matplotlib-3.9.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7c0410f181a531ec4e93bbc27692f2c71a15c2da16766f5ba9761e7ae518413"},
+    {file = "matplotlib-3.9.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:909645cce2dc28b735674ce0931a4ac94e12f5b13f6bb0b5a5e65e7cea2c192b"},
+    {file = "matplotlib-3.9.2-cp313-cp313-win_amd64.whl", hash = "sha256:f32c7410c7f246838a77d6d1eff0c0f87f3cb0e7c4247aebea71a6d5a68cab49"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:37e51dd1c2db16ede9cfd7b5cabdfc818b2c6397c83f8b10e0e797501c963a03"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b82c5045cebcecd8496a4d694d43f9cc84aeeb49fe2133e036b207abe73f4d30"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f053c40f94bc51bc03832a41b4f153d83f2062d88c72b5e79997072594e97e51"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbe196377a8248972f5cede786d4c5508ed5f5ca4a1e09b44bda889958b33f8c"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5816b1e1fe8c192cbc013f8f3e3368ac56fbecf02fb41b8f8559303f24c5015e"},
+    {file = "matplotlib-3.9.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:cef2a73d06601437be399908cf13aee74e86932a5ccc6ccdf173408ebc5f6bb2"},
+    {file = "matplotlib-3.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e0830e188029c14e891fadd99702fd90d317df294c3298aad682739c5533721a"},
+    {file = "matplotlib-3.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03ba9c1299c920964e8d3857ba27173b4dbb51ca4bab47ffc2c2ba0eb5e2cbc5"},
+    {file = "matplotlib-3.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cd93b91ab47a3616b4d3c42b52f8363b88ca021e340804c6ab2536344fad9ca"},
+    {file = "matplotlib-3.9.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6d1ce5ed2aefcdce11904fc5bbea7d9c21fff3d5f543841edf3dea84451a09ea"},
+    {file = "matplotlib-3.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:b2696efdc08648536efd4e1601b5fd491fd47f4db97a5fbfd175549a7365c1b2"},
+    {file = "matplotlib-3.9.2-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:d52a3b618cb1cbb769ce2ee1dcdb333c3ab6e823944e9a2d36e37253815f9556"},
+    {file = "matplotlib-3.9.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:039082812cacd6c6bec8e17a9c1e6baca230d4116d522e81e1f63a74d01d2e21"},
+    {file = "matplotlib-3.9.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6758baae2ed64f2331d4fd19be38b7b4eae3ecec210049a26b6a4f3ae1c85dcc"},
+    {file = "matplotlib-3.9.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:050598c2b29e0b9832cde72bcf97627bf00262adbc4a54e2b856426bb2ef0697"},
+    {file = "matplotlib-3.9.2.tar.gz", hash = "sha256:96ab43906269ca64a6366934106fa01534454a69e471b7bf3d79083981aaab92"},
 ]
 
 [package.dependencies]
+contourpy = ">=1.0.1"
 cycler = ">=0.10"
 fonttools = ">=4.22.0"
-kiwisolver = ">=1.0.1"
-numpy = ">=1.17"
+kiwisolver = ">=1.3.1"
+numpy = ">=1.23"
 packaging = ">=20.0"
-pillow = ">=6.2.0"
-pyparsing = ">=2.2.1"
+pillow = ">=8"
+pyparsing = ">=2.3.1"
 python-dateutil = ">=2.7"
+
+[package.extras]
+dev = ["meson-python (>=0.13.1)", "numpy (>=1.25)", "pybind11 (>=2.6)", "setuptools (>=64)", "setuptools_scm (>=7)"]
 
 [[package]]
 name = "matplotlib-inline"
@@ -4126,17 +4218,17 @@ testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "no
 
 [[package]]
 name = "pytest-cov"
-version = "5.0.0"
+version = "6.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
-    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
+    {file = "pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0"},
+    {file = "pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35"},
 ]
 
 [package.dependencies]
-coverage = {version = ">=5.2.1", extras = ["toml"]}
+coverage = {version = ">=7.5", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
@@ -4973,7 +5065,6 @@ optional = true
 python-versions = ">=3.7"
 files = [
     {file = "schedule-1.2.2-py3-none-any.whl", hash = "sha256:5bef4a2a0183abf44046ae0d164cadcac21b1db011bdd8102e4a0c1e91e06a7d"},
-    {file = "schedule-1.2.2.tar.gz", hash = "sha256:15fe9c75fe5fd9b9627f3f19cc0ef1420508f9f9a46f45cd0769ef75ede5f0b7"},
 ]
 
 [package.extras]
@@ -5892,11 +5983,10 @@ all = ["fastapi", "jinja2", "oxrdflib", "prometheus-client", "pyoxigraph", "pyth
 docs = ["mkdocs", "mkdocs-autorefs", "mkdocs-git-authors-plugin", "mkdocs-git-revision-date-localized-plugin", "mkdocs-gitbook", "mkdocs-glightbox", "mkdocs-jupyter", "mkdocs-material-extensions", "mkdocstrings", "pymdown-extensions"]
 google = ["google-api-python-client", "google-auth-oauthlib", "gspread"]
 graphql = ["jinja2"]
-jupyter = ["rich"]
 oxi = ["oxrdflib", "pyoxigraph"]
 service = ["fastapi", "prometheus-client", "python-multipart", "schedule", "uvicorn"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a5d236a9711a0c24f0a6a671425c40564b72011aeb413e6429944d0b8ecefd7c"
+content-hash = "3018d22ec3b47d23e35428d12d7c217953ac99d6573e549634ac6124af03d405"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,10 @@ urllib3 = "^2"
 openpyxl = "*"
 networkx = "^3.4.2"
 ipycytoscape = "^1.3.3"
-matplotlib = "=3.5.2"
-
+matplotlib = ">=3.5.2"
 
 # Notebook
-rich = { version = "^13.7.1", extras = ["jupyter"], optional = true }
+rich = { version = "^13.7.1", extras = ["jupyter"]}
 
 # Backport from Python 3.11
 exceptiongroup = { version = "^1.1.3", python = "<3.11" }
@@ -125,7 +124,6 @@ google = ["gspread", "google-api-python-client", "google-auth-oauthlib"]
 oxi = ["oxrdflib", "pyoxigraph"]
 service = ["uvicorn", "prometheus-client", "fastapi", "schedule", "python-multipart"]
 graphql = ["jinja2"]
-jupyter = ["rich"]
 
 all = [
     "jinja2",


### PR DESCRIPTION
Updated first migration tutorial to use `NeatSession`. A few changes

* Added `neat.read.cdf.class.asset()` to read assets from classic CDF.
* Added `neat.inspect.properties` to return a DataFrame with all properties.
* Made the visualization of the instances account for being less than 6 types.
