### PR TITLE
🕵️‍♂️ Neat 771 update ancestor plotting

### DIFF
--- a/cognite/neat/_rules/analysis/_base.py
+++ b/cognite/neat/_rules/analysis/_base.py
@@ -490,40 +490,27 @@ class RulesAnalysis:
         # Views with properties or used as ValueType
         # If a view is not used in properties or as ValueType, it is not added to the graph
         # as we typically do not have the properties for it.
-        used_views = {prop_.view for prop_ in rules.properties} | {
-            prop_.value_type for prop_ in rules.properties if isinstance(prop_.value_type, ViewEntity)
-        }
 
         # Add nodes and edges from Views sheet
         for view in rules.views:
-            if view.view not in used_views:
-                continue
-            # if possible use human-readable label coming from the view name
-            if not di_graph.has_node(view.view.suffix):
-                di_graph.add_node(view.view.suffix, label=view.view.suffix)
+            di_graph.add_node(view.view.suffix, label=view.view.suffix)
 
-                if format == "implements" and view.implements:
-                    for implement in view.implements:
-                        if not di_graph.has_node(implement.suffix):
-                            di_graph.add_node(implement.suffix, label=implement.suffix)
-
-                        di_graph.add_edge(
-                            view.view.suffix,
-                            implement.suffix,
-                            label="implements",
-                            dashes=True,
-                        )
+            if format == "implements" and view.implements:
+                for implement in view.implements:
+                    di_graph.add_node(implement.suffix, label=implement.suffix)
+                    di_graph.add_edge(
+                        view.view.suffix,
+                        implement.suffix,
+                        label="implements",
+                        dashes=True,
+                    )
 
         if format == "data-model":
             # Add nodes and edges from Properties sheet
             for prop_ in rules.properties:
                 if prop_.connection and isinstance(prop_.value_type, ViewEntity):
-                    if not di_graph.has_node(prop_.view.suffix):
-                        di_graph.add_node(prop_.view.suffix, label=prop_.view.suffix)
-
-                    if not di_graph.has_node(prop_.value_type.suffix):
-                        di_graph.add_node(prop_.value_type.suffix, label=prop_.value_type.suffix)
-
+                    di_graph.add_node(prop_.view.suffix, label=prop_.view.suffix)
+                    di_graph.add_node(prop_.value_type.suffix, label=prop_.value_type.suffix)
                     di_graph.add_edge(
                         prop_.view.suffix,
                         prop_.value_type.suffix,
@@ -541,32 +528,28 @@ class RulesAnalysis:
         # Add nodes and edges from Views sheet
         for class_ in rules.classes:
             # if possible use human readable label coming from the view name
-            if not di_graph.has_node(class_.class_.suffix):
-                di_graph.add_node(
-                    class_.class_.suffix,
-                    label=class_.name or class_.class_.suffix,
-                )
 
-                if format == "implements" and class_.implements:
-                    for parent in class_.implements:
-                        if not di_graph.has_node(parent.suffix):
-                            di_graph.add_node(parent.suffix, label=parent.suffix)
-                        di_graph.add_edge(
-                            class_.class_.suffix,
-                            parent.suffix,
-                            label="implements",
-                            dashes=True,
-                        )
+            di_graph.add_node(
+                class_.class_.suffix,
+                label=class_.name or class_.class_.suffix,
+            )
+
+            if format == "implements" and class_.implements:
+                for parent in class_.implements:
+                    di_graph.add_node(parent.suffix, label=parent.suffix)
+                    di_graph.add_edge(
+                        class_.class_.suffix,
+                        parent.suffix,
+                        label="implements",
+                        dashes=True,
+                    )
 
         if format == "data-model":
             # Add nodes and edges from Properties sheet
             for prop_ in rules.properties:
                 if isinstance(prop_.value_type, ClassEntity) and not isinstance(prop_.value_type, UnknownEntity):
-                    if not di_graph.has_node(prop_.class_.suffix):
-                        di_graph.add_node(prop_.class_.suffix, label=prop_.class_.suffix)
-
-                    if not di_graph.has_node(prop_.value_type.suffix):
-                        di_graph.add_node(prop_.value_type.suffix, label=prop_.value_type.suffix)
+                    di_graph.add_node(prop_.class_.suffix, label=prop_.class_.suffix)
+                    di_graph.add_node(prop_.value_type.suffix, label=prop_.value_type.suffix)
 
                     di_graph.add_edge(
                         prop_.class_.suffix,

--- a/cognite/neat/_rules/analysis/_base.py
+++ b/cognite/neat/_rules/analysis/_base.py
@@ -487,10 +487,6 @@ class RulesAnalysis:
 
         rules = self.dms
 
-        # Views with properties or used as ValueType
-        # If a view is not used in properties or as ValueType, it is not added to the graph
-        # as we typically do not have the properties for it.
-
         # Add nodes and edges from Views sheet
         for view in rules.views:
             di_graph.add_node(view.view.suffix, label=view.view.suffix)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ Changes are grouped as follows:
 - Setting of proper value type for default
 - Errors that do not have loc are now well handled in neat session
 - Validation on used spaces
+- Data model implements visualization in NeatSession
 
 ## [0.110.0] - 17-02-**2025**
 ### Added


### PR DESCRIPTION
We are not plotting entire depth of data model implements (i.e. all the ancestors) when running method:
neat.show.data_model.implements()

The bug was caused when creating di-graph (networkx) from data model. We simply were too restrictive which nodes and edges should be added to di-graph. This has been now been fixed and full implements / inheritance is derived as expected.

Full implement depth is now being shown in visualization of data model in NeatSession

![improve-viz](https://github.com/user-attachments/assets/04a007df-202d-460c-983b-fd5740c91351)