### PR TITLE
[NEAT-545] 🤗 Regex user experience

### DIFF
--- a/cognite/neat/_issues/__init__.py
+++ b/cognite/neat/_issues/__init__.py
@@ -3,12 +3,14 @@ as some helper classes to handle them like NeatIssueList"""
 
 from ._base import (
     DefaultWarning,
+    FutureResult,
     IssueList,
     MultiValueError,
     NeatError,
     NeatIssue,
     NeatIssueList,
     NeatWarning,
+    catch_issues,
     catch_warnings,
 )
 
@@ -21,4 +23,6 @@ __all__ = [
     "IssueList",
     "MultiValueError",
     "catch_warnings",
+    "catch_issues",
+    "FutureResult",
 ]

--- a/cognite/neat/_issues/_base.py
+++ b/cognite/neat/_issues/_base.py
@@ -399,6 +399,10 @@ class NeatIssueList(list, Sequence[T_NeatIssue], ABC):
         """Return all the warnings in this list."""
         return type(self)([issue for issue in self if isinstance(issue, NeatWarning)])  # type: ignore[misc]
 
+    def has_error_type(self, error_type: type[NeatError]) -> bool:
+        """Return True if this list contains any errors of the given type."""
+        return any(isinstance(issue, error_type) for issue in self)
+
     def as_errors(self, operation: str = "Operation failed") -> ExceptionGroup:
         """Return an ExceptionGroup with all the errors in this list."""
         return ExceptionGroup(

--- a/cognite/neat/_issues/errors/_general.py
+++ b/cognite/neat/_issues/errors/_general.py
@@ -19,10 +19,12 @@ class NeatTypeError(NeatError, TypeError):
 
 @dataclass(unsafe_hash=True)
 class RegexViolationError(NeatError, ValueError):
-    """Value, {value} failed regex, {regex}, validation. Make sure that the name follows the regex pattern."""
+    """Value, {value} in {location} failed regex, {regex}, validation.
+    Make sure that the name follows the regex pattern."""
 
     value: str
     regex: str
+    location: str
 
 
 @dataclass(unsafe_hash=True)

--- a/cognite/neat/_session/_base.py
+++ b/cognite/neat/_session/_base.py
@@ -6,6 +6,7 @@ from cognite.client import data_modeling as dm
 
 from cognite.neat import _version
 from cognite.neat._issues import IssueList, catch_issues
+from cognite.neat._issues.errors import RegexViolationError
 from cognite.neat._rules import importers
 from cognite.neat._rules._shared import ReadRules, VerifiedRules
 from cognite.neat._rules.importers._rdf._base import DEFAULT_NON_EXISTING_NODE_TYPE
@@ -128,6 +129,9 @@ class NeatSession:
             print("Conversion failed.")
         if issues:
             print("You can inspect the issues with the .inspect.issues(...) method.")
+            if issues.has_error_type(RegexViolationError):
+                print("You can use .prepare. to try to fix the issues")
+
         return issues
 
     def infer(

--- a/tests/tests_unit/test_issues/test_issue_behavior.py
+++ b/tests/tests_unit/test_issues/test_issue_behavior.py
@@ -5,7 +5,7 @@ from cognite.client import data_modeling as dm
 from cognite.neat._issues import IssueList
 from cognite.neat._issues.errors import ResourceCreationError, ResourceNotDefinedError
 from cognite.neat._issues.warnings import NeatValueWarning
-from cognite.neat._rules.transformers._verification import _catch_issues
+from cognite.neat._rules.transformers._verification import catch_issues
 
 
 class TestIssues:
@@ -14,7 +14,7 @@ class TestIssues:
         my_error = ResourceCreationError(identifier="missing", resource_type="space", error="No CDF Connection")
 
         errors = IssueList()
-        with _catch_issues(issues=errors):
+        with catch_issues(issues=errors):
             raise my_error
 
         assert errors == IssueList([my_error])
@@ -24,7 +24,7 @@ class TestIssues:
         my_warning = NeatValueWarning("This is a warning")
 
         warning_list = IssueList()
-        with _catch_issues(issues=warning_list):
+        with catch_issues(issues=warning_list):
             warnings.warn(my_warning, stacklevel=2)
 
         assert warning_list == IssueList([my_warning])


### PR DESCRIPTION
This was caused by 2 things. 

1. We we not catching issues in `.conversion(...)`. This can happen when you have values that do not comply with DMS.
2. The `RegexError` lacked location making it hard to read.

### Before
![image](https://github.com/user-attachments/assets/9beffe42-d6de-44db-a69e-e06f1d95f05f)

### After
![image](https://github.com/user-attachments/assets/a1e6d398-6038-4c06-be08-1f86d11e8bc6)
