### PR TITLE
[NEAT-511] ⬅ Inwards edges with properties

### DIFF
--- a/cognite/neat/_session/_base.py
+++ b/cognite/neat/_session/_base.py
@@ -55,7 +55,7 @@ class NeatSession:
                 self._state.store.add_rules(output.rules)
         self._state.issue_lists.append(output.issues)
         if output.issues:
-            print("You can inspect the issues with the .inspect attribute.")
+            print("You can inspect the issues with the .inspect.issues(...) method.")
         return output.issues
 
     def convert(self, target: Literal["dms"]) -> None:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,10 @@ Changes are grouped as follows:
 ### Added
 - Can configure `neat.to.cdf.data_model` behavior for data model components that already exist in CDF
 
+### Changed
+- When reading a data model from CDF, `inwards` edges are now treated as an edge with direction inwards and
+  not the reverse edge. 
+
 ## [0.96.1] - 04-11-**2024**
 ### Fixed
 - `naet.show` working in a pyodide environment

--- a/tests/data/windturbine.py
+++ b/tests/data/windturbine.py
@@ -178,7 +178,7 @@ INPUT_RULES = DMSInputRules(
             "MetMast",
             "windTurbines",
             "WindTurbine",
-            connection="reverse(property=metmasts)",
+            connection="edge(properties=Distance, type=distance, direction=inwards)",
             is_list=True,
         ),
         DMSInputProperty(

--- a/tests/tests_unit/rules/test_importers/test_dms_importer.py
+++ b/tests/tests_unit/rules/test_importers/test_dms_importer.py
@@ -109,7 +109,7 @@ class TestDMSImporter:
 
         dms_recreated = DMSExporter().export(rules)
 
-        assert dms_recreated.dump() == SCHEMA_INWARDS_EDGE_WITH_PROPERTIES.dump()
+        assert dms_recreated.views.dump() == SCHEMA_INWARDS_EDGE_WITH_PROPERTIES.views.dump()
 
 
 SCHEMA_WITH_DIRECT_RELATION_NONE = DMSSchema(
@@ -150,10 +150,11 @@ SCHEMA_INWARDS_EDGE_WITH_PROPERTIES = DMSSchema(
         space="neat",
         external_id="data_model",
         version="1",
+        description="Creator: MISSING",
         views=[
+            dm.ViewId("neat", "EdgeView", "1"),
             dm.ViewId("neat", "NodeView1", "1"),
             dm.ViewId("neat", "NodeView2", "1"),
-            dm.ViewId("neat", "EdgeView", "1"),
         ],
     ),
     spaces=SpaceApplyDict([dm.SpaceApply(space="neat")]),
@@ -163,11 +164,18 @@ SCHEMA_INWARDS_EDGE_WITH_PROPERTIES = DMSSchema(
                 space="neat",
                 external_id="NodeView1",
                 version="1",
+                filter=dm.filters.Equals(
+                    ["node", "type"],
+                    value={
+                        "space": "neat",
+                        "externalId": "NodeView1",
+                    },
+                ),
                 properties={
                     "to": dm.MultiEdgeConnectionApply(
                         type=dm.DirectRelationReference("neat", "myEdgeType"),
-                        source=dm.ViewId("neat", "NodeView2", "v1"),
-                        edge_source=dm.ViewId("neat", "EdgeView", "v1"),
+                        source=dm.ViewId("neat", "NodeView2", "1"),
+                        edge_source=dm.ViewId("neat", "EdgeView", "1"),
                         direction="inwards",
                     )
                 },
@@ -176,11 +184,18 @@ SCHEMA_INWARDS_EDGE_WITH_PROPERTIES = DMSSchema(
                 space="neat",
                 external_id="NodeView2",
                 version="1",
+                filter=dm.filters.Equals(
+                    ["node", "type"],
+                    value={
+                        "space": "neat",
+                        "externalId": "NodeView2",
+                    },
+                ),
                 properties={
                     "from": dm.MultiEdgeConnectionApply(
                         type=dm.DirectRelationReference("neat", "myEdgeType"),
-                        source=dm.ViewId("neat", "NodeView1", "v1"),
-                        edge_source=dm.ViewId("neat", "EdgeView", "v1"),
+                        source=dm.ViewId("neat", "NodeView1", "1"),
+                        edge_source=dm.ViewId("neat", "EdgeView", "1"),
                         direction="outwards",
                     )
                 },
@@ -189,6 +204,7 @@ SCHEMA_INWARDS_EDGE_WITH_PROPERTIES = DMSSchema(
                 space="neat",
                 external_id="EdgeView",
                 version="1",
+                filter=dm.filters.HasData(containers=[dm.ContainerId("neat", "container")]),
                 properties={
                     "distance": dm.MappedPropertyApply(
                         container=dm.ContainerId("neat", "container"),

--- a/tests/tests_unit/rules/test_importers/test_dms_importer.py
+++ b/tests/tests_unit/rules/test_importers/test_dms_importer.py
@@ -9,6 +9,7 @@ from cognite.neat._rules.exporters import DMSExporter
 from cognite.neat._rules.importers import DMSImporter, ExcelImporter
 from cognite.neat._rules.models import DMSRules, DMSSchema, RoleTypes
 from cognite.neat._rules.transformers import DMSToInformation, ImporterPipeline, VerifyDMSRules
+from cognite.neat._utils.cdf.data_classes import ContainerApplyDict, SpaceApplyDict, ViewApplyDict
 from tests.config import DOC_RULES
 from tests.data import windturbine
 
@@ -98,6 +99,18 @@ class TestDMSImporter:
             dms_recreated.containers[windturbine.DISTANCE_CONTAINER_ID].dump() == windturbine.DISTANCE_CONTAINER.dump()
         )
 
+    def test_import_export_schema_with_inwards_edge_with_properties(self) -> None:
+        importer = DMSImporter(SCHEMA_INWARDS_EDGE_WITH_PROPERTIES)
+
+        result = ImporterPipeline.try_verify(importer)
+        rules = cast(DMSRules, result.rules)
+        issues = result.issues
+        assert len(issues) == 0
+
+        dms_recreated = DMSExporter().export(rules)
+
+        assert dms_recreated.dump() == SCHEMA_INWARDS_EDGE_WITH_PROPERTIES.dump()
+
 
 SCHEMA_WITH_DIRECT_RELATION_NONE = DMSSchema(
     data_model=dm.DataModelApply(
@@ -131,4 +144,71 @@ SCHEMA_WITH_DIRECT_RELATION_NONE.views[dm.ViewId("neat", "OneView", "1")] = dm.V
             description="Direction Relation",
         )
     },
+)
+SCHEMA_INWARDS_EDGE_WITH_PROPERTIES = DMSSchema(
+    data_model=dm.DataModelApply(
+        space="neat",
+        external_id="data_model",
+        version="1",
+        views=[
+            dm.ViewId("neat", "NodeView1", "1"),
+            dm.ViewId("neat", "NodeView2", "1"),
+            dm.ViewId("neat", "EdgeView", "1"),
+        ],
+    ),
+    spaces=SpaceApplyDict([dm.SpaceApply(space="neat")]),
+    views=ViewApplyDict(
+        [
+            dm.ViewApply(
+                space="neat",
+                external_id="NodeView1",
+                version="1",
+                properties={
+                    "to": dm.MultiEdgeConnectionApply(
+                        type=dm.DirectRelationReference("neat", "myEdgeType"),
+                        source=dm.ViewId("neat", "NodeView2", "v1"),
+                        edge_source=dm.ViewId("neat", "EdgeView", "v1"),
+                        direction="inwards",
+                    )
+                },
+            ),
+            dm.ViewApply(
+                space="neat",
+                external_id="NodeView2",
+                version="1",
+                properties={
+                    "from": dm.MultiEdgeConnectionApply(
+                        type=dm.DirectRelationReference("neat", "myEdgeType"),
+                        source=dm.ViewId("neat", "NodeView1", "v1"),
+                        edge_source=dm.ViewId("neat", "EdgeView", "v1"),
+                        direction="outwards",
+                    )
+                },
+            ),
+            dm.ViewApply(
+                space="neat",
+                external_id="EdgeView",
+                version="1",
+                properties={
+                    "distance": dm.MappedPropertyApply(
+                        container=dm.ContainerId("neat", "container"),
+                        container_property_identifier="distance",
+                    )
+                },
+            ),
+        ]
+    ),
+    containers=ContainerApplyDict(
+        [
+            dm.ContainerApply(
+                space="neat",
+                external_id="container",
+                properties={
+                    "distance": dm.ContainerProperty(
+                        type=dm.data_types.Float64(),
+                    )
+                },
+            )
+        ]
+    ),
 )


### PR DESCRIPTION
- When reading a data model from CDF, `inwards` edges are now treated as an edge with direction inwards and
  not the reverse edge. 