### PR TITLE
🤖 Allow Improved Header in Changelog.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,6 @@ Please describe the change you have made.
 - [ ] Skip
 
 ## Changelog
-### Added/Changed/Improved/Removed
+### Added/Changed/Improved/Removed/Fixed
 
 - My change.

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -151,7 +151,6 @@ jobs:
             coverageFile: coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
             thresholdAll: 0.6
-
   validate-description:
     name: Validate PR description
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,13 +33,13 @@ jobs:
         run: git describe --tags --abbrev=0 > last_version.txt
       - name: Bump Version
         run: python dev.py bump --verbose
-      - name: Create CHANGELOG entry
-        run: python dev.py changelog
       - id: version
         name: Read the new version
         # Read the version from the cognite/neat/_version.py file
         run: echo "version=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' cognite/neat/_version.py)" >> $GITHUB_ENV
-
+      - name: Create CHANGELOG entry
+        if: env.version != '0.0.0'
+        run: python dev.py changelog
       - name: Build package
         if: env.version != '0.0.0'
         run: poetry build

--- a/dev.py
+++ b/dev.py
@@ -75,7 +75,7 @@ def create_changelog_entry() -> None:
     if version_bump == "skip":
         print("No changes to release.")
         return
-    if changelog_text:
+    if changelog_text is None:
         print(f"No changelog entry found in the last commit message. This is required for a {version_bump} release.")
         raise SystemExit(1)
     _validate_changelog_entry(changelog_text)

--- a/dev.py
+++ b/dev.py
@@ -14,7 +14,7 @@ REPO_ROOT = Path(__file__).parent
 VERSION_FILE = REPO_ROOT / "cognite" / "neat" / "_version.py"
 
 
-VALID_CHANGELOG_HEADERS = {"Added", "Changed", "Removed", "Fixed"}
+VALID_CHANGELOG_HEADERS = {"Added", "Changed", "Removed", "Fixed", "Improved"}
 BUMP_OPTIONS = Literal["major", "minor", "patch", "skip"]
 VALID_BUMP_OPTIONS = get_args(BUMP_OPTIONS)
 LAST_GIT_MESSAGE_FILE = REPO_ROOT / "last_git_message.txt"
@@ -75,13 +75,16 @@ def create_changelog_entry() -> None:
     if version_bump == "skip":
         print("No changes to release.")
         return
+    if changelog_text:
+        print(f"No changelog entry found in the last commit message. This is required for a {version_bump} release.")
+        raise SystemExit(1)
     _validate_changelog_entry(changelog_text)
 
     CHANGELOG_ENTRY_FILE.write_text(changelog_text, encoding="utf-8")
     print(f"Changelog entry written to {CHANGELOG_ENTRY_FILE}.")
 
 
-def _read_last_commit_message() -> tuple[str, str]:
+def _read_last_commit_message() -> tuple[str, str | None]:
     last_git_message = LAST_GIT_MESSAGE_FILE.read_text()
     if "## Bump" not in last_git_message:
         print("No bump entry found in the last commit message.")
@@ -89,8 +92,7 @@ def _read_last_commit_message() -> tuple[str, str]:
 
     after_bump = last_git_message.split("## Bump")[1].strip()
     if "## Changelog" not in after_bump:
-        print("No changelog entry found in the last commit message.")
-        raise SystemExit(1)
+        return after_bump, None
 
     bump_text, changelog_text = after_bump.split("## Changelog")
     return bump_text, changelog_text
@@ -117,7 +119,7 @@ def _validate_changelog_entry(changelog_text: str) -> None:
                 raise SystemExit(1)
             header_text = item.children[0].children
             if header_text not in VALID_CHANGELOG_HEADERS:
-                print(f"Unexpected header in changelog: {header_text}. Must be one of {header_text}.")
+                print(f"Unexpected header in changelog: {header_text}. Must be one of {VALID_CHANGELOG_HEADERS}.")
                 raise SystemExit(1)
             if header_text in seen_headers:
                 print(f"Duplicate header in changelog: {header_text}.")


### PR DESCRIPTION
# Description

Allow Improved header in changelog. In addition, no longer require a changelog entry when you select `skip` in the bump section.

**Note** Repeating the changelog from PR #1022 as that was not released due to the `Improved` header was not allowed. This is unlikely to happen in the future as a new check of the PR description will validate the bump and changelog entry. 

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Improved
- The `neat.to.cdf.instances()` no longer loads CogniteAsset (and extensions) twice.