### PR TITLE
[NEAT-720, NEAT-722] 👫Information + DMS = True

### DIFF
--- a/cognite/neat/_rules/transformers/__init__.py
+++ b/cognite/neat/_rules/transformers/__init__.py
@@ -1,4 +1,4 @@
-from ._base import RulesTransformer
+from ._base import RulesTransformer, VerifiedRulesTransformer
 from ._converters import (
     AddClassImplements,
     ChangeViewPrefix,
@@ -48,4 +48,5 @@ __all__ = [
     "VerifyAnyRules",
     "VerifyDMSRules",
     "VerifyInformationRules",
+    "VerifiedRulesTransformer",
 ]

--- a/cognite/neat/_rules/transformers/__init__.py
+++ b/cognite/neat/_rules/transformers/__init__.py
@@ -45,8 +45,8 @@ __all__ = [
     "ToEnterpriseModel",
     "ToExtensionModel",
     "ToSolutionModel",
+    "VerifiedRulesTransformer",
     "VerifyAnyRules",
     "VerifyDMSRules",
     "VerifyInformationRules",
-    "VerifiedRulesTransformer",
 ]

--- a/cognite/neat/_rules/transformers/_base.py
+++ b/cognite/neat/_rules/transformers/_base.py
@@ -5,13 +5,14 @@ from types import UnionType
 from typing import Generic, TypeVar, Union, get_args, get_origin
 
 from cognite.neat._constants import DEFAULT_NAMESPACE
-from cognite.neat._rules._shared import ReadRules, Rules
+from cognite.neat._rules._shared import ReadRules, Rules, VerifiedRules
 from cognite.neat._rules.models import DMSInputRules, InformationInputRules
 from cognite.neat._store._provenance import Agent as ProvenanceAgent
 
 T_RulesIn = TypeVar("T_RulesIn", bound=Rules)
 T_RulesOut = TypeVar("T_RulesOut", bound=Rules)
-
+T_VerifiedIn = TypeVar("T_VerifiedIn", bound=VerifiedRules)
+T_VerifiedOut = TypeVar("T_VerifiedOut", bound=VerifiedRules)
 
 class RulesTransformer(ABC, Generic[T_RulesIn, T_RulesOut]):
     """This is the base class for all rule transformers."""
@@ -62,3 +63,7 @@ class RulesTransformer(ABC, Generic[T_RulesIn, T_RulesOut]):
             return ReadRules[DMSInputRules], ReadRules[InformationInputRules]
 
         return (annotation,)
+
+
+class VerifiedRulesTransformer(RulesTransformer[T_VerifiedIn, T_VerifiedOut], ABC):
+    ...

--- a/cognite/neat/_rules/transformers/_base.py
+++ b/cognite/neat/_rules/transformers/_base.py
@@ -14,6 +14,7 @@ T_RulesOut = TypeVar("T_RulesOut", bound=Rules)
 T_VerifiedIn = TypeVar("T_VerifiedIn", bound=VerifiedRules)
 T_VerifiedOut = TypeVar("T_VerifiedOut", bound=VerifiedRules)
 
+
 class RulesTransformer(ABC, Generic[T_RulesIn, T_RulesOut]):
     """This is the base class for all rule transformers."""
 
@@ -65,5 +66,4 @@ class RulesTransformer(ABC, Generic[T_RulesIn, T_RulesOut]):
         return (annotation,)
 
 
-class VerifiedRulesTransformer(RulesTransformer[T_VerifiedIn, T_VerifiedOut], ABC):
-    ...
+class VerifiedRulesTransformer(RulesTransformer[T_VerifiedIn, T_VerifiedOut], ABC): ...

--- a/cognite/neat/_rules/transformers/_converters.py
+++ b/cognite/neat/_rules/transformers/_converters.py
@@ -65,7 +65,7 @@ from cognite.neat._rules.models.information._rules_input import (
 )
 from cognite.neat._utils.text import to_camel
 
-from ._base import RulesTransformer, VerifiedRulesTransformer, T_VerifiedIn, T_VerifiedOut
+from ._base import RulesTransformer, T_VerifiedIn, T_VerifiedOut, VerifiedRulesTransformer
 from ._verification import VerifyDMSRules
 
 T_InputInRules = TypeVar("T_InputInRules", bound=ReadInputRules)

--- a/cognite/neat/_rules/transformers/_mapping.py
+++ b/cognite/neat/_rules/transformers/_mapping.py
@@ -13,10 +13,10 @@ from cognite.neat._rules.models.data_types import Enum
 from cognite.neat._rules.models.dms import DMSContainer, DMSEnum, DMSProperty
 from cognite.neat._rules.models.entities import ClassEntity, ContainerEntity, ViewEntity
 
-from ._base import RulesTransformer
+from ._base import VerifiedRulesTransformer
 
 
-class MapOntoTransformers(RulesTransformer[DMSRules, DMSRules], ABC):
+class MapOntoTransformers(VerifiedRulesTransformer[DMSRules, DMSRules], ABC):
     """Base class for transformers that map one rule onto another."""
 
     ...
@@ -100,7 +100,7 @@ class MapOneToOne(MapOntoTransformers):
         return solution
 
 
-class RuleMapper(RulesTransformer[DMSRules, DMSRules]):
+class RuleMapper(VerifiedRulesTransformer[DMSRules, DMSRules]):
     """Maps properties and classes using the given mapping.
 
     Args:
@@ -232,7 +232,7 @@ class RuleMapper(RulesTransformer[DMSRules, DMSRules]):
         return f"Mapping to {self.mapping.metadata.as_data_model_id()!r}."
 
 
-class AsParentPropertyId(RulesTransformer[DMSRules, DMSRules]):
+class AsParentPropertyId(VerifiedRulesTransformer[DMSRules, DMSRules]):
     """Looks up all view properties that map to the same container property,
     and changes the child view property id to match the parent property id.
     """

--- a/cognite/neat/_session/_base.py
+++ b/cognite/neat/_session/_base.py
@@ -20,7 +20,6 @@ from cognite.neat._rules.transformers import (
     VerifyAnyRules,
     VerifyInformationRules,
 )
-from cognite.neat._store._rules_store import ModelEntity
 from cognite.neat._utils.auxiliary import local_import
 
 from ._collector import _COLLECTOR, Collector

--- a/cognite/neat/_session/_create.py
+++ b/cognite/neat/_session/_create.py
@@ -6,10 +6,10 @@ from cognite.neat._issues import IssueList
 from cognite.neat._rules.models.dms import DMSValidation
 from cognite.neat._rules.transformers import (
     IncludeReferenced,
-    RulesTransformer,
     ToDataProductModel,
     ToEnterpriseModel,
     ToSolutionModel,
+    VerifiedRulesTransformer,
 )
 
 from ._state import SessionState
@@ -117,7 +117,7 @@ class CreateAPI:
         view_ids, container_ids = DMSValidation(
             self._state.rule_store.last_verified_dms_rules
         ).imported_views_and_containers_ids()
-        transformers: list[RulesTransformer] = []
+        transformers: list[VerifiedRulesTransformer] = []
         client = self._state.client
         if (view_ids or container_ids) and client is None:
             raise NeatSessionError(

--- a/cognite/neat/_session/_inspect.py
+++ b/cognite/neat/_session/_inspect.py
@@ -59,7 +59,13 @@ class InspectAPI:
             neat.inspect.properties
             ```
         """
-        df = self._state.rule_store.last_verified_rule.properties.to_pandas()
+        if self._state.rule_store.empty:
+            return pd.DataFrame()
+        last_entity = self._state.rule_store.provenance[-1].target_entity
+        if last_entity.dms:
+            df = last_entity.dms.properties.to_pandas()
+        else:
+            df = last_entity.information.properties.to_pandas()
         df.drop(columns=["neatId"], errors="ignore", inplace=True)
         return df
 

--- a/cognite/neat/_session/_prepare.py
+++ b/cognite/neat/_session/_prepare.py
@@ -264,7 +264,9 @@ class DataModelPrepareAPI:
             prefix: The prefix to add to the views in the data model.
 
         """
-        return self._state.rule_transform(PrefixEntities(prefix))
+        # Todo: Fix prefix entities to be a verified rules transformer
+        raise NotImplementedError("Prefix entities is not implemented yet.")
+        return self._state.rule_transform(PrefixEntities(prefix))  # type: ignore[arg-type]
 
     def reduce(self, drop: Collection[Literal["3D", "Annotation", "BaseViews"] | str]) -> IssueList:
         """This is a special method that allow you to drop parts of the data model.

--- a/cognite/neat/_session/_set.py
+++ b/cognite/neat/_session/_set.py
@@ -32,7 +32,9 @@ class SetAPI:
             neat.set.data_model_id(("my_data_model_space", "My_Data_Model", "v1"))
             ```
         """
-        rules = self._state.rule_store.get_last_successful_entity().result
+        if self._state.rule_store.empty:
+            raise NeatSessionError("No rules to set the data model ID.")
+        rules = self._state.rule_store.provenance[-1].target_entity.dms
         if isinstance(rules, DMSRules):
             if rules.metadata.as_data_model_id() in COGNITE_MODELS:
                 raise NeatSessionError(

--- a/cognite/neat/_session/_state.py
+++ b/cognite/neat/_session/_state.py
@@ -12,7 +12,7 @@ from cognite.neat._rules.transformers import (
     ToExtensionModel,
 )
 from cognite.neat._store import NeatGraphStore, NeatRulesStore
-from cognite.neat._store._rules_store import ModelEntity
+
 from cognite.neat._utils.rdf_ import uri_display_name
 from cognite.neat._utils.text import humanize_collection
 from cognite.neat._utils.upload import UploadResultList

--- a/cognite/neat/_session/_state.py
+++ b/cognite/neat/_session/_state.py
@@ -29,9 +29,10 @@ class SessionState:
 
         start = self.rule_store.provenance[-1].target_entity.display_name
         issues = self.rule_store.transform(*transformer)
-        end = self.rule_store.provenance[-1].target_entity.display_name
-        issues.action = f"{start} &#8594; {end}"
+        last_entity = self.rule_store.provenance[-1].target_entity
+        issues.action = f"{start} &#8594; {last_entity.display_name}"
         issues.hint = "Use the .inspect.issues() for more details."
+        self.instances.store.add_rules(last_entity.information)
         return issues
 
     def rule_import(self, importer: BaseImporter) -> IssueList:

--- a/cognite/neat/_session/_state.py
+++ b/cognite/neat/_session/_state.py
@@ -69,7 +69,7 @@ class SessionState:
         return issues
 
     def rule_import(self, importer: BaseImporter) -> IssueList:
-        issues = self.rule_store.import_(importer)
+        issues = self.rule_store.import_rules(importer)
         result = cast(ModelEntity, self.rule_store.provenance[-1].target_entity).display_name
         if isinstance(importer, InferenceImporter):
             issues.action = f"Inferred {result}"

--- a/cognite/neat/_session/_state.py
+++ b/cognite/neat/_session/_state.py
@@ -7,7 +7,7 @@ from cognite.neat._issues import IssueList
 from cognite.neat._rules.importers import BaseImporter, InferenceImporter
 from cognite.neat._rules.models import DMSRules, InformationRules
 from cognite.neat._rules.transformers import (
-    RulesTransformer,
+    VerifiedRulesTransformer,
 )
 from cognite.neat._store import NeatGraphStore, NeatRulesStore
 from cognite.neat._utils.upload import UploadResultList
@@ -23,7 +23,7 @@ class SessionState:
         self.client = client
         self.quoted_source_identifiers = False
 
-    def rule_transform(self, *transformer: RulesTransformer) -> IssueList:
+    def rule_transform(self, *transformer: VerifiedRulesTransformer) -> IssueList:
         if not transformer:
             raise NeatSessionError("No transformers provided.")
 

--- a/cognite/neat/_session/_state.py
+++ b/cognite/neat/_session/_state.py
@@ -35,8 +35,11 @@ class SessionState:
         return issues
 
     def rule_import(self, importer: BaseImporter) -> IssueList:
-        issues = self.rule_store.import_rules(importer)
-        result = self.rule_store.provenance[-1].target_entity.display_name
+        issues = self.rule_store.import_rules(importer, client=self.client)
+        if self.rule_store.empty:
+            result = "failed"
+        else:
+            result = self.rule_store.provenance[-1].target_entity.display_name
         if isinstance(importer, InferenceImporter):
             issues.action = f"Inferred {result}"
         else:

--- a/cognite/neat/_store/_graph_store.py
+++ b/cognite/neat/_store/_graph_store.py
@@ -24,7 +24,7 @@ from cognite.neat._shared import InstanceType, Triple
 from cognite.neat._utils.auxiliary import local_import
 from cognite.neat._utils.rdf_ import add_triples_in_batch, remove_namespace_from_uri
 
-from ._provenance import Change, Provenance
+from ._provenance import Change, Entity, Provenance
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self
@@ -59,7 +59,7 @@ class NeatGraphStore:
 
         _start = datetime.now(timezone.utc)
         self.dataset = dataset
-        self.provenance = Provenance(
+        self.provenance = Provenance[Entity](
             [
                 Change.record(
                     activity=f"{type(self).__name__}.__init__",

--- a/cognite/neat/_store/_provenance.py
+++ b/cognite/neat/_store/_provenance.py
@@ -143,7 +143,7 @@ class Change(FrozenNeatObject, Generic[T_Entity]):
         )
 
     @classmethod
-    def record(cls, activity: str, start: datetime, end: datetime, description: str) -> "Change":
+    def record(cls, activity: str, start: datetime, end: datetime, description: str) -> "Change[Entity]":
         """User friendly method to record a change that occurred in the graph store."""
         agent = Agent()
         activity = Activity(
@@ -152,8 +152,8 @@ class Change(FrozenNeatObject, Generic[T_Entity]):
             started_at_time=start,
             ended_at_time=end,
         )
-        target_entity = Entity(was_generated_by=activity, was_attributed_to=agent)
-        return cls(
+        target_entity = Entity.create_with_defaults(was_generated_by=activity, was_attributed_to=agent)
+        return Change(
             agent=agent,
             activity=activity,
             target_entity=target_entity,

--- a/cognite/neat/_store/_provenance.py
+++ b/cognite/neat/_store/_provenance.py
@@ -208,31 +208,3 @@ class Provenance(NeatList[Change[T_Entity]]):
     def as_triples(self) -> Iterable[Triple]:
         for change in self:
             yield from change.as_triples()
-
-
-class NeatProvenanceExceptions(Exception):
-    """Base class for all neat provenance exceptions. Note that these are different than the issue exceptions"""
-
-    def __str__(self):
-        return type(self).__name__
-
-class ActivityFailed(NeatProvenanceExceptions):
-    """Raised when an activity fails"""
-
-    def __init__(self, activity: Activity, issue_list: IssueList) -> None:
-        self.activity = activity
-        self.issue_list = issue_list
-
-    def __str__(self):
-        return f"{super().__str__()}: {self.activity.id_}"
-
-class InvalidActivityOutput(NeatProvenanceExceptions):
-    """Raised when an activity has an invalid output"""
-
-    def __init__(self, activity: Activity, output: str) -> None:
-        self.activity = activity
-        self.output = output
-
-    def __str__(self):
-        return f"{super().__str__()}: {self.activity.id_} -> {self.output}"
-

--- a/cognite/neat/_store/_provenance.py
+++ b/cognite/neat/_store/_provenance.py
@@ -20,7 +20,7 @@ import uuid
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional
+from typing import Generic, Optional, TypeVar
 
 from rdflib import PROV, RDF, Literal, URIRef
 
@@ -78,6 +78,7 @@ class Entity:
         )
 
 
+T_Entity = TypeVar("T_Entity", bound=Entity)
 INSTANCES_ENTITY = Entity(was_attributed_to=NEAT_AGENT, id_=CDF_NAMESPACE["instances"])
 EMPTY_ENTITY = Entity(was_attributed_to=NEAT_AGENT, id_=DEFAULT_NAMESPACE["empty-entity"])
 
@@ -111,10 +112,10 @@ class Activity:
 
 
 @dataclass(frozen=True)
-class Change(FrozenNeatObject):
+class Change(FrozenNeatObject, Generic[T_Entity]):
     agent: Agent
     activity: Activity
-    target_entity: Entity
+    target_entity: T_Entity
     description: str
     source_entity: Entity = field(default_factory=Entity.new_unknown_entity)
 
@@ -154,7 +155,7 @@ class Change(FrozenNeatObject):
         }
 
 
-class Provenance(NeatList[Change]):
+class Provenance(NeatList[Change[T_Entity]]):
     def __init__(self, changes: Sequence[Change] | None = None):
         super().__init__(changes or [])
 

--- a/cognite/neat/_store/_provenance.py
+++ b/cognite/neat/_store/_provenance.py
@@ -20,7 +20,7 @@ import uuid
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 from rdflib import PROV, RDF, Literal, URIRef
 
@@ -54,7 +54,13 @@ class Entity:
     id_: URIRef
 
     @classmethod
-    def create_with_defaults(cls, was_attributed_to: Agent, issues: IssueList | None = None, was_generated_by: "Activity | None" = None, id_: URIRef = DEFAULT_NAMESPACE["graph-store"]) -> "Entity":
+    def create_with_defaults(
+        cls,
+        was_attributed_to: Agent,
+        issues: IssueList | None = None,
+        was_generated_by: "Activity | None" = None,
+        id_: URIRef = DEFAULT_NAMESPACE["graph-store"],
+    ) -> "Entity":
         return cls(
             was_attributed_to=was_attributed_to,
             issues=issues or IssueList(),

--- a/cognite/neat/_store/_rules_store.py
+++ b/cognite/neat/_store/_rules_store.py
@@ -70,7 +70,7 @@ class NeatRulesStore:
     ) -> IssueList:
         def action() -> tuple[InformationRules, DMSRules | None]:
             read_rules = importer.to_rules()
-            verified = VerifyAnyRules(validate, client).transform(read_rules)
+            verified = VerifyAnyRules(validate, client).transform(read_rules)  # type: ignore[arg-type]
             if isinstance(verified, InformationRules):
                 return verified, None
             elif isinstance(verified, DMSRules):
@@ -197,7 +197,7 @@ class NeatRulesStore:
         elif isinstance(source_entity.information, expected_types):
             input_ = source_entity.information
         else:
-            available = [InformationRules]
+            available: list[type] = [InformationRules]
             if source_entity.dms is not None:
                 available.append(DMSRules)
             raise InvalidActivityInput(expected=expected_types, have=tuple(available))
@@ -216,7 +216,7 @@ class NeatRulesStore:
             used=source_entity,
         )
         if isinstance(result, UploadResultList | Path | URIRef):
-            outcome_result = result
+            outcome_result: UploadResultList | Path | URIRef | str = result
         else:
             outcome_result = type(result).__name__
 

--- a/cognite/neat/_store/_rules_store.py
+++ b/cognite/neat/_store/_rules_store.py
@@ -68,6 +68,15 @@ class NeatRulesStore:
     def import_rules(
         self, importer: BaseImporter, validate: bool = True, client: NeatClient | None = None
     ) -> IssueList:
+        if self.empty:
+            return self._import_rules(importer, validate, client)
+        else:
+            # Importing can be used as a manual transformation.
+            return self._manual_transform(importer, validate, client)
+
+    def _import_rules(
+        self, importer: BaseImporter, validate: bool = True, client: NeatClient | None = None
+    ) -> IssueList:
         def action() -> tuple[InformationRules, DMSRules | None]:
             read_rules = importer.to_rules()
             verified = VerifyAnyRules(validate, client).transform(read_rules)  # type: ignore[arg-type]
@@ -80,6 +89,11 @@ class NeatRulesStore:
                 raise ValueError(f"Invalid output from importer: {type(verified)}")
 
         return self.import_action(action, importer)
+
+    def _manual_transform(
+        self, importer: BaseImporter, validate: bool = True, client: NeatClient | None = None
+    ) -> IssueList:
+        raise NotImplementedError("Manual transformation is not yet implemented.")
 
     def import_graph(self, extractor: KnowledgeGraphExtractor) -> IssueList:
         def action() -> tuple[InformationRules, DMSRules | None]:

--- a/cognite/neat/_store/_rules_store.py
+++ b/cognite/neat/_store/_rules_store.py
@@ -3,9 +3,8 @@ from collections import defaultdict
 from collections.abc import Callable, Hashable
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from functools import partial
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import rdflib
 from cognite.client import data_modeling as dm
@@ -21,13 +20,12 @@ from cognite.neat._rules.exporters import BaseExporter
 from cognite.neat._rules.exporters._base import CDFExporter, T_Export
 from cognite.neat._rules.importers import BaseImporter
 from cognite.neat._rules.models import DMSRules, InformationRules
-from cognite.neat._rules.models._base_input import InputRules
+from cognite.neat._rules.transformers import DMSToInformation, VerifyAnyRules
 from cognite.neat._rules.transformers import VerifiedRulesTransformer
 from cognite.neat._utils.upload import UploadResultList
-from cognite.neat._rules.transformers import DMSToInformation, InformationToDMS, MergeInformationRules, MergeDMSRules, VerifyAnyRules
+from ._provenance import UNKNOWN_AGENT, Activity, Change, Entity, Provenance
+from .exceptions import EmptyStore, InvalidInputOperation, ActivityFailed
 
-from ._provenance import EMPTY_ENTITY, UNKNOWN_AGENT, Activity, Agent, Change, Entity, Provenance
-from .exceptions import EmptyStore, InvalidInputOperation, ActivityFailed, InvalidActivityOutput
 
 @dataclass(frozen=True)
 class RulesEntity(Entity):
@@ -60,38 +58,95 @@ class NeatRulesStore:
             return calculated_hash[:8]
         return calculated_hash
 
-    def import_(self, importer: BaseImporter, validate: bool = True, client: NeatClient | None = None) -> IssueList:
+    def import_rules(self, importer: BaseImporter, validate: bool = True, client: NeatClient | None = None) -> IssueList:
         if self.provenance:
-            raise NeatValueError(f"Data model already exists in the store. Cannot import {importer.source_uri}.")
+            raise NeatValueError(f"Data model already exists. Cannot import {importer.source_uri}.")
         source_entity = Entity.create_with_defaults(
             was_attributed_to=UNKNOWN_AGENT,
             id_=importer.source_uri,
         )
-        start = datetime.now(timezone.utc)
-        verified: InformationRules | DMSRules | None = None
-        with catch_issues() as issue_list:
+        def action() -> tuple[InformationRules, DMSRules | None]:
             read_rules = importer.to_rules()
             verified = VerifyAnyRules(validate, client).transform(read_rules)
+            if isinstance(verified, InformationRules):
+                return verified, None
+            elif isinstance(verified, DMSRules):
+                return DMSToInformation().transform(verified), verified
+            else:
+                # Bug in the code
+                raise ValueError(f"Invalid output from importer: {type(verified)}")
+
+        return self._do_activity(action, importer, source_entity)
+
+    def import_graph(self, extractor: KnowledgeGraphExtractor) -> IssueList:
+        if self.provenance:
+            raise NeatValueError(f"Data model already exists. Cannot import {extractor.source_uri}.")
+
+        def action() -> tuple[InformationRules, DMSRules | None]:
+            info = extractor.get_information_rules()
+            dms: DMSRules | None = None
+            if isinstance(extractor, DMSGraphExtractor):
+                dms = extractor.get_dms_rules()
+            return info, dms
+        return self._do_activity(action, extractor)
+
+    def transform(self, *transformer: VerifiedRulesTransformer) -> IssueList:
+        if not self.provenance:
+            raise EmptyStore()
+
+        all_issues = IssueList()
+        for item in transformer:
+            def action() -> tuple[InformationRules, DMSRules | None]:
+                last_change = self.provenance[-1]
+                source_entity = last_change.target_entity
+                transformer_input = self._get_transformer_input(source_entity, item)
+                transformer_output = item.transform(transformer_input)
+                if isinstance(transformer_output, InformationRules):
+                    return transformer_output, None
+                return last_change.target_entity.information, transformer_output
+
+            issues = self._do_activity(action, item)
+            all_issues.extend(issues)
+        return all_issues
+
+    def export(self, exporter: BaseExporter[T_VerifiedRules, T_Export]) -> T_Export:
+        return self._export_activity(exporter.export, exporter, DEFAULT_NAMESPACE["export-result"])
+
+    def export_to_file(self, exporter: BaseExporter, path: Path) -> None:
+        def export_action(input_: VerifiedRules) -> Path:
+            exporter.export_to_file(input_, path)
+            return path
+        self._export_activity(export_action, exporter, DEFAULT_NAMESPACE[path.name])
+
+    def export_to_cdf(self, exporter: CDFExporter, client: NeatClient, dry_run: bool) -> UploadResultList:
+        return self._export_activity(exporter.export_to_cdf, exporter, DEFAULT_NAMESPACE["upload-result"], client, dry_run)
+
+    def _do_activity(self, action: Callable[[], tuple[InformationRules, DMSRules | None]],
+                     agent_tool: BaseImporter | VerifiedRulesTransformer | KnowledgeGraphExtractor) -> IssueList:
+        if isinstance(agent_tool, BaseImporter | KnowledgeGraphExtractor):
+            source_entity = Entity.create_with_defaults(
+                was_attributed_to=UNKNOWN_AGENT,
+                id_=agent_tool.source_uri,
+            )
+        else:
+            # This is a transformer
+            source_entity = self.provenance[-1].target_entity
+
+        start = datetime.now(timezone.utc)
+        result: tuple[InformationRules, DMSRules | None] | None = None
+        with catch_issues() as issue_list:
+            info, dms = action()
 
         end = datetime.now(timezone.utc)
-        agent = importer.agent
+        agent = agent_tool.agent
         activity = Activity(
             was_associated_with=agent,
             ended_at_time=end,
             started_at_time=start,
             used=source_entity,
         )
-        if verified is None:
-            raise ActivityFailed(activity, issue_list)
-
-        dms: DMSRules | None = None
-        if isinstance(verified, InformationRules):
-            info = verified
-        elif isinstance(verified, DMSRules):
-            dms = verified
-            info = DMSToInformation().transform(dms)
-        else:
-            raise InvalidActivityOutput(activity, type(verified))
+        if result is None:
+            raise ActivityFailed(activity, issue_list, agent_tool)
 
         target_entity = RulesEntity(
             was_attributed_to=agent,
@@ -100,97 +155,19 @@ class NeatRulesStore:
             dms=dms,
             issues=issue_list,
             # here id can be bumped in case id already exists
-            id_=self._create_id(verified),
+            id_=self._create_id(info, dms),
         )
         change = Change(
             agent=agent,
             activity=activity,
             target_entity=target_entity,
-            description=importer.description,
+            description=agent_tool.description,
             source_entity=source_entity,
         )
         self.provenance.append(change)
         return issue_list
 
-    def import_graph(self, extractor: KnowledgeGraphExtractor) -> IssueList:
-        agent = extractor.agent
-        source_entity = Entity.create_with_defaults(
-            was_attributed_to=UNKNOWN_AGENT,
-            id_=extractor.source_uri,
-        )
-        _, issues = self._do_activity(extractor.get_information_rules, agent, source_entity, extractor.description)
-        if isinstance(extractor, DMSGraphExtractor):
-            _, dms_issues = self._do_activity(extractor.get_dms_rules, agent, source_entity, extractor.description)
-            issues.extend(dms_issues)
-        return issues
-
-    def transform(self, *transformer: VerifiedRulesTransformer) -> IssueList:
-        if not self.provenance:
-            raise EmptyStore()
-
-        all_issues = IssueList()
-        for item in transformer:
-            last_change = self.provenance[-1]
-            source_entity = last_change.target_entity
-
-            transformer_input = self._get_transformer_input(source_entity, item)
-            start = datetime.now(timezone.utc)
-            result: InformationRules | DMSRules | None = None
-            with catch_issues() as issue_list:
-                result = item.transform(transformer_input)
-            all_issues.extend(issue_list)
-            if result is None:
-                return all_issues
-            end = datetime.now(timezone.utc)
-
-            activity = Activity(
-                was_associated_with=item.agent,
-                ended_at_time=end,
-                started_at_time=start,
-                used=source_entity,
-            )
-            if isinstance(result, InformationRules):
-                info = result
-                dms = None
-            elif isinstance(result, DMSRules):
-                dms = result
-                info = source_entity.information
-            else:
-                raise InvalidActivityOutput(activity, type(result))
-
-            target_entity = RulesEntity(
-                was_attributed_to=item.agent,
-                was_generated_by=activity,
-                information=info,
-                dms=dms,
-                issues=issue_list,
-                # here id can be bumped in case id already exists
-                id_=self._create_id(result),
-            )
-            change = Change(
-                agent=item.agent,
-                activity=activity,
-                target_entity=target_entity,
-                description=item.description,
-                source_entity=source_entity,
-            )
-            self.provenance.append(change)
-        return all_issues
-
-    @staticmethod
-    def _get_transformer_input(source_entity: RulesEntity, transformer: VerifiedRulesTransformer) -> InformationRules | DMSRules:
-        # Case 1: We only have information rules
-        if source_entity.dms is None:
-            if transformer.is_valid_input(source_entity.information):
-                return source_entity.information
-            raise InvalidInputOperation(expected=(DMSRules, ), have=(InformationRules,))
-        # Case 2: We have both information and dms rules and the transformer is compatible with dms rules
-        elif isinstance(source_entity.dms, DMSRules) and transformer.is_valid_input(source_entity.dms):
-            return source_entity.dms
-        # Case 3: We have both information and dms rules and the transformer is compatible with information rules
-        raise NeatValueError(f"Cannot do action {transformer.description} on a converted physical model.")
-
-    def export(self, exporter: BaseExporter[T_VerifiedRules, T_Export]) -> T_Export:
+    def _export_activity(self, action: Callable, exporter: BaseExporter, target_id: URIRef, *exporter_args: Any) -> Any:
         if self.empty:
             raise EmptyStore()
         last_change = self.provenance[-1]
@@ -211,19 +188,24 @@ class NeatRulesStore:
         start = datetime.now(timezone.utc)
         with catch_issues() as issue_list:
             # Validate the type of the result
-            result = exporter.export(input_)
+            result = action(input_, *exporter_args)
+
         end = datetime.now(timezone.utc)
-        target_id = DEFAULT_NAMESPACE["export-result"]
         activity = Activity(
             was_associated_with=agent,
             ended_at_time=end,
             started_at_time=start,
             used=source_entity,
         )
+        if isinstance(result, UploadResultList | Path | URIRef):
+            outcome_result = result
+        else:
+            outcome_result = type(result).__name__
+
         target_entity = OutcomeEntity(
             was_attributed_to=agent,
             was_generated_by=activity,
-            result=type(result).__name__,
+            result=outcome_result,
             issues=issue_list,
             id_=target_id,
         )
@@ -235,87 +217,22 @@ class NeatRulesStore:
             source_entity=source_entity,
         )
         self.exports_by_source_entity_id[source_entity.id_].append(change)
+        if isinstance(result, UploadResultList):
+            self._last_outcome = result
         return result
 
-    def export_to_file(self, exporter: BaseExporter, path: Path) -> None:
-        last_change = self.provenance[-1]
-        source_entity = last_change.target_entity
-        if not isinstance(source_entity, ModelEntity):
-            # Todo: Provenance should be of an entity type
-            raise ValueError("Bug in neat: The last entity in the provenance is not a model entity.")
-        expected_types = exporter.source_types()
-        if not any(isinstance(source_entity.result, type_) for type_ in expected_types):
-            raise InvalidInputOperation(expected=expected_types, got=type(source_entity.result))
-        target_id = DEFAULT_NAMESPACE[path.name]
-        agent = exporter.agent
-        start = datetime.now(timezone.utc)
-        with catch_issues() as issue_list:
-            exporter.export_to_file(source_entity.result, path)
-        end = datetime.now(timezone.utc)
-
-        activity = Activity(
-            was_associated_with=agent,
-            ended_at_time=end,
-            started_at_time=start,
-            used=source_entity,
-        )
-        target_entity = OutcomeEntity(
-            was_attributed_to=agent,
-            was_generated_by=activity,
-            result=path,
-            issues=issue_list,
-            id_=target_id,
-        )
-        change = Change(
-            agent=agent,
-            activity=activity,
-            target_entity=target_entity,
-            description=exporter.description,
-            source_entity=source_entity,
-        )
-        self.exports_by_source_entity_id[source_entity.id_].append(change)
-
-    def export_to_cdf(self, exporter: CDFExporter, client: NeatClient, dry_run: bool) -> UploadResultList:
-        last_change = self.provenance[-1]
-        source_entity = last_change.target_entity
-        if not isinstance(source_entity, ModelEntity):
-            # Todo: Provenance should be of an entity type
-            raise ValueError("Bug in neat: The last entity in the provenance is not a model entity.")
-        expected_types = exporter.source_types()
-        if not any(isinstance(source_entity.result, type_) for type_ in expected_types):
-            raise InvalidInputOperation(expected=expected_types, got=type(source_entity.result))
-
-        agent = exporter.agent
-        start = datetime.now(timezone.utc)
-        target_id = DEFAULT_NAMESPACE["upload-result"]
-        result: UploadResultList | None = None
-        with catch_issues() as issue_list:
-            result = exporter.export_to_cdf(source_entity.result, client, dry_run)
-        end = datetime.now(timezone.utc)
-
-        activity = Activity(
-            was_associated_with=agent,
-            ended_at_time=end,
-            started_at_time=start,
-            used=source_entity,
-        )
-        target_entity = OutcomeEntity(
-            was_attributed_to=agent,
-            was_generated_by=activity,
-            result=result,
-            issues=issue_list,
-            id_=target_id,
-        )
-        change = Change(
-            agent=agent,
-            activity=activity,
-            target_entity=target_entity,
-            description=exporter.description,
-            source_entity=source_entity,
-        )
-        self.exports_by_source_entity_id[source_entity.id_].append(change)
-        self._last_outcome = result
-        return result
+    @staticmethod
+    def _get_transformer_input(source_entity: RulesEntity, transformer: VerifiedRulesTransformer) -> InformationRules | DMSRules:
+        # Case 1: We only have information rules
+        if source_entity.dms is None:
+            if transformer.is_valid_input(source_entity.information):
+                return source_entity.information
+            raise InvalidInputOperation(expected=(DMSRules, ), have=(InformationRules,))
+        # Case 2: We have both information and dms rules and the transformer is compatible with dms rules
+        elif isinstance(source_entity.dms, DMSRules) and transformer.is_valid_input(source_entity.dms):
+            return source_entity.dms
+        # Case 3: We have both information and dms rules and the transformer is compatible with information rules
+        raise NeatValueError(f"Cannot do action {transformer.description} on a converted physical model.")
 
     def _update_source_entity(self, source_entity: Entity, result: Rules, issue_list: IssueList) -> Entity:
         """Update source entity to keep the unbroken provenance chain of changes."""
@@ -366,52 +283,6 @@ class NeatRulesStore:
 
         return update_source_entity or source_entity
 
-    def _do_activity(
-        self, action: Callable[[], Rules | None], agent: Agent, source_entity: Entity, description: str
-    ) -> tuple[Any, IssueList]:
-        start = datetime.now(timezone.utc)
-        result: Rules | None = None
-        with catch_issues() as issue_list:
-            result = action()
-        end = datetime.now(timezone.utc)
-
-        # This handles import activity that needs to be properly registered
-        # hence we check if class of action is subclass of BaseImporter
-        # and only if the store is not empty !
-        if (
-            hasattr(action, "__self__")
-            and issubclass(action.__self__.__class__, BaseImporter)
-            and source_entity.was_attributed_to == UNKNOWN_AGENT
-            and result
-            and not self.empty
-        ):
-            source_entity = self._update_source_entity(source_entity, result, issue_list)
-
-        activity = Activity(
-            was_associated_with=agent,
-            ended_at_time=end,
-            started_at_time=start,
-            used=source_entity,
-        )
-        target_entity = ModelEntity(
-            was_attributed_to=agent,
-            was_generated_by=activity,
-            result=result,
-            issues=issue_list,
-            # here id can be bumped in case id already exists
-            id_=self._create_id(result),
-        )
-        change = Change(
-            agent=agent,
-            activity=activity,
-            target_entity=target_entity,
-            description=description,
-            source_entity=source_entity,
-        )
-
-        self.provenance.append(change)
-        return result, issue_list
-
     def _get_source_id(self, result: Rules) -> rdflib.URIRef | None:
         """Return the source of the result."""
 
@@ -430,8 +301,11 @@ class NeatRulesStore:
             return result.metadata.as_data_model_id()
         return None
 
-    def _create_id(self, result: InformationRules | DMSRules) -> rdflib.URIRef:
-        identifier = result.metadata.identifier
+    def _create_id(self, info: InformationRules, dms: DMSRules | None) -> rdflib.URIRef:
+        if dms is None:
+            identifier = info.metadata.identifier
+        else:
+            identifier = dms.metadata.identifier
 
         # Here we check if the identifier is already in the iteration dictionary
         # to track specific changes to the same entity, if it is we increment the iteration
@@ -444,30 +318,27 @@ class NeatRulesStore:
         self._iteration_by_id[identifier] += 1
         return identifier + f"/Iteration_{self._iteration_by_id[identifier]}"
 
-    # @property
-    # def last_verified_dms_rules(self) -> DMSRules:
-    #     for change in reversed(self.provenance):
-    #         if isinstance(change.target_entity, ModelEntity) and isinstance(change.target_entity.result, DMSRules):
-    #             return change.target_entity.result
-    #     raise NeatValueError("No verified DMS rules found in the provenance.")
-    #
-    # @property
-    # def last_verified_information_rules(self) -> InformationRules:
-    #     for change in reversed(self.provenance):
-    #         if isinstance(change.target_entity, ModelEntity) and isinstance(
-    #             change.target_entity.result, InformationRules
-    #         ):
-    #             return change.target_entity.result
-    #     raise NeatValueError("No verified information rules found in the provenance.")
+    @property
+    def last_verified_dms_rules(self) -> DMSRules:
+        if not self.provenance:
+            raise EmptyStore()
+        if self.provenance[-1].target_entity.dms is None:
+            raise NeatValueError("No verified DMS rules found in the provenance.")
+        return self.provenance[-1].target_entity.dms
 
-    # @property
-    # def last_issues(self) -> IssueList:
-    #     if not self.provenance:
-    #         raise NeatValueError("No issues found in the provenance.")
-    #     last_change = self.provenance[-1]
-    #     if last_change.target_entity.issues:
-    #         return last_change.target_entity.issues
-    #     return last_change.source_entity.issues
+    @property
+    def last_verified_information_rules(self) -> InformationRules:
+        if not self.provenance:
+            raise EmptyStore()
+        return self.provenance[-1].target_entity.information
+
+    @property
+    def last_issues(self) -> IssueList:
+        if not self.provenance:
+            raise EmptyStore()
+        if self.provenance[-1].target_entity.issues:
+            return self.provenance[-1].target_entity.issues
+        return self.provenance[-1].source_entity.issues
 
     @property
     def last_outcome(self) -> UploadResultList:

--- a/cognite/neat/_store/exceptions.py
+++ b/cognite/neat/_store/exceptions.py
@@ -1,12 +1,35 @@
 """These are special exceptions that are used by the store to signal invalid transformers"""
 
 from dataclasses import dataclass
+from ._provenance import Activity
+from cognite.neat._issues import IssueList
 
 
 class NeatStoreError(Exception):
     """Base class for all exceptions in the store module"""
+    def __str__(self):
+        return type(self).__name__
 
-    ...
+class ActivityFailed(NeatStoreError):
+    """Raised when an activity fails"""
+
+    def __init__(self, activity: Activity, issue_list: IssueList) -> None:
+        self.activity = activity
+        self.issue_list = issue_list
+
+    def __str__(self):
+        return f"{super().__str__()}: {self.activity.id_}"
+
+class InvalidActivityOutput(NeatStoreError):
+    """Raised when an activity has an invalid output"""
+
+    def __init__(self, activity: Activity, output: str) -> None:
+        self.activity = activity
+        self.output = output
+
+    def __str__(self):
+        return f"{super().__str__()}: {self.activity.id_} -> {self.output}"
+
 
 
 @dataclass
@@ -14,7 +37,7 @@ class InvalidInputOperation(NeatStoreError, RuntimeError):
     """Raised when an invalid operation is attempted"""
 
     expected: tuple[type, ...]
-    got: type
+    have: tuple[type, ...]
 
 
 class EmptyStore(NeatStoreError, RuntimeError):

--- a/cognite/neat/_store/exceptions.py
+++ b/cognite/neat/_store/exceptions.py
@@ -1,8 +1,12 @@
 """These are special exceptions that are used by the store to signal invalid transformers"""
 
 from dataclasses import dataclass
-from ._provenance import Activity
+
+from cognite.neat._graph.extractors import KnowledgeGraphExtractor
 from cognite.neat._issues import IssueList
+from cognite.neat._rules.importers import BaseImporter
+from cognite.neat._rules.transformers import VerifiedRulesTransformer
+from ._provenance import Activity
 
 
 class NeatStoreError(Exception):
@@ -13,12 +17,13 @@ class NeatStoreError(Exception):
 class ActivityFailed(NeatStoreError):
     """Raised when an activity fails"""
 
-    def __init__(self, activity: Activity, issue_list: IssueList) -> None:
+    def __init__(self, activity: Activity, issue_list: IssueList, tool: BaseImporter | VerifiedRulesTransformer | KnowledgeGraphExtractor) -> None:
         self.activity = activity
         self.issue_list = issue_list
+        self.tool = tool
 
     def __str__(self):
-        return f"{super().__str__()}: {self.activity.id_}"
+        return f"{super().__str__()}: {self.tool.description}"
 
 class InvalidActivityOutput(NeatStoreError):
     """Raised when an activity has an invalid output"""

--- a/cognite/neat/_store/exceptions.py
+++ b/cognite/neat/_store/exceptions.py
@@ -6,18 +6,26 @@ from cognite.neat._graph.extractors import KnowledgeGraphExtractor
 from cognite.neat._issues import IssueList
 from cognite.neat._rules.importers import BaseImporter
 from cognite.neat._rules.transformers import VerifiedRulesTransformer
+
 from ._provenance import Activity
 
 
 class NeatStoreError(Exception):
     """Base class for all exceptions in the store module"""
+
     def __str__(self):
         return type(self).__name__
+
 
 class ActivityFailed(NeatStoreError):
     """Raised when an activity fails"""
 
-    def __init__(self, activity: Activity, issue_list: IssueList, tool: BaseImporter | VerifiedRulesTransformer | KnowledgeGraphExtractor) -> None:
+    def __init__(
+        self,
+        activity: Activity,
+        issue_list: IssueList,
+        tool: BaseImporter | VerifiedRulesTransformer | KnowledgeGraphExtractor,
+    ) -> None:
         self.activity = activity
         self.issue_list = issue_list
         self.tool = tool
@@ -25,12 +33,14 @@ class ActivityFailed(NeatStoreError):
     def __str__(self):
         return self.tool.description
 
+
 @dataclass
 class InvalidActivityInput(NeatStoreError, RuntimeError):
     """Raised when an invalid activity is attempted"""
 
     expected: tuple[type, ...]
     have: tuple[type, ...]
+
 
 class InvalidActivityOutput(NeatStoreError):
     """Raised when an activity has an invalid output"""

--- a/cognite/neat/_store/exceptions.py
+++ b/cognite/neat/_store/exceptions.py
@@ -23,7 +23,14 @@ class ActivityFailed(NeatStoreError):
         self.tool = tool
 
     def __str__(self):
-        return f"{super().__str__()}: {self.tool.description}"
+        return self.tool.description
+
+@dataclass
+class InvalidActivityInput(NeatStoreError, RuntimeError):
+    """Raised when an invalid activity is attempted"""
+
+    expected: tuple[type, ...]
+    have: tuple[type, ...]
 
 class InvalidActivityOutput(NeatStoreError):
     """Raised when an activity has an invalid output"""
@@ -34,15 +41,6 @@ class InvalidActivityOutput(NeatStoreError):
 
     def __str__(self):
         return f"{super().__str__()}: {self.activity.id_} -> {self.output}"
-
-
-
-@dataclass
-class InvalidInputOperation(NeatStoreError, RuntimeError):
-    """Raised when an invalid operation is attempted"""
-
-    expected: tuple[type, ...]
-    have: tuple[type, ...]
 
 
 class EmptyStore(NeatStoreError, RuntimeError):

--- a/tests/tests_integration/test_session/test_data_model_to.py
+++ b/tests/tests_integration/test_session/test_data_model_to.py
@@ -110,6 +110,7 @@ class TestRulesStoreProvenanceSyncing:
             "this neat session have the same data model id"
         ) in e.value.raw_message
 
+    @pytest.mark.skip("Skipped need a discussion on how to add with the Info + DMS regime")
     def test_stop_model_import_which_source_is_not_in_session(self, neat_client: NeatClient) -> None:
         neat = NeatSession(neat_client)
         neat.read.excel.examples.pump_example()

--- a/tests/tests_integration/test_session/test_data_model_to.py
+++ b/tests/tests_integration/test_session/test_data_model_to.py
@@ -110,12 +110,12 @@ class TestRulesStoreProvenanceSyncing:
             "this neat session have the same data model id"
         ) in e.value.raw_message
 
-    def test_stop_model_import_which_source_is_not_in_session(self, neat_client: NeatClient, tmp_path: Path) -> None:
+    def test_stop_model_import_which_source_is_not_in_session(self, neat_client: NeatClient) -> None:
         neat = NeatSession(neat_client)
         neat.read.excel.examples.pump_example()
 
         # set source to be the same as the target
-        target = neat._state.rule_store.provenance[-1].target_entity.result
+        target = neat._state.rule_store.provenance[-1].target_entity.dms
         target.metadata.source_id = target.metadata.namespace + "some_other_source"
 
         with pytest.raises(NeatValueError) as e:

--- a/tests/tests_integration/test_session/test_data_model_to.py
+++ b/tests/tests_integration/test_session/test_data_model_to.py
@@ -113,7 +113,6 @@ class TestRulesStoreProvenanceSyncing:
     def test_stop_model_import_which_source_is_not_in_session(self, neat_client: NeatClient, tmp_path: Path) -> None:
         neat = NeatSession(neat_client)
         neat.read.excel.examples.pump_example()
-        neat.verify()
 
         # set source to be the same as the target
         target = neat._state.rule_store.provenance[-1].target_entity.result

--- a/tests/tests_integration/test_session/test_graph_flow.py
+++ b/tests/tests_integration/test_session/test_graph_flow.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Any
 
 import yaml
@@ -72,11 +73,9 @@ class TestExtractToLoadFlow:
         neat.infer(max_number_of_instance=-1)
 
         # Hack to ensure deterministic output
-        rules = neat._state.rule_store.last_unverified_rule
-        rules.metadata.created = "2024-09-19T00:00:00Z"
-        rules.metadata.updated = "2024-09-19T00:00:00Z"
-
-        neat.verify()
+        rules = neat._state.rule_store.last_verified_information_rules
+        rules.metadata.created = datetime.datetime.fromisoformat("2024-09-19T00:00:00Z")
+        rules.metadata.updated = datetime.datetime.fromisoformat("2024-09-19T00:00:00Z")
 
         neat.convert("dms")
         neat.set.data_model_id(("dexpi_playground", "DEXPI", "v1.3.1"))

--- a/tests/tests_integration/test_session/test_graph_flow.py
+++ b/tests/tests_integration/test_session/test_graph_flow.py
@@ -110,11 +110,9 @@ class TestExtractToLoadFlow:
         neat.infer(max_number_of_instance=-1)
 
         # Hack to ensure deterministic output
-        rules = neat._state.rule_store.last_unverified_rule
-        rules.metadata.created = "2024-09-19T00:00:00Z"
-        rules.metadata.updated = "2024-09-19T00:00:00Z"
-
-        neat.verify()
+        rules = neat._state.rule_store.last_verified_information_rules
+        rules.metadata.created = datetime.datetime.fromisoformat("2024-09-19T00:00:00Z")
+        rules.metadata.updated = datetime.datetime.fromisoformat("2024-09-19T00:00:00Z")
 
         neat.convert("dms")
         neat.set.data_model_id(("aml_playground", "AML", "terminology_3.0"))

--- a/tests/tests_integration/test_session/test_read.py
+++ b/tests/tests_integration/test_session/test_read.py
@@ -20,10 +20,8 @@ class TestRead:
         # The data product should lookup the describable properties and include them.
         view = cognite_client.data_modeling.views.retrieve(("cdf_cdm", "CogniteDescribable", "v1"))[0]
 
-        neat.read.yaml(data.REFERENCING_CORE, format="toolkit")
-
-        issues = neat.verify()
-        assert not issues.has_errors
+        issues = neat.read.yaml(data.REFERENCING_CORE, format="toolkit")
+        assert not issues.has_errors, issues
 
         neat.create.data_product_model(("sp_my_space", "MyProduct", "v1"))
 

--- a/tests/tests_unit/graph/test_loaders/test_dms_loader.py
+++ b/tests/tests_unit/graph/test_loaders/test_dms_loader.py
@@ -1,3 +1,4 @@
+import pytest
 from cognite.client.data_classes import Asset, FileMetadata
 from cognite.client.data_classes.data_modeling import InstanceApply
 
@@ -81,6 +82,7 @@ def test_imf_attribute_nodes():
     assert len(store.multi_type_instances[store.default_named_graph]) == 63
 
 
+@pytest.mark.xfail(reason="Need to update the prefix to work on verified rules")
 def test_extract_above_direct_relation_limit() -> None:
     with monkeypatch_neat_client() as client:
         neat = NeatSession(client, storage="oxigraph")
@@ -92,7 +94,6 @@ def test_extract_above_direct_relation_limit() -> None:
 
         neat.infer(max_number_of_instance=2)
         neat.prepare.data_model.prefix("Classic")
-        neat.verify()
         neat.convert("dms")
         dms_rules = neat._state.rule_store.last_verified_dms_rules
         # Default conversion uses edges for connections. We need to change it to direct relations

--- a/tests/tests_unit/test_session/test_to_yaml.py
+++ b/tests/tests_unit/test_session/test_to_yaml.py
@@ -16,7 +16,7 @@ class TestToYaml:
     def test_to_yaml(self, tmp_path: Path) -> None:
         neat = NeatSession()
         # Hack to read in model.
-        neat._state.rule_store.import_(RuleImporter())
+        neat._state.rule_store.import_rules(RuleImporter())
 
         neat.verify()
         neat.to.yaml(tmp_path, format="toolkit")

--- a/tests/tests_unit/test_store/tests_rules_store.py
+++ b/tests/tests_unit/test_store/tests_rules_store.py
@@ -19,7 +19,7 @@ class TestRuleStore:
     def test_import_export(self, data_regression: DataRegressionFixture) -> None:
         store = NeatRulesStore()
 
-        import_issues = store.import_(importers.ExcelImporter(catalog.hello_world_pump), validate=False)
+        import_issues = store.import_rules(importers.ExcelImporter(catalog.hello_world_pump), validate=False)
 
         assert not import_issues.errors
 
@@ -32,7 +32,7 @@ class TestRuleStore:
     def test_import_fail_transform(self) -> None:
         store = NeatRulesStore()
 
-        import_issues = store.import_(importers.ExcelImporter(catalog.hello_world_pump), validate=False)
+        import_issues = store.import_rules(importers.ExcelImporter(catalog.hello_world_pump), validate=False)
 
         assert not import_issues.errors
 
@@ -46,7 +46,7 @@ class TestRuleStore:
     def test_import_invalid_transformer(self) -> None:
         store = NeatRulesStore()
 
-        import_issues = store.import_(importers.ExcelImporter(catalog.hello_world_pump), validate=False)
+        import_issues = store.import_rules(importers.ExcelImporter(catalog.hello_world_pump), validate=False)
 
         assert not import_issues.errors
 

--- a/tests/tests_unit/test_store/tests_rules_store.py
+++ b/tests/tests_unit/test_store/tests_rules_store.py
@@ -7,12 +7,16 @@ from cognite.neat._rules import catalog, exporters, importers, transformers
 from cognite.neat._rules.models import DMSRules, InformationRules
 from cognite.neat._rules.transformers import VerifiedRulesTransformer
 from cognite.neat._store import NeatRulesStore
-from cognite.neat._store.exceptions import InvalidInputOperation
+from cognite.neat._store.exceptions import InvalidActivityInput
 
 
 class FailingTransformer(VerifiedRulesTransformer[DMSRules, DMSRules]):
     def transform(self, rules: DMSRules) -> DMSRules:
         raise NeatValueError("This transformer always fails")
+
+    @property
+    def description(self) -> str:
+        return "Failing transformer"
 
 
 class TestRuleStore:
@@ -50,7 +54,8 @@ class TestRuleStore:
 
         assert not import_issues.errors
 
-        with pytest.raises(NeatValueError) as exc_info:
+        with pytest.raises(InvalidActivityInput) as exc_info:
             _ = store.transform(transformers.ToCompliantEntities())
 
-        assert exc_info.value.as_message()
+        assert exc_info.value.expected == (InformationRules,)
+        assert exc_info.value.have == (DMSRules,)

--- a/tests/tests_unit/test_store/tests_rules_store.py
+++ b/tests/tests_unit/test_store/tests_rules_store.py
@@ -15,22 +15,16 @@ class FailingTransformer(RulesTransformer[DMSInputRules, DMSRules]):
 
 
 class TestRuleStore:
-    def test_import_transform_export(self, data_regression: DataRegressionFixture) -> None:
+    def test_import_export(self, data_regression: DataRegressionFixture) -> None:
         store = NeatRulesStore()
 
-        import_issues = store.import_(importers.ExcelImporter(catalog.hello_world_pump))
+        import_issues = store.import_(importers.ExcelImporter(catalog.hello_world_pump), validate=False)
 
         assert not import_issues.errors
-
-        transform_issues = store.transform(transformers.VerifyDMSRules(validate=False))
-
-        assert not transform_issues.errors
 
         result = store.export(exporters.YAMLExporter())
 
         assert isinstance(result, str)
-        last_entity = store.get_last_successful_entity()
-        assert last_entity.result == result
 
         data_regression.check(yaml.safe_load(result))
 

--- a/tests/tests_unit/test_store/tests_rules_store/test_import_export.yml
+++ b/tests/tests_unit/test_store/tests_rules_store/test_import_export.yml
@@ -1,15 +1,12 @@
 containers:
 - container: Documentation
   name: Documentation
-  neatId: http://purl.org/cognite/neat/neatId_405cacec_8774_49a9_b7d2_1e02ff01cf99
   used_for: node
 - container: Facility
   name: Facility
-  neatId: http://purl.org/cognite/neat/neatId_f143262f_dc5c_4eed_8da0_365bf89897b9
   used_for: node
 - container: Pump
   name: Pump
-  neatId: http://purl.org/cognite/neat/neatId_1d53434b_b881_49b9_ae27_0da702f06b90
   used_for: node
 metadata:
   created: '2024-12-12T11:16:24.615000'
@@ -26,7 +23,7 @@ properties:
   description: digital object identifier
   immutable: false
   is_list: false
-  neatId: http://purl.org/cognite/neat/neatId_972a8469_1641_4f82_8b9d_2434e465e150
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation/doi
   nullable: true
   value_type: text
   view: Documentation
@@ -36,7 +33,7 @@ properties:
   immutable: false
   is_list: false
   name: name
-  neatId: http://purl.org/cognite/neat/neatId_23b8c1e9_3924_46de_beb1_3b9046685257
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation/name
   nullable: true
   value_type: text
   view: Documentation
@@ -47,7 +44,7 @@ properties:
   immutable: false
   is_list: true
   name: relatedPumps
-  neatId: http://purl.org/cognite/neat/neatId_bd9c66b3_ad3c_4d6d_9a3d_1fa7bc8960a9
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation/relatedPumps
   nullable: true
   value_type: Pump
   view: Documentation
@@ -57,7 +54,7 @@ properties:
   description: unique identifier
   immutable: false
   is_list: false
-  neatId: http://purl.org/cognite/neat/neatId_6b65a6a4_8b81_48f6_b38a_088ca65ed389
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/UUID
   nullable: true
   value_type: text
   view: Facility
@@ -67,7 +64,7 @@ properties:
   immutable: false
   is_list: false
   name: desc
-  neatId: http://purl.org/cognite/neat/neatId_17fc695a_07a0_4a6e_8822_e8f36c031199
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/desc
   nullable: true
   value_type: text
   view: Facility
@@ -75,7 +72,7 @@ properties:
 - connection: reverse(property=livesIn)
   is_list: true
   name: hasPumps
-  neatId: http://purl.org/cognite/neat/neatId_9a1de644_815e_46d1_bb8f_aa1837f8a88b
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/hasPumps
   value_type: Pump
   view: Facility
   view_property: hasPumps
@@ -84,7 +81,7 @@ properties:
   immutable: false
   is_list: false
   name: name
-  neatId: http://purl.org/cognite/neat/neatId_b74d0fb1_32e7_4629_8fad_c1a606cb0fb3
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/name
   nullable: true
   value_type: text
   view: Facility
@@ -92,7 +89,7 @@ properties:
 - connection: reverse(property=relatedPumps)
   is_list: true
   name: documentation
-  neatId: http://purl.org/cognite/neat/neatId_47378190_96da_4dac_b2ff_5d2a386ecbe0
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/documentation
   value_type: Documentation
   view: Pump
   view_property: documentation
@@ -102,7 +99,7 @@ properties:
   immutable: false
   is_list: false
   name: livesIn
-  neatId: http://purl.org/cognite/neat/neatId_c241330b_01a9_471f_9e8a_774bcf36d58b
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/livesIn
   nullable: true
   value_type: Facility
   view: Pump
@@ -112,7 +109,7 @@ properties:
   immutable: false
   is_list: false
   name: name
-  neatId: http://purl.org/cognite/neat/neatId_6c307511_b2b9_437a_a8df_6ec4ce4a2bbd
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/name
   nullable: true
   value_type: text
   view: Pump
@@ -123,7 +120,7 @@ properties:
   immutable: false
   is_list: false
   name: pressure
-  neatId: http://purl.org/cognite/neat/neatId_371ecd7b_27cd_4130_8722_9389571aa876
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/pressure
   nullable: true
   value_type: cdf_cdm:CogniteTimeSeries(version=v1)
   view: Pump
@@ -134,7 +131,7 @@ properties:
   immutable: false
   is_list: false
   name: temperature
-  neatId: http://purl.org/cognite/neat/neatId_1a2a73ed_562b_4f79_8374_59eef50bea63
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/temperature
   nullable: true
   value_type: cdf_cdm:CogniteTimeSeries(version=v1)
   view: Pump
@@ -145,7 +142,7 @@ properties:
   immutable: false
   is_list: false
   name: weight
-  neatId: http://purl.org/cognite/neat/neatId_5be6128e_18c2_4797_a142_ea7d17be3111
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/weight
   nullable: true
   value_type: float64(unit=mass:kilogm)
   view: Pump
@@ -155,7 +152,7 @@ properties:
   immutable: false
   is_list: false
   name: year
-  neatId: http://purl.org/cognite/neat/neatId_43b7a3a6_9a8d_4a03_980d_7b71d8f56413
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/year
   nullable: true
   value_type: int32
   view: Pump
@@ -163,44 +160,44 @@ properties:
 views:
 - implements: cdf_cdm:Cognite3DTransformation(version=v1),cdf_cdm:CogniteCubeMap(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_e2acf72f_9e57_4f7a_a0ee_89aed453dd32
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360Image
   view: cdf_cdm:Cognite360Image(version=v1)
 - implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1),cdf_cdm:CogniteAnnotation(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_3139d32c_93cd_49bf_9c94_1cf0dc98d2c1
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageAnnotation
   view: cdf_cdm:Cognite360ImageAnnotation(version=v1)
 - description: Represents a logical collection of Cognite360Image instances
   implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:Cognite3DRevision(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_a9488d99_0bbb_4599_91ce_5dd2b45ed1f0
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageCollection
   view: cdf_cdm:Cognite360ImageCollection(version=v1)
 - description: Navigational aid for traversing Cognite360ImageModel instances
   implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:Cognite3DModel(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_fc377a4c_4a15_444d_85e7_ce8a3a578a8e
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageModel
   view: cdf_cdm:Cognite360ImageModel(version=v1)
 - description: A way to group images across collections. Used for creating visual
     scan history
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_ddd1dfb2_3b98_4ef8_9af6_1a26146d3f31
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageStation
   view: cdf_cdm:Cognite360ImageStation(version=v1)
 - description: Groups revisions of 3D data of various kinds together (CAD, PointCloud,
     Image360)
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_7412b293_4729_4739_a14f_f3d719db3ad0
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DModel
   view: cdf_cdm:Cognite3DModel(version=v1)
 - description: This is the virtual position representation of an object in the physical
     world, connecting an asset to one or more 3D resources
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_29a3b2e9_5d65_4441_9588_42dea2bc372f
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DObject
   view: cdf_cdm:Cognite3DObject(version=v1)
 - description: Shared revision information for various 3D data types. Normally not
     used directly, but through CognitePointCloudRevision, Image360Collection or CogniteCADRevision
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_ab9099a4_35a2_40ae_9af3_05535ec42e08
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DRevision
   view: cdf_cdm:Cognite3DRevision(version=v1)
 - description: The Cognite3DTransformation object defines a comprehensive 3D transformation,
     enabling precise adjustments to an object's position, orientation, and size in
@@ -209,136 +206,136 @@ views:
     each axis to modify the object's dimensions. The object's transformation is defined
     in "CDF space", a coordinate system where the positive Z axis is the up direction
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_aefcfad8_efc8_4849_b3aa_7efe4458a885
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DTransformation
   view: cdf_cdm:Cognite3DTransformation(version=v1)
 - description: Represents activities. Activities typically happen over a period and
     have a start and end time.
   implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1),cdf_cdm:CogniteSchedulable(version=v1)
   in_model: true
   name: Activity
-  neatId: http://purl.org/cognite/neat/neatId_a28defe3_9bf0_4273_9247_6f57a5e5a5ab
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteActivity
   view: cdf_cdm:CogniteActivity(version=v1)
 - description: Annotation represents contextualization results or links
   implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_3eabedcb_baa8_4dd4_88bd_64072bcfbe01
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAnnotation
   view: cdf_cdm:CogniteAnnotation(version=v1)
 - description: Assets represent systems that support industrial functions or processes.
     Assets are often called 'functional location'.
   implements: cdf_cdm:CogniteVisualizable(version=v1),cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
   in_model: true
   name: Asset
-  neatId: http://purl.org/cognite/neat/neatId_451b4cf3_6123_4df7_b656_af7229d4beef
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAsset
   view: cdf_cdm:CogniteAsset(version=v1)
 - description: Represents the class of an asset.
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
   name: Asset class
-  neatId: http://purl.org/cognite/neat/neatId_b02b61c4_a3d7_4628_ace6_6fa2fd5166e6
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAssetClass
   view: cdf_cdm:CogniteAssetClass(version=v1)
 - description: Represents the type of an asset.
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
   name: Asset type
-  neatId: http://purl.org/cognite/neat/neatId_5304317f_af42_412f_b838_b3268e944239
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAssetType
   view: cdf_cdm:CogniteAssetType(version=v1)
 - description: Navigational aid for traversing CogniteCADModel instances
   implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:Cognite3DModel(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_0e51f30d_c6a7_4e39_84b0_32ccd7c524a5
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCADModel
   view: cdf_cdm:CogniteCADModel(version=v1)
 - description: Represents nodes from the 3D model that have been contextualized
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_ce177b4e_0837_48a3_9261_a7ab3aa2e4f9
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCADNode
   view: cdf_cdm:CogniteCADNode(version=v1)
 - implements: cdf_cdm:Cognite3DRevision(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_10f1bc81_448a_4a9e_a6b2_bc5b50c187fc
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCADRevision
   view: cdf_cdm:CogniteCADRevision(version=v1)
 - description: The cube map holds references to 6 images in used to visually represent
     the surrounding environment
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_9132b63e_f162_47e4_a9c3_49e03602f8ac
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCubeMap
   view: cdf_cdm:CogniteCubeMap(version=v1)
 - description: The describable core concept is used as a standard way of holding the
     bare minimum of information about the instance
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_366eb16f_508e_4ad7_b7c9_3acfe059a0ee
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteDescribable
   view: cdf_cdm:CogniteDescribable(version=v1)
 - description: Equipment represents physical supplies or devices.
   implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
   in_model: true
   name: Equipment
-  neatId: http://purl.org/cognite/neat/neatId_e27a984d_6548_41d0_bfcd_9eb1a7cad415
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteEquipment
   view: cdf_cdm:CogniteEquipment(version=v1)
 - description: Represents the type of equipment.
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
   name: Equipment type
-  neatId: http://purl.org/cognite/neat/neatId_24933b83_7577_40a9_a491_f0b2ea1fca65
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteEquipmentType
   view: cdf_cdm:CogniteEquipmentType(version=v1)
 - description: Represents files.
   implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
   in_model: true
   name: File
-  neatId: http://purl.org/cognite/neat/neatId_beb79919_3f22_4af8_a3be_d01d43cf2fde
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteFile
   view: cdf_cdm:CogniteFile(version=v1)
 - description: Represents the categories of files as determined by contextualization
     or categorization.
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
   name: File category
-  neatId: http://purl.org/cognite/neat/neatId_bf3c4c06_4343_48bc_89fa_6a688fb5d27b
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteFileCategory
   view: cdf_cdm:CogniteFileCategory(version=v1)
 - description: PointCloud volume definition
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_956269f0_e5d7_4875_adad_d6c795a76d79
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CognitePointCloudVolume
   view: cdf_cdm:CognitePointCloudVolume(version=v1)
 - description: CogniteSchedulable represents the metadata about when an activity (or
     similar) starts and ends.
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_ff50bde4_3825_47b8_9cab_cc97663f1c97
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteSchedulable
   view: cdf_cdm:CogniteSchedulable(version=v1)
 - description: The CogniteSourceSystem core concept is used to standardize the way
     source system is stored.
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_7e570ddf_8270_40a8_a369_b584ff5e9ff0
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteSourceSystem
   view: cdf_cdm:CogniteSourceSystem(version=v1)
 - in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_dc713d96_0c0f_4195_817a_f08a1745d6d8
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteSourceable
   view: cdf_cdm:CogniteSourceable(version=v1)
 - description: Represents a series of data points in time order.
   implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
   in_model: true
   name: Time series
-  neatId: http://purl.org/cognite/neat/neatId_28f49481_a0a0_4dc4_a720_9bdf1c11f735
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteTimeSeries
   view: cdf_cdm:CogniteTimeSeries(version=v1)
 - description: Represents a single unit of measurement
   implements: cdf_cdm:CogniteDescribable(version=v1)
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_98ae4334_6c12_4ce8_ae34_0454cac5b68c
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteUnit
   view: cdf_cdm:CogniteUnit(version=v1)
 - description: CogniteVisualizable defines the standard way to reference a related
     3D resource
   in_model: true
-  neatId: http://purl.org/cognite/neat/neatId_988c24c9_61b1_4d22_a280_1c4510435a10
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteVisualizable
   view: cdf_cdm:CogniteVisualizable(version=v1)
 - implements: cdf_cdm:CogniteFile(version=v1)
   in_model: true
   name: Documentation
-  neatId: http://purl.org/cognite/neat/neatId_759cde66_bacf_43d0_8b1f_9163ce9ff57f
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation
   view: Documentation
 - implements: cdf_cdm:CogniteAsset(version=v1)
   in_model: true
   name: Facility
-  neatId: http://purl.org/cognite/neat/neatId_ec1b8ca1_f91e_4d4c_9ff4_9b7889463e85
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility
   view: Facility
 - description: this is a description of the type Pump
   implements: cdf_cdm:CogniteAsset(version=v1)
   in_model: true
   name: Pump
-  neatId: http://purl.org/cognite/neat/neatId_4b0dbb41_8d52_48f1_942c_3fe860e7a113
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump
   view: Pump


### PR DESCRIPTION
Changes:
* RuleStore now has a provenance of type `RuleEntity`. This only has verified models, either info or info+dms.
* `.verify()` no longer has any effect. We can reintroduce it if we add support for keeping unverified model in the session.

**Note**: Removed pruning. As now only successful transformations moves the provenance forward.

Todo/discuss:
* Prefix transformer from unverified to verified.
* How to deal with manual transformations, i.e., importing when the rules store has rules in it. 