### PR TITLE
Export rules to excel with properties only from the same space as data model

### DIFF
--- a/cognite/neat/_alpha.py
+++ b/cognite/neat/_alpha.py
@@ -11,3 +11,4 @@ class AlphaWarning(UserWarning):
 
 class AlphaFlags:
     manual_rules_edit = AlphaWarning("enable_manual_edit")
+    same_space_properties_only_export = AlphaWarning("same-space-properties-only")

--- a/cognite/neat/_rules/exporters/_rules2excel.py
+++ b/cognite/neat/_rules/exporters/_rules2excel.py
@@ -79,6 +79,7 @@ class ExcelExporter(BaseExporter[VerifiedRules, Workbook]):
         reference_rules_with_prefix: tuple[VerifiedRules, str] | None = None,
         add_empty_rows: bool = False,
         hide_internal_columns: bool = True,
+        include_properties: Literal["same-space", "all"] = "all",
     ):
         self.sheet_prefix = sheet_prefix or ""
         if styling not in self.style_options:
@@ -89,6 +90,7 @@ class ExcelExporter(BaseExporter[VerifiedRules, Workbook]):
         self.reference_rules_with_prefix = reference_rules_with_prefix
         self.add_empty_rows = add_empty_rows
         self.hide_internal_columns = hide_internal_columns
+        self.include_properties = include_properties
 
     @property
     def description(self) -> str:
@@ -178,6 +180,11 @@ class ExcelExporter(BaseExporter[VerifiedRules, Workbook]):
                         side = Side(style="thin", color="000000")
                         cell.border = Border(left=side, right=side, top=side, bottom=side)
                     fill_color = next(fill_colors)
+
+                if is_properties and self.include_properties == "same-space":
+                    space = class_.split(":")[0] if ":" in class_ else rules.metadata.space
+                    if space != rules.metadata.space:
+                        continue
 
                 sheet.append(row)
                 if self._styling_level > 2 and is_properties:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,7 +56,7 @@ Changes are grouped as follows:
 - New method `neat.inspect.views()` to check the views in the data model.
 - [ALPHA] Support for external modification of data model from NeatSession and its re-import
 - Export of data model to Excel will now automatically hide the columns used for the internal neat processes.
-
+- [ALPHA] when exporting data model to Excel one can specify to export only properties of views which are in the same space as the data model
 
 ## [0.108.0] - 22-01-**2025**
 ### Added


### PR DESCRIPTION
This example shows result of command:

```
neat.to.excel("dm-redux.xlsx", include_properties="same-space")
```

![Screenshot 2025-01-31 at 13 19 37](https://github.com/user-attachments/assets/6c87c547-1d41-4981-adaa-3428aa008f2e)
