### PR TITLE
Dm prepare steps on verified rules

### DIFF
--- a/cognite/neat/_graph/loaders/_rdf2dms.py
+++ b/cognite/neat/_graph/loaders/_rdf2dms.py
@@ -168,6 +168,7 @@ class DMSLoader(CDFLoader[dm.InstanceApply]):
                 # If the views have a dependency on themselves, we need to run it twice.
                 view_ids.append(f"{view_id!r} (self)")
 
+        print(view_and_count_by_id)
         tracker = self._tracker(type(self).__name__, view_ids, "views")
         for view_id, (view, instance_count) in view_and_count_by_id.items():
             pydantic_cls, edge_by_type, edge_by_prop_id, issues = self._create_validation_classes(view)  # type: ignore[var-annotated]

--- a/cognite/neat/_graph/loaders/_rdf2dms.py
+++ b/cognite/neat/_graph/loaders/_rdf2dms.py
@@ -168,7 +168,6 @@ class DMSLoader(CDFLoader[dm.InstanceApply]):
                 # If the views have a dependency on themselves, we need to run it twice.
                 view_ids.append(f"{view_id!r} (self)")
 
-        print(view_and_count_by_id)
         tracker = self._tracker(type(self).__name__, view_ids, "views")
         for view_id, (view, instance_count) in view_and_count_by_id.items():
             pydantic_cls, edge_by_type, edge_by_prop_id, issues = self._create_validation_classes(view)  # type: ignore[var-annotated]

--- a/cognite/neat/_issues/warnings/_resources.py
+++ b/cognite/neat/_issues/warnings/_resources.py
@@ -21,7 +21,7 @@ class ResourceRegexViolationWarning(ResourceNeatWarning):
 
     fix = (
         "Either export the data model and make the necessary changes manually"
-        " or run prepare.data_model.cdf_compliant_external_ids."
+        " or run fix.data_model.cdf_compliant_external_ids."
     )
 
     location: str

--- a/cognite/neat/_rules/transformers/_converters.py
+++ b/cognite/neat/_rules/transformers/_converters.py
@@ -60,8 +60,6 @@ from cognite.neat._rules.models.entities import (
 )
 from cognite.neat._rules.models.information import InformationClass, InformationMetadata, InformationProperty
 from cognite.neat._rules.models.information._rules_input import (
-    InformationInputClass,
-    InformationInputProperty,
     InformationInputRules,
 )
 from cognite.neat._utils.text import to_camel
