### PR TITLE
[NEAT-734]🤼 Appropriate error message when user does illegal actions

### DIFF
--- a/cognite/neat/_session/_base.py
+++ b/cognite/neat/_session/_base.py
@@ -165,6 +165,9 @@ class NeatSession:
             neat.convert()
             ```
         """
+        self._state._raise_exception_if_condition_not_met(
+            "Convert to physical", has_dms_rules=False, has_information_rules=True
+        )
         converter = InformationToDMS(reserved_properties=reserved_properties)
 
         issues = self._state.rule_transform(converter)

--- a/cognite/neat/_session/_read.py
+++ b/cognite/neat/_session/_read.py
@@ -362,6 +362,11 @@ class ExcelReadAPI(BaseReadAPI):
         if enable_manual_edit:
             warnings.filterwarnings("default")
             AlphaFlags.manual_rules_edit.warn()
+        else:
+            self._state._raise_exception_if_condition_not_met(
+                "Read Excel Rules",
+                empty_rules_store_required=True,
+            )
 
         return self._state.rule_import(importers.ExcelImporter(path), enable_manual_edit)
 
@@ -381,6 +386,10 @@ class YamlReadAPI(BaseReadAPI):
             neat.read.yaml("path_to_toolkit_yamls")
             ```
         """
+        self._state._raise_exception_if_condition_not_met(
+            "Read YAML data model",
+            empty_rules_store_required=True,
+        )
         reader = NeatReader.create(io)
         path = reader.materialize_path()
         importer: BaseImporter
@@ -634,6 +643,10 @@ class RDFReadAPI(BaseReadAPI):
         return self._state.rule_import(importer)
 
     def instances(self, io: Any) -> IssueList:
+        self._state._raise_exception_if_condition_not_met(
+            "Read RDF Instances",
+            empty_rules_store_required=True,
+        )
         reader = NeatReader.create(io)
         self._state.instances.store.write(extractors.RdfFileExtractor(reader.materialize_path()))
         return IssueList()

--- a/cognite/neat/_session/_state.py
+++ b/cognite/neat/_session/_state.py
@@ -72,6 +72,8 @@ class SessionState:
         empty_instances_store_required: bool = False,
         instances_required: bool = False,
         client_required: bool = False,
+        has_information_rules: bool | None = None,
+        has_dms_rules: bool | None = None,
     ) -> None:
         """Set conditions for raising an error in the session that are used by various methods in the session."""
         condition = set()
@@ -80,6 +82,12 @@ class SessionState:
         if client_required and not self.client:
             condition.add(f"{activity} expects a client in NEAT session")
             suggestion.add("Please provide a client")
+        if has_information_rules is True and self.rule_store.try_get_last_information_rules is None:
+            condition.add(f"{activity} expects information rules in NEAT session")
+            suggestion.add("Read in information rules to neat session")
+        if has_dms_rules is False and self.rule_store.try_get_last_dms_rules is not None:
+            condition.add(f"{activity} expects no DMS rules in NEAT session")
+            suggestion.add("Start new session")
         if empty_rules_store_required and not self.rule_store.empty:
             condition.add(f"{activity} expects no data model in NEAT session")
             suggestion.add("Start new session")

--- a/cognite/neat/_session/_state.py
+++ b/cognite/neat/_session/_state.py
@@ -78,7 +78,7 @@ class SessionState:
         """Set conditions for raising an error in the session that are used by various methods in the session."""
         condition = set()
         suggestion = set()
-
+        try_again = True
         if client_required and not self.client:
             condition.add(f"{activity} expects a client in NEAT session")
             suggestion.add("Please provide a client")
@@ -86,8 +86,9 @@ class SessionState:
             condition.add(f"{activity} expects information rules in NEAT session")
             suggestion.add("Read in information rules to neat session")
         if has_dms_rules is False and self.rule_store.try_get_last_dms_rules is not None:
-            condition.add(f"{activity} expects no DMS rules in NEAT session")
-            suggestion.add("Start new session")
+            condition.add(f"{activity} expects no DMS data model in NEAT session")
+            suggestion.add("You already have a DMS data model in the session")
+            try_again = False
         if empty_rules_store_required and not self.rule_store.empty:
             condition.add(f"{activity} expects no data model in NEAT session")
             suggestion.add("Start new session")
@@ -99,7 +100,10 @@ class SessionState:
             suggestion.add("Read in instances to neat session")
 
         if condition:
-            raise NeatSessionError(". ".join(condition) + ". " + ". ".join(suggestion) + ". And try again.")
+            message = ". ".join(condition) + ". " + ". ".join(suggestion) + "."
+            if try_again:
+                message += " And try again."
+            raise NeatSessionError(message)
 
 
 class InstancesState:

--- a/cognite/neat/_store/_rules_store.py
+++ b/cognite/neat/_store/_rules_store.py
@@ -422,6 +422,20 @@ class NeatRulesStore:
         return identifier + f"/Iteration_{self._iteration_by_id[identifier]}"
 
     @property
+    def try_get_last_dms_rules(self) -> DMSRules | None:
+        if not self.provenance:
+            return None
+        if self.provenance[-1].target_entity.dms is None:
+            return None
+        return self.provenance[-1].target_entity.dms
+
+    @property
+    def try_get_last_information_rules(self) -> InformationRules | None:
+        if not self.provenance:
+            return None
+        return self.provenance[-1].target_entity.information
+
+    @property
     def last_verified_dms_rules(self) -> DMSRules:
         if not self.provenance:
             raise EmptyStore()


### PR DESCRIPTION
# Description

## Before
![image](https://github.com/user-attachments/assets/3035bed6-87b7-4970-9e8c-54eac0a620f6)

## After
![image](https://github.com/user-attachments/assets/a53f89db-e11b-49b5-bd84-985814d69165)


## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Improved

- Give appropriate error messages if the user execute the `NeatSession` methods in the wrong order.
