### PR TITLE
[NEAT-587] 😏 Fix skip drop to views

### DIFF
--- a/cognite/neat/_rules/exporters/_rules2dms.py
+++ b/cognite/neat/_rules/exporters/_rules2dms.py
@@ -41,6 +41,7 @@ class DMSExporter(CDFExporter[DMSRules, DMSSchema]):
             Defaults to "update". See below for details.
         instance_space (str, optional): The space to use for the instance. Defaults to None.
         suppress_warnings (bool, optional): Suppress warnings. Defaults to False.
+        remove_cdf_spaces (bool, optional): Skip views and containers that are system are in system spaces.
 
     ... note::
 
@@ -58,6 +59,7 @@ class DMSExporter(CDFExporter[DMSRules, DMSSchema]):
         existing_handling: Literal["fail", "skip", "update", "force"] = "update",
         instance_space: str | None = None,
         suppress_warnings: bool = False,
+        remove_cdf_spaces: bool = True,
     ):
         self.export_components = {export_components} if isinstance(export_components, str) else set(export_components)
         self.include_space = include_space
@@ -65,6 +67,7 @@ class DMSExporter(CDFExporter[DMSRules, DMSSchema]):
         self.instance_space = instance_space
         self.suppress_warnings = suppress_warnings
         self._schema: DMSSchema | None = None
+        self.remove_cdf_spaces = remove_cdf_spaces
 
     def export_to_file(self, rules: DMSRules, filepath: Path) -> None:
         """Export the rules to a file(s).
@@ -103,7 +106,7 @@ class DMSExporter(CDFExporter[DMSRules, DMSSchema]):
 
     def export(self, rules: DMSRules) -> DMSSchema:
         # We do not want to include CogniteCore/CogniteProcess Inudstries in the schema
-        return rules.as_schema(instance_space=self.instance_space, remove_cdf_spaces=True)
+        return rules.as_schema(instance_space=self.instance_space, remove_cdf_spaces=self.remove_cdf_spaces)
 
     def delete_from_cdf(
         self, rules: DMSRules, client: NeatClient, dry_run: bool = False, skip_space: bool = False

--- a/cognite/neat/_session/_to.py
+++ b/cognite/neat/_session/_to.py
@@ -51,7 +51,24 @@ class ToAPI:
     @overload
     def yaml(self, io: Any, format: Literal["neat", "toolkit"] = "neat") -> None: ...
 
-    def yaml(self, io: Any | None = None, format: Literal["neat", "toolkit"] = "neat") -> str | None:
+    def yaml(
+        self, io: Any | None = None, format: Literal["neat", "toolkit"] = "neat", skip_system_spaces: bool = True
+    ) -> str | None:
+        """Export the verified data model to YAML.
+
+        Args:
+            io: The file path or file-like object to write the YAML file to. Defaults to None.
+            format: The format of the YAML file. Defaults to "neat".
+            skip_system_spaces: If True, system spaces will be skipped. Defaults to True.
+
+        ... note::
+
+            - "neat": This is the format Neat uses to store the data model.
+            - "toolkit": This is the format used by Cognite Toolkit, that matches the CDF API.
+
+        Returns:
+            str | None: If io is None, the YAML string will be returned. Otherwise, None will be returned.
+        """
         if format == "neat":
             exporter = exporters.YAMLExporter()
             last_verified = self._state.data_model.last_verified_rule[1]
@@ -69,7 +86,7 @@ class ToAPI:
             user_path = Path(io)
             if user_path.suffix == "" and not user_path.exists():
                 user_path.mkdir(parents=True)
-            exporters.DMSExporter().export_to_file(dms_rule, user_path)
+            exporters.DMSExporter(remove_cdf_spaces=skip_system_spaces).export_to_file(dms_rule, user_path)
         else:
             raise NeatSessionError("Please provide a valid format. 'neat' or 'toolkit'")
 

--- a/tests/tests_unit/test_session/test_to_yaml.py
+++ b/tests/tests_unit/test_session/test_to_yaml.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from rdflib import URIRef
+
+from cognite.neat import NeatSession
+from cognite.neat._issues import IssueList
+from cognite.neat._rules._shared import ReadRules
+from tests.data.windturbine import INPUT_RULES
+
+
+class TestToYaml:
+    def test_to_yaml(self, tmp_path: Path) -> None:
+        neat = NeatSession()
+        # Hack to read in model.
+        neat._state.data_model._rules[URIRef("https://my_model")] = ReadRules(INPUT_RULES, IssueList(), {})
+
+        neat.verify()
+        neat.to.yaml(tmp_path, format="toolkit")
+
+        files = list(tmp_path.rglob("*.yaml"))
+        assert len(files) == 9


### PR DESCRIPTION
This is not really ay bug. What happen is that when we stopped writing the Core model to cdf in `neat.to.cdf.data_model()` we stop exporting it in all other methods as well. It is better to have this explicitly set as a flag as it is clearer that we skip the core views + containers. And there are use cases when you want to dump these, to inspect them.