### PR TITLE
[NEAT-672] 🤔 Not skip externalId in inference importer

### DIFF
--- a/cognite/neat/_issues/warnings/__init__.py
+++ b/cognite/neat/_issues/warnings/__init__.py
@@ -31,7 +31,6 @@ from ._properties import (
     PropertyDirectRelationLimitWarning,
     PropertyNotFoundWarning,
     PropertyOverwritingWarning,
-    PropertySkippedWarning,
     PropertyTypeNotSupportedWarning,
     PropertyValueTypeUndefinedWarning,
 )
@@ -68,7 +67,6 @@ __all__ = [
     "PropertyDirectRelationLimitWarning",
     "PropertyNotFoundWarning",
     "PropertyOverwritingWarning",
-    "PropertySkippedWarning",
     "PropertyTypeNotSupportedWarning",
     "PropertyValueTypeUndefinedWarning",
     "RegexViolationWarning",

--- a/cognite/neat/_issues/warnings/_properties.py
+++ b/cognite/neat/_issues/warnings/_properties.py
@@ -66,14 +66,6 @@ class PropertyOverwritingWarning(PropertyWarning[T_Identifier]):
 
 
 @dataclass(unsafe_hash=True)
-class PropertySkippedWarning(PropertyWarning[T_Identifier]):
-    """The {resource_type} with identifier {identifier} has a property {property_name}
-    which is skipped. {reason}."""
-
-    reason: str
-
-
-@dataclass(unsafe_hash=True)
 class PropertyDataTypeConversionWarning(PropertyWarning[T_Identifier]):
     """The {resource_type} with identifier {identifier} failed to convert the property {property_name}: {error}"""
 

--- a/cognite/neat/_rules/importers/_rdf/_inference2rules.py
+++ b/cognite/neat/_rules/importers/_rdf/_inference2rules.py
@@ -8,7 +8,7 @@ from cognite.client import data_modeling as dm
 from rdflib import RDF, Namespace, URIRef
 from rdflib import Literal as RdfLiteral
 
-from cognite.neat._issues.warnings import PropertySkippedWarning, PropertyValueTypeUndefinedWarning
+from cognite.neat._issues.warnings import PropertyValueTypeUndefinedWarning
 from cognite.neat._rules.models import data_types
 from cognite.neat._rules.models.data_types import AnyURI
 from cognite.neat._rules.models.entities._single_value import UnknownEntity
@@ -190,18 +190,6 @@ class InferenceImporter(BaseRDFImporter):
                     if property_uri == RDF.type:
                         continue
                     property_id = remove_namespace_from_uri(property_uri)
-                    if property_id in {"external_id", "externalId"}:
-                        skip_issue = PropertySkippedWarning(
-                            resource_type="Property",
-                            identifier=f"{class_id}:{property_id}",
-                            property_name=property_id,
-                            reason="External ID is assumed to be the unique identifier of the instance "
-                            "and is not part of the data model schema.",
-                        )
-                        if skip_issue not in self.issue_list:
-                            self.issue_list.append(skip_issue)
-                        continue
-
                     self._add_uri_namespace_to_prefixes(cast(URIRef, property_uri), prefixes)
 
                     if isinstance(data_type_uri, URIRef):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,9 @@ Changes are grouped as follows:
 ### Added
 - Support RDF Datasets in NeatGraphStore enabling writing of sources triples to dedicated named graphs
 
+### Improved
+- The `neat.infer()` no longer skips `externalId`/`external_id` properties when inferring the data model.
+
 ## [0.107.0] - 15-01-**2025**
 ### Fixed
 - The `neat.prepare.instances.relationships_as_edges()` no longer creates invalid identifiers for the edges.

--- a/tests/tests_unit/graph/test_loaders/test_dms_loader.py
+++ b/tests/tests_unit/graph/test_loaders/test_dms_loader.py
@@ -23,6 +23,11 @@ def test_metadata_as_json_filed():
     importer = InferenceImporter.from_graph_store(store)
 
     info_rules = importer.to_rules().rules.as_verified_rules()
+    # Need to change externalId as it is not allowed in DMS
+    for prop in info_rules.properties:
+        if prop.property_ == "externalId":
+            prop.property_ = "classicExternalId"
+
     dms_rules = InformationToDMS().transform(info_rules)
 
     # simulating update of the DMS rules

--- a/tests/tests_unit/rules/test_importers/test_inference_importer.py
+++ b/tests/tests_unit/rules/test_importers/test_inference_importer.py
@@ -103,7 +103,7 @@ def test_json_value_type_inference():
 
     properties = {prop.property_: prop for prop in rules.properties}
 
-    assert len(rules.properties) == 8
+    assert len(rules.properties) == 9
     assert len(rules.classes) == 1
 
     assert isinstance(properties["metadata"].value_type, Json)


### PR DESCRIPTION
It was a mistake to drop this one. It can for example be used in the information rules to set an alternative ID, similarly to have we now do for edges start and end node.