### PR TITLE
[NEAT-684] 🤗 Remove annoyance

### DIFF
--- a/cognite/neat/_session/_base.py
+++ b/cognite/neat/_session/_base.py
@@ -2,7 +2,6 @@ from typing import Literal
 
 from cognite.client import CogniteClient
 from cognite.client import data_modeling as dm
-from cognite.client.config import global_config
 
 from cognite.neat import _version
 from cognite.neat._client import NeatClient
@@ -75,7 +74,6 @@ class NeatSession:
         verbose: bool = True,
         load_engine: Literal["newest", "cache", "skip"] = "cache",
     ) -> None:
-        global_config.disable_pypi_version_check = True
         self._verbose = verbose
         self._state = SessionState(store_type=storage, client=NeatClient(client) if client else None)
         self.read = ReadAPI(self._state, verbose)

--- a/cognite/neat/_session/_base.py
+++ b/cognite/neat/_session/_base.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from cognite.client import CogniteClient
 from cognite.client import data_modeling as dm
+from cognite.client.config import global_config
 
 from cognite.neat import _version
 from cognite.neat._client import NeatClient
@@ -74,6 +75,7 @@ class NeatSession:
         verbose: bool = True,
         load_engine: Literal["newest", "cache", "skip"] = "cache",
     ) -> None:
+        global_config.disable_pypi_version_check = True
         self._verbose = verbose
         self._state = SessionState(store_type=storage, client=NeatClient(client) if client else None)
         self.read = ReadAPI(self._state, verbose)

--- a/cognite/neat/_session/_read.py
+++ b/cognite/neat/_session/_read.py
@@ -396,7 +396,6 @@ class RDFExamples:
     def __init__(self, state: SessionState) -> None:
         self._state = state
 
-    @property
     def nordic44(self) -> IssueList:
         """Reads the Nordic 44 knowledge graph into the NeatSession graph store."""
         self._state.instances.store.write(extractors.RdfFileExtractor(instances_examples.nordic44_knowledge_graph))

--- a/cognite/neat/_session/exceptions.py
+++ b/cognite/neat/_session/exceptions.py
@@ -2,7 +2,7 @@ import functools
 from collections.abc import Callable
 from typing import Any
 
-from cognite.neat._issues.errors import CDFMissingClientError
+from cognite.neat._issues.errors import CDFMissingClientError, NeatImportError
 
 from ._collector import _COLLECTOR
 
@@ -29,7 +29,7 @@ def _session_method_wrapper(func: Callable, cls_name: str):
         except NeatSessionError as e:
             action = _get_action()
             print(f"{_PREFIX} Cannot {action}: {e}")
-        except CDFMissingClientError as e:
+        except (CDFMissingClientError, NeatImportError) as e:
             print(f"{_PREFIX} {e.as_message()}")
         except ModuleNotFoundError as e:
             if e.name == "neatengine":

--- a/cognite/neat/_session/exceptions.py
+++ b/cognite/neat/_session/exceptions.py
@@ -8,10 +8,14 @@ from ._collector import _COLLECTOR
 
 try:
     from rich import print
+    from rich.markup import escape
 
     _PREFIX = "[bold red][ERROR][/bold red]"
 except ImportError:
     _PREFIX = "[ERROR]"
+
+    def escape(x: Any, *_: Any, **__: Any) -> Any:  # type: ignore[misc]
+        return x
 
 
 class NeatSessionError(Exception):
@@ -30,7 +34,7 @@ def _session_method_wrapper(func: Callable, cls_name: str):
             action = _get_action()
             print(f"{_PREFIX} Cannot {action}: {e}")
         except (CDFMissingClientError, NeatImportError) as e:
-            print(f"{_PREFIX} {e.as_message()}")
+            print(f"{_PREFIX} {escape(e.as_message())}")
         except ModuleNotFoundError as e:
             if e.name == "neatengine":
                 action = _get_action()

--- a/cognite/neat/_utils/auth.py
+++ b/cognite/neat/_utils/auth.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Literal, TypeAlias, get_args
 
 from cognite.client import ClientConfig, CogniteClient
+from cognite.client.config import global_config
 from cognite.client.credentials import CredentialProvider, OAuthClientCredentials, OAuthInteractive, Token
 
 from cognite.neat import _version
@@ -33,6 +34,7 @@ def get_cognite_client(env_file_name: str) -> CogniteClient:
     """
     if not env_file_name.endswith(".env"):
         raise ValueError("env_file_name must end with '.env'")
+    global_config.disable_pypi_version_check = True
     # First try to load from .env file in repository root
     repo_root = _repo_root()
     if repo_root:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,9 @@ Changes are grouped as follows:
 ### Fixed
 - The `neat.prepare.instances.relationships_as_edges()` no longer creates invalid identifiers for the edges.
 
+### Improved
+- Better error message if `NeatSession(..., storage="oxigraph")` and the `oxigraph` package is not installed.
+
 ## [0.106.0] - 09-01-**2025**
 ### Added
 - Method for setting session client, `neat.set.client(...)`.

--- a/docs/tutorials/data-onboarding/nordic44_onboarding.ipynb
+++ b/docs/tutorials/data-onboarding/nordic44_onboarding.ipynb
@@ -90,7 +90,7 @@
     }
    ],
    "source": [
-    "neat.read.rdf.examples.nordic44"
+    "neat.read.rdf.examples.nordic44()"
    ]
   },
   {


### PR DESCRIPTION
## Disable pypi check

### Before
![image](https://github.com/user-attachments/assets/aa25abf8-207a-4737-8419-52425a4d4d10)

### After
![image](https://github.com/user-attachments/assets/76fbf7c2-aab8-4756-b657-f77b82f37ece)

**Note**: The user should not care about which version of the PySDK they are using. We always have a lower bound that enables all the functionality we need in neat.

## Missing Oxigraph

### Before
![image](https://github.com/user-attachments/assets/a8a1955d-407c-468b-a565-c5aed376aa5b)

### After
![image](https://github.com/user-attachments/assets/c336fa32-8353-4cae-bca4-c02ffb312592)


**Open Question**: I made the `nordic44` a method instead of property. This is for consistency with other methods, but it is up for discussion. Note that the session wrapper that deals with errors do not handle properties.