### PR TITLE
[NEAT-796] 🤨 Display Name

### DIFF
--- a/cognite/neat/_session/_set.py
+++ b/cognite/neat/_session/_set.py
@@ -23,14 +23,20 @@ class SetAPI:
         self._verbose = verbose
         self.instances = SetInstances(state, verbose)
 
-    def data_model_id(self, new_model_id: dm.DataModelId | tuple[str, str, str]) -> IssueList:
+    def data_model_id(self, new_model_id: dm.DataModelId | tuple[str, str, str], name: str | None = None) -> IssueList:
         """Sets the data model ID of the latest verified data model. Set the data model id as a tuple of strings
         following the template (<data_model_space>, <data_model_name>, <data_model_version>).
+
+        Args:
+            new_model_id (dm.DataModelId | tuple[str, str, str]): The new data model id.
+            name (str, optional): The display name of the data model. If not set, the external ID will be used
+                to generate the name.
 
         Example:
             Set a new data model id:
             ```python
             neat.set.data_model_id(("my_data_model_space", "My_Data_Model", "v1"))
+            neat.set.data_model_id(("my_data_model_space", "MyDataModel", "v1"), name="My Data Model")
             ```
         """
         if self._state.rule_store.empty:

--- a/cognite/neat/_utils/text.py
+++ b/cognite/neat/_utils/text.py
@@ -1,10 +1,43 @@
 import re
 import urllib.parse
-from collections.abc import Collection
+from collections.abc import Collection, Set
 from re import Pattern
 from typing import Any
 
 from cognite.neat._rules._constants import get_reserved_words
+
+PREPOSITIONS = frozenset(
+    {
+        "in",
+        "on",
+        "at",
+        "by",
+        "for",
+        "with",
+        "about",
+        "against",
+        "between",
+        "into",
+        "through",
+        "during",
+        "before",
+        "after",
+        "above",
+        "below",
+        "to",
+        "from",
+        "up",
+        "down",
+        "out",
+        "off",
+        "over",
+        "under",
+        "again",
+        "further",
+        "then",
+        "once",
+    }
+)
 
 
 def to_camel_case(string: str) -> str:
@@ -129,6 +162,18 @@ def to_snake_case(string: str) -> str:
     else:
         words = pattern.findall(string)
     return "_".join(map(str.lower, words))
+
+
+def to_words(string: str) -> str:
+    """Converts snake_case camelCase or PascalCase to words."""
+    return to_snake_case(string).replace("_", " ")
+
+
+def title(text: str, skip_words: Set[str] = PREPOSITIONS) -> str:
+    """Converts text to title case, skipping prepositions."""
+    words = (word.lower() for word in text.split())
+    titled_words = (word.capitalize() if word not in skip_words else word for word in words)
+    return " ".join(titled_words)
 
 
 def sentence_or_string_to_camel(string: str) -> str:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ Changes are grouped as follows:
 - Setting of proper value type for default
 - Errors that do not have loc are now well handled in neat session
 - Validation on used spaces
+- The `neat.set.data_model_id()` now also sets the display name of the data model.
 
 ## [0.110.0] - 17-02-**2025**
 ### Added

--- a/tests/tests_integration/test_session/test_graph_flow/test_aml_to_dms.yml
+++ b/tests/tests_integration/test_session/test_graph_flow/test_aml_to_dms.yml
@@ -12,7 +12,7 @@ rules:
     creator: NEAT
     external_id: AML
     logical: http://purl.org/cognite/neat/data-model/verified/logical/neat_space/NeatInferredDataModel/v1
-    name: Inferred Model
+    name: Aml
     role: DMS Architect
     source_id: http://purl.org/cognite/neat/data-model/verified/physical/aml_playground/AML/terminology_3.0
     space: aml_playground

--- a/tests/tests_integration/test_session/test_graph_flow/test_dexpi_to_dms.yml
+++ b/tests/tests_integration/test_session/test_graph_flow/test_dexpi_to_dms.yml
@@ -88,7 +88,7 @@ rules:
     creator: NEAT
     external_id: DEXPI
     logical: http://purl.org/cognite/neat/data-model/verified/logical/neat_space/NeatInferredDataModel/v1
-    name: Inferred Model
+    name: Dexpi
     role: DMS Architect
     source_id: http://purl.org/cognite/neat/data-model/verified/physical/dexpi_playground/DEXPI/v1.3.1
     space: dexpi_playground

--- a/tests/tests_integration/test_session/test_graph_flow/test_snapshot_workflow_to_python.yml
+++ b/tests/tests_integration/test_session/test_graph_flow/test_snapshot_workflow_to_python.yml
@@ -2189,7 +2189,7 @@ rules:
     creator: Cognite
     external_id: WindFarm
     logical: http://purl.org/cognite/neat/data-model/verified/logical/neat_space/ClassicDataModel/v1
-    name: ClassicDataModel
+    name: Wind Farm
     role: DMS Architect
     source_id: http://purl.org/cognite/neat/data-model/verified/physical/sp_windfarm/WindFarm/v1
     space: sp_windfarm

--- a/tests/tests_unit/test_utils/test_text.py
+++ b/tests/tests_unit/test_utils/test_text.py
@@ -34,7 +34,7 @@ class TestToWords:
         ],
     )
     def test_to_words(self, input_: str, expected: list[str]) -> None:
-        assert to_words(actual) == expected
+        assert to_words(input_) == expected
 
 
 class TestNamingStandardization:

--- a/tests/tests_unit/test_utils/test_text.py
+++ b/tests/tests_unit/test_utils/test_text.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cognite.neat._utils.text import NamingStandardization, to_camel_case
+from cognite.neat._utils.text import NamingStandardization, to_camel_case, to_words
 
 
 class TestToCamel:
@@ -19,6 +19,22 @@ class TestToCamel:
     )
     def test_to_camel(self, actual: str, expected: str) -> None:
         assert to_camel_case(actual) == expected
+
+
+class TestToWords:
+    @pytest.mark.parametrize(
+        "actual, expected",
+        [
+            ("tagName", "tag name"),
+            ("aB", "a b"),
+            ("workOrderID", "work order id"),
+            ("camelCaseAlready", "camel case already"),
+            ("a_Strange_CombinationOfCasing", "a strange combination of casing"),
+            ("shouting_snake_case_1234", "shouting snake case 1234"),
+        ],
+    )
+    def test_to_words(self, actual: str, expected: list[str]) -> None:
+        assert to_words(actual) == expected
 
 
 class TestNamingStandardization:

--- a/tests/tests_unit/test_utils/test_text.py
+++ b/tests/tests_unit/test_utils/test_text.py
@@ -23,7 +23,7 @@ class TestToCamel:
 
 class TestToWords:
     @pytest.mark.parametrize(
-        "actual, expected",
+        "input_, expected",
         [
             ("tagName", "tag name"),
             ("aB", "a b"),
@@ -33,7 +33,7 @@ class TestToWords:
             ("shouting_snake_case_1234", "shouting snake case 1234"),
         ],
     )
-    def test_to_words(self, actual: str, expected: list[str]) -> None:
+    def test_to_words(self, input_: str, expected: list[str]) -> None:
         assert to_words(actual) == expected
 
 


### PR DESCRIPTION
## Before
Before when you set data model id, the display name of the old model was kept leading to confusion when deploying a model.

![image](https://github.com/user-attachments/assets/8fce3d20-60f2-4a95-8353-35f27e0f8373)

## After
Now allow the user to set the display name, and if it is not set, it is generated based on the external ID of the model.