@@ -81,7 +79,7 @@ class ConversionTransformer(RulesTransformer[T_VerifiedInRules, T_VerifiedOutRul
     ...
 
 
-class ToCompliantEntities(RulesTransformer[ReadRules[InformationInputRules], ReadRules[InformationInputRules]]):  # type: ignore[misc]
+class ToCompliantEntities(RulesTransformer[InformationRules, InformationRules]):  # type: ignore[misc]
     """Converts input rules to rules with compliant entity IDs that match regex patters used
     by DMS schema components."""
 
@@ -89,13 +87,11 @@ class ToCompliantEntities(RulesTransformer[ReadRules[InformationInputRules], Rea
     def description(self) -> str:
         return "Ensures externalIDs are compliant with CDF"
 
-    def transform(self, rules: ReadRules[InformationInputRules]) -> ReadRules[InformationInputRules]:
-        if rules.rules is None:
-            return rules
-        copy: InformationInputRules = dataclasses.replace(rules.rules)
+    def transform(self, rules: InformationRules) -> InformationRules:
+        copy: InformationRules = rules.model_copy(deep=True)
         copy.classes = self._fix_classes(copy.classes)
         copy.properties = self._fix_properties(copy.properties)
-        return ReadRules(copy, rules.read_context)
+        return copy
 
     @classmethod
     def _fix_entity(cls, entity: str) -> str:
@@ -112,16 +108,8 @@ class ToCompliantEntities(RulesTransformer[ReadRules[InformationInputRules], Rea
         return re.sub(r"[^a-zA-Z0-9]+", "_", entity)
 
     @classmethod
-    def _fix_class(cls, class_: str | ClassEntity) -> str | ClassEntity:
-        if isinstance(class_, str):
-            if len(class_.split(":")) == 2:
-                prefix, suffix = class_.split(":")
-                class_ = f"{cls._fix_entity(prefix)}:{cls._fix_entity(suffix)}"
-
-            else:
-                class_ = cls._fix_entity(class_)
-
-        elif isinstance(class_, ClassEntity) and type(class_.prefix) is str:
+    def _fix_class(cls, class_: ClassEntity) -> ClassEntity:
+        if isinstance(class_, ClassEntity) and type(class_.prefix) is str:
             class_ = ClassEntity(
                 prefix=cls._fix_entity(class_.prefix),
                 suffix=cls._fix_entity(class_.suffix),
@@ -131,28 +119,17 @@ class ToCompliantEntities(RulesTransformer[ReadRules[InformationInputRules], Rea
 
     @classmethod
     def _fix_value_type(
-        cls, value_type: str | DataType | ClassEntity | MultiValueTypeInfo
-    ) -> str | DataType | ClassEntity | MultiValueTypeInfo:
-        fixed_value_type: str | DataType | ClassEntity | MultiValueTypeInfo
+        cls, value_type: DataType | ClassEntity | MultiValueTypeInfo
+    ) -> DataType | ClassEntity | MultiValueTypeInfo:
+        fixed_value_type: DataType | ClassEntity | MultiValueTypeInfo
 
-        if isinstance(value_type, str):
-            # this is a multi value type but as string
-            if " | " in value_type:
-                value_types = value_type.split(" | ")
-                fixed_value_type = " | ".join([cast(str, cls._fix_value_type(v)) for v in value_types])
-            # this is value type specified with prefix:suffix string
-            elif ":" in value_type:
-                fixed_value_type = cls._fix_class(value_type)
-
-            # this is value type specified as suffix only
-            else:
-                fixed_value_type = cls._fix_entity(value_type)
-
-        # value type specified as instances of DataType, ClassEntity or MultiValueTypeInfo
-        elif isinstance(value_type, MultiValueTypeInfo):
+        # value type specified as MultiValueTypeInfo
+        if isinstance(value_type, MultiValueTypeInfo):
             fixed_value_type = MultiValueTypeInfo(
                 types=[cast(DataType | ClassEntity, cls._fix_value_type(type_)) for type_ in value_type.types],
             )
+
+        # value type specified as ClassEntity instance
         elif isinstance(value_type, ClassEntity):
             fixed_value_type = cls._fix_class(value_type)
 
@@ -163,16 +140,16 @@ class ToCompliantEntities(RulesTransformer[ReadRules[InformationInputRules], Rea
         return fixed_value_type
 
     @classmethod
-    def _fix_classes(cls, definitions: list[InformationInputClass]) -> list[InformationInputClass]:
-        fixed_definitions = []
+    def _fix_classes(cls, definitions: SheetList[InformationClass]) -> SheetList[InformationClass]:
+        fixed_definitions = SheetList[InformationClass]()
         for definition in definitions:
             definition.class_ = cls._fix_class(definition.class_)
             fixed_definitions.append(definition)
         return fixed_definitions
 
     @classmethod
-    def _fix_properties(cls, definitions: list[InformationInputProperty]) -> list[InformationInputProperty]:
-        fixed_definitions = []
+    def _fix_properties(cls, definitions: SheetList[InformationProperty]) -> SheetList[InformationProperty]:
+        fixed_definitions = SheetList[InformationProperty]()
         for definition in definitions:
             definition.class_ = cls._fix_class(definition.class_)
             definition.property_ = cls._fix_entity(definition.property_)

--- a/cognite/neat/_rules/transformers/_converters.py
+++ b/cognite/neat/_rules/transformers/_converters.py
@@ -88,7 +88,7 @@ class ToCompliantEntities(RulesTransformer[InformationRules, InformationRules]):
         return "Ensures externalIDs are compliant with CDF"
 
     def transform(self, rules: InformationRules) -> InformationRules:
-        copy: InformationRules = rules.model_copy(deep=True)
+        copy = rules.model_copy(deep=True)
         copy.classes = self._fix_classes(copy.classes)
         copy.properties = self._fix_properties(copy.properties)
         return copy

--- a/cognite/neat/_session/_base.py
+++ b/cognite/neat/_session/_base.py
@@ -25,6 +25,7 @@ from cognite.neat._utils.auxiliary import local_import
 
 from ._collector import _COLLECTOR, Collector
 from ._drop import DropAPI
+from ._fix import FixAPI
 from ._inspect import InspectAPI
 from ._mapping import MappingAPI
 from ._prepare import PrepareAPI
@@ -91,6 +92,7 @@ class NeatSession:
         )
         self.read = ReadAPI(self._state, verbose)
         self.to = ToAPI(self._state, verbose)
+        self.fix = FixAPI(self._state, verbose)
         self.prepare = PrepareAPI(self._state, verbose)
         self.show = ShowAPI(self._state)
         self.set = SetAPI(self._state, verbose)

--- a/cognite/neat/_session/_fix.py
+++ b/cognite/neat/_session/_fix.py
@@ -1,0 +1,28 @@
+from cognite.neat._issues._base import IssueList
+from cognite.neat._rules.transformers import (
+    ToCompliantEntities,
+)
+
+from ._state import SessionState
+from .exceptions import session_class_wrapper
+
+
+@session_class_wrapper
+class FixAPI:
+    """Apply variety of fix methods to data model and isntances"""
+
+    def __init__(self, state: SessionState, verbose: bool) -> None:
+        self._state = state
+        self._verbose = verbose
+        self.data_model = DataModelFixAPI(state, verbose)
+
+
+@session_class_wrapper
+class DataModelFixAPI:
+    def __init__(self, state: SessionState, verbose: bool) -> None:
+        self._state = state
+        self._verbose = verbose
+
+    def cdf_compliant_external_ids(self) -> IssueList:
+        """Convert (information/logical) data model component external ids to CDF compliant entities."""
+        return self._state.rule_transform(ToCompliantEntities())

--- a/cognite/neat/_session/_prepare.py
+++ b/cognite/neat/_session/_prepare.py
@@ -19,7 +19,6 @@ from cognite.neat._rules.transformers import (
     PrefixEntities,
     ReduceCogniteModel,
     RulesTransformer,
-    ToCompliantEntities,
     ToDataProductModel,
     ToEnterpriseModel,
     ToSolutionModel,
@@ -263,10 +262,6 @@ class DataModelPrepareAPI:
     def __init__(self, state: SessionState, verbose: bool) -> None:
         self._state = state
         self._verbose = verbose
-
-    def cdf_compliant_external_ids(self) -> IssueList:
-        """Convert data model component external ids to CDF compliant entities."""
-        return self._state.rule_transform(ToCompliantEntities())
 
     def prefix(self, prefix: str) -> IssueList:
         """Prefix all views in the data model with the given prefix.

--- a/cognite/neat/_session/_state.py
+++ b/cognite/neat/_session/_state.py
@@ -6,7 +6,11 @@ from cognite.neat._graph.extractors import KnowledgeGraphExtractor
 from cognite.neat._issues import IssueList
 from cognite.neat._rules.importers import BaseImporter, InferenceImporter
 from cognite.neat._rules.models import DMSRules, InformationRules
-from cognite.neat._rules.transformers import RulesTransformer, ToExtensionModel
+from cognite.neat._rules.transformers import (
+    RulesTransformer,
+    ToCompliantEntities,
+    ToExtensionModel,
+)
 from cognite.neat._store import NeatGraphStore, NeatRulesStore
 from cognite.neat._store._rules_store import ModelEntity
 from cognite.neat._utils.rdf_ import uri_display_name
@@ -53,6 +57,15 @@ class SessionState:
         end = cast(ModelEntity, self.rule_store.provenance[-1].target_entity).display_name
         issues.action = f"{start} &#8594; {end}"
         issues.hint = "Use the .inspect.issues() for more details."
+
+        # Make sure to attach the latest information rules to the instances store
+        if (
+            any(isinstance(t, ToCompliantEntities) for t in transformer)
+            and isinstance(self.rule_store.provenance[-1].target_entity, ModelEntity)
+            and isinstance(self.rule_store.provenance[-1].target_entity.result, InformationRules)
+        ):
+            self.instances.store.add_rules(self.rule_store.provenance[-1].target_entity.result)
+
         return issues
 
     def rule_import(self, importer: BaseImporter) -> IssueList:

--- a/cognite/neat/_session/_to.py
+++ b/cognite/neat/_session/_to.py
@@ -4,7 +4,7 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import Any, Literal, overload
 
-from cognite.client.data_classes.data_modeling import SpaceApply
+from cognite.client import data_modeling as dm
 
 from cognite.neat._constants import COGNITE_MODELS
 from cognite.neat._graph import loaders
@@ -194,7 +194,10 @@ class CDFToAPI:
         self._state = state
         self._verbose = verbose
 
-    def instances(self, space: str | None = None) -> UploadResultList:
+    def instances(
+        self,
+        space: str | None = None,
+    ) -> UploadResultList:
         """Export the verified DMS instances to CDF.
 
         Args:
@@ -213,7 +216,7 @@ class CDFToAPI:
             raise NeatSessionError("Please provide a valid space name. {PATTERNS.space_compliance.pattern}")
 
         if not client.data_modeling.spaces.retrieve(space):
-            client.data_modeling.spaces.apply(SpaceApply(space=space))
+            client.data_modeling.spaces.apply(dm.SpaceApply(space=space))
 
         loader = loaders.DMSLoader.from_rules(
             self._state.rule_store.last_verified_dms_rules,
@@ -224,6 +227,7 @@ class CDFToAPI:
             # urllib.parse.unquote() on the load.
             unquote_external_ids=self._state.quoted_source_identifiers,
         )
+
         result = loader.load_into_cdf(client)
         self._state.instances.outcome.append(result)
         print("You can inspect the details with the .inspect.outcome.instances(...) method.")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,12 +19,15 @@ Changes are grouped as follows:
 ## TBD
 ### Improved
 - AML and DEXPI reader for neat session automatically perform extraction and transformation
+- [BREAKING] NeatSession.prepare.data_model.cdf_compliant_external_ids is moved under NeatSession.fix.data_model.cdf_compliant_external_ids
+- [BREAKING] `cdf_compliant_external_ids` expects validated InformationRules as added
 
 ### Removed
 - [BREAKING] NeatSession.prepare.dexpi and NeatSession.prepare.aml methods are removed. Use NeatSession.read.rdf.dexpi and NeatSession.read.rdf.aml instead.
 
 ### Fixed
 - Fixed issue with not correctly set of max count when inferring properties which value type are multi type
+
 
 ## [0.108.0] - 22-01-**2025**
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ Changes are grouped as follows:
 ### Improved
 - AML and DEXPI reader for neat session automatically perform extraction and transformation
 - [BREAKING] NeatSession.prepare.data_model.cdf_compliant_external_ids is moved under NeatSession.fix.data_model.cdf_compliant_external_ids
-- [BREAKING] `cdf_compliant_external_ids` expects validated InformationRules as added
+- [BREAKING] `cdf_compliant_external_ids` expects validated InformationRules as input instead of InformationInputRules
 
 ### Removed
 - [BREAKING] NeatSession.prepare.dexpi and NeatSession.prepare.aml methods are removed. Use NeatSession.read.rdf.dexpi and NeatSession.read.rdf.aml instead.

--- a/tests/tests_unit/rules/test_models/test_information_rules.py
+++ b/tests/tests_unit/rules/test_models/test_information_rules.py
@@ -27,6 +27,7 @@ from cognite.neat._rules.transformers._converters import (
     ToCompliantEntities,
     _InformationRulesConverter,
 )
+from cognite.neat._rules.transformers._verification import VerifyAnyRules
 
 
 def case_insensitive_value_types():
@@ -398,10 +399,13 @@ class TestInformationConverter:
         self,
         rules_dict: dict[str, dict[str, Any]],
     ) -> None:
-        input_rules = InformationInputRules.load(rules_dict)
+        input_rules = ReadRules(rules=InformationInputRules.load(rules_dict), read_context={})
+        transformer = VerifyAnyRules(validate=True)
+        rules = transformer.transform(input_rules)
 
-        rules = ToCompliantEntities().transform(ReadRules(input_rules, {})).rules.as_verified_rules()
+        rules = ToCompliantEntities().transform(rules)
 
         assert rules.classes[0].class_.prefix == "power_or_not"
+        assert rules.classes[0].class_.suffix == "Generating_Unit"
         assert rules.properties[0].property_ == "IdentifiedObject_name"
-        assert rules.properties[0].value_type == data_types.String()
+        assert rules.properties[0].class_.suffix == "Generating_Unit"


### PR DESCRIPTION
### Improved
- [BREAKING] NeatSession.prepare.data_model.cdf_compliant_external_ids is moved under NeatSession.fix.data_model.cdf_compliant_external_ids
- [BREAKING] `cdf_compliant_external_ids` expects validated InformationRules as its input instead of InputRules
