### PR TITLE
[NEAT-810] 😦 No warning from reading core

### DIFF
--- a/cognite/neat/_rules/models/dms/_validation.py
+++ b/cognite/neat/_rules/models/dms/_validation.py
@@ -16,7 +16,12 @@ from cognite.client.data_classes.data_modeling.views import (
 from cognite.neat._client import NeatClient
 from cognite.neat._client.data_classes.data_modeling import ViewApplyDict
 from cognite.neat._client.data_classes.schema import DMSSchema
-from cognite.neat._constants import COGNITE_MODELS, DMS_CONTAINER_PROPERTY_SIZE_LIMIT, DMS_VIEW_CONTAINER_SIZE_LIMIT
+from cognite.neat._constants import (
+    COGNITE_MODELS,
+    COGNITE_SPACES,
+    DMS_CONTAINER_PROPERTY_SIZE_LIMIT,
+    DMS_VIEW_CONTAINER_SIZE_LIMIT,
+)
 from cognite.neat._issues import IssueList, NeatError
 from cognite.neat._issues.errors import (
     CDFMissingClientError,
@@ -455,7 +460,7 @@ class DMSValidation:
     def _validate_raw_filter(self) -> IssueList:
         issue_list = IssueList()
         for view in self._views:
-            if view.filter_ and isinstance(view.filter_, RawFilter):
+            if view.filter_ and isinstance(view.filter_, RawFilter) and view.view.space not in COGNITE_SPACES:
                 issue_list.append(
                     NotNeatSupportedFilterWarning(view.view.as_id()),
                 )

--- a/tests/tests_integration/test_session/test_read.py
+++ b/tests/tests_integration/test_session/test_read.py
@@ -73,3 +73,10 @@ class TestRead:
             neat._state.rule_store.last_issues[0],
             ViewsAndDataModelNotInSameSpaceWarning,
         )
+
+    def test_read_core_no_warnings(self, cognite_client: CogniteClient) -> None:
+        neat = NeatSession(client=cognite_client)
+
+        issues = neat.read.examples.core_data_model()
+
+        assert len(issues) == 0


### PR DESCRIPTION
# Description

### Before
![image](https://github.com/user-attachments/assets/ebc08cad-962a-458c-8302-2b94568f5b14)

### After
![image](https://github.com/user-attachments/assets/f13788c4-3d02-4529-9f2e-918b561ba8e0)


## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed
- Reading the `CogniteCore` model, `neat.read.examples.core_data_model()`, no longer give warnings.
