### PR TITLE
[CDF-23143] 🐛 Issue serialization bug

### DIFF
--- a/cognite/neat/_issues/_base.py
+++ b/cognite/neat/_issues/_base.py
@@ -109,7 +109,11 @@ class NeatIssue:
     def dump(self) -> dict[str, Any]:
         """Return a dictionary representation of the issue."""
         variables = vars(self)
-        output = {to_camel(key): self._dump_value(value) for key, value in variables.items() if value is not None}
+        output = {
+            to_camel(key): self._dump_value(value)
+            for key, value in variables.items()
+            if not (value is None or key.startswith("_"))
+        }
         output["NeatIssue"] = type(self).__name__
         return output
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,11 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+### Fixed
+- Serializing `ResourceNotDefinedError` class no longer raises a `ValueError`. This happens when a `ResourceNotDefinedError`
+  is found, for example, when calling `neat.verify()`. 
+
 ## [0.96.4] - 05-11-**2024**
 ### Fixed
 - `neat.to.excel` or `neat.to.yaml` now correctly writes `ViewTypes` and `Edge` that do not have the default

--- a/tests/tests_unit/test_issues/test_issue_behavior.py
+++ b/tests/tests_unit/test_issues/test_issue_behavior.py
@@ -1,7 +1,9 @@
 import warnings
 
+from cognite.client import data_modeling as dm
+
 from cognite.neat._issues import IssueList
-from cognite.neat._issues.errors import ResourceCreationError
+from cognite.neat._issues.errors import ResourceCreationError, ResourceNotDefinedError
 from cognite.neat._issues.warnings import NeatValueWarning
 from cognite.neat._rules.transformers._verification import _catch_issues
 
@@ -26,3 +28,15 @@ class TestIssues:
             warnings.warn(my_warning, stacklevel=2)
 
         assert warning_list == IssueList([my_warning])
+
+    def test_dump_generic_specified(self) -> None:
+        my_issue = ResourceNotDefinedError[dm.ViewId](
+            identifier=dm.ViewId("neat", "SKUKpi", "v1"),
+            location="View Sheet",
+            row_number=66,
+            sheet_name="Properties",
+            resource_type="view",
+        )
+        dumped = my_issue.dump()
+
+        assert isinstance(dumped, dict)


### PR DESCRIPTION
## Trigger bug
```python
from cognite.neat import NeatSession
session = NeatSession(verbose=True)
session.read.excel("saputo_datamodel_v1.xlsx")
issues = session.verify()

print(issues.to_pandas())
```
leads to
![image](https://github.com/user-attachments/assets/d83d3630-e1ed-4067-90bc-23006448d533)

## Fix 
Don't attempt to serialize the type of the issue by skipping private variables.