### PR TITLE
🐛 DMS Equals filter on property

### DIFF
--- a/cognite/neat/_rules/models/entities/_wrapped.py
+++ b/cognite/neat/_rules/models/entities/_wrapped.py
@@ -104,7 +104,11 @@ class DMSFilter(WrappedEntity):
     @classmethod
     def from_dms_filter(cls, filter: dm.Filter) -> "DMSFilter":
         dumped = filter.dump()
-        if (body := dumped.get(dm.filters.Equals._filter_name)) and (value := body.get("value")):
+        if (
+            (body := dumped.get(dm.filters.Equals._filter_name))
+            and (value := body.get("value"))
+            and isinstance(value, dict)
+        ):
             space = value.get("space")
             external_id = value.get("externalId")
             if space is not None and external_id is not None:

--- a/tests/tests_unit/rules/test_models/test_wrapped_entities.py
+++ b/tests/tests_unit/rules/test_models/test_wrapped_entities.py
@@ -106,6 +106,11 @@ class TestWrappedEntities:
                     ]
                 ),
             ),
+            pytest.param(
+                dm.filters.Equals(["govern-space", "Property", "type"], "Input"),
+                RawFilter(filter='{"equals": {"property": ["govern-space", "Property", "type"], "value": "Input"}}'),
+                id="Equal filter on property",
+            ),
         ],
     )
     def test_from_dms_filter(self, filter_: dm.Filter, expected: DMSFilter) -> None:


### PR DESCRIPTION
# Description

See changelog below.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- Reading a data model with a view with an equals filter on a property no longer raises a `AttributeError: 'str' object has no attribute 'get'` error.
