### PR TITLE
[NEAT-823] 🧙‍♂️ Rename create to template

### DIFF
--- a/cognite/neat/_session/_base.py
+++ b/cognite/neat/_session/_base.py
@@ -23,7 +23,6 @@ from cognite.neat._store._rules_store import RulesEntity
 from cognite.neat._utils.auxiliary import local_import
 
 from ._collector import _COLLECTOR, Collector
-from ._create import CreateAPI
 from ._drop import DropAPI
 from ._explore import ExploreAPI
 from ._fix import FixAPI
@@ -35,6 +34,7 @@ from ._set import SetAPI
 from ._show import ShowAPI
 from ._state import SessionState
 from ._subset import SubsetAPI
+from ._template import TemplateAPI
 from ._to import ToAPI
 from .engine import load_neat_engine
 from .exceptions import session_class_wrapper
@@ -104,7 +104,7 @@ class NeatSession:
         self.mapping = MappingAPI(self._state)
         self.drop = DropAPI(self._state)
         self.subset = SubsetAPI(self._state)
-        self.create = CreateAPI(self._state)
+        self.template = TemplateAPI(self._state)
         self._explore = ExploreAPI(self._state)
         self.opt = OptAPI()
         self.opt._display()

--- a/cognite/neat/_session/_template.py
+++ b/cognite/neat/_session/_template.py
@@ -19,7 +19,7 @@ from .exceptions import NeatSessionError, session_class_wrapper
 @session_class_wrapper
 class TemplateAPI:
     """
-    Create new data model based on the given data.
+    Create a template for a new data model.
     """
 
     def __init__(self, state: SessionState):
@@ -31,7 +31,10 @@ class TemplateAPI:
         org_name: str = "CopyOf",
         dummy_property: str = "GUID",
     ) -> IssueList:
-        """Uses the current data model as a basis to create enterprise data model
+        """Creates a template for an enterprise model based on the current data model in the session.
+        An enterprise data model is a model that is used for read and write of instances. In addition,
+        it is governed by the organization.
+        The basis for an enterprise data model should be a Cognite Data Model.
 
         Args:
             data_model_id: The enterprise data model id that is being created
@@ -76,7 +79,9 @@ class TemplateAPI:
         direct_property: str = "enterprise",
         view_prefix: str = "Enterprise",
     ) -> IssueList:
-        """Uses the current data model as a basis to create solution data model
+        """Creates a template for a solution model based on the current data model in the session.
+        A solution data model is for read and write of instances.
+        The basis for a solution data model should be an enterprise data model.
 
         Args:
             data_model_id: The solution data model id that is being created.
@@ -121,7 +126,9 @@ class TemplateAPI:
         data_model_id: DataModelIdentifier,
         include: Literal["same-space", "all"] = "same-space",
     ) -> IssueList:
-        """Uses the current data model as a basis to create data product data model.
+        """Creates a template for a data product model based on the current data model in the session.
+        A data product model is only used for reading of instances.
+        It can be based on any data model, but typically it is based on an enterprise or solution data model.
 
         A data product model is a data model that ONLY maps to containers and do not use implements. This is
         typically used for defining the data in a data product.

--- a/cognite/neat/_session/_template.py
+++ b/cognite/neat/_session/_template.py
@@ -17,7 +17,7 @@ from .exceptions import NeatSessionError, session_class_wrapper
 
 
 @session_class_wrapper
-class CreateAPI:
+class TemplateAPI:
     """
     Create new data model based on the given data.
     """

--- a/docs/reference/NeatSession/create.md
+++ b/docs/reference/NeatSession/create.md
@@ -1,1 +1,0 @@
-::: cognite.neat._session._create.CreateAPI

--- a/docs/reference/NeatSession/template.md
+++ b/docs/reference/NeatSession/template.md
@@ -1,0 +1,1 @@
+::: cognite.neat._session._template.TemplateAPI

--- a/docs/tutorials/data-modeling/core_extension.ipynb
+++ b/docs/tutorials/data-modeling/core_extension.ipynb
@@ -163,7 +163,7 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "Dropped \u001b[1;36m22\u001b[0m views.\n"
+       "Dropped \u001B[1;36m22\u001B[0m views.\n"
       ]
      },
      "metadata": {},
@@ -222,9 +222,7 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "neat.create.enterprise_model(data_model_id=(\"enterprise_extension\", \"ExtensionCore\", \"v1\"))"
-   ]
+   "source": "neat.template.enterprise_model(data_model_id=(\"enterprise_extension\", \"ExtensionCore\", \"v1\"))"
   },
   {
    "cell_type": "markdown",

--- a/docs/tutorials/data-onboarding/classic_knowledge_graph.ipynb
+++ b/docs/tutorials/data-onboarding/classic_knowledge_graph.ipynb
@@ -795,9 +795,7 @@
    "id": "cfdbfe3d-a86a-452a-a46c-247f96db6ff2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "neat.create.data_product_model((\"sp_doctrino_readonly\", \"WindFarmReadOnlny\", \"v1\"))"
-   ]
+   "source": "neat.template.data_product_model((\"sp_doctrino_readonly\", \"WindFarmReadOnlny\", \"v1\"))"
   },
   {
    "cell_type": "markdown",

--- a/tests/tests_end_to_end/test_rules_flow.py
+++ b/tests/tests_end_to_end/test_rules_flow.py
@@ -92,18 +92,18 @@ class TestImportersToYAMLExporter:
 
             neat.verify()
 
-            neat.create.enterprise_model(("sp_enterprise", "Enterprise", "v1"), "Neat")
+            neat.template.enterprise_model(("sp_enterprise", "Enterprise", "v1"), "Neat")
 
             enterprise_yml_str = neat.to.yaml()
 
             # Writing to CDF such that the mock client can look up the containers in the data product step.
             neat.to.cdf.data_model()
 
-            neat.create.solution_model(("sp_solution", "Solution", "v1"))
+            neat.template.solution_model(("sp_solution", "Solution", "v1"))
 
             solution_yml_str = neat.to.yaml()
 
-            neat.create.data_product_model(("sp_data_product", "DataProduct", "v1"))
+            neat.template.data_product_model(("sp_data_product", "DataProduct", "v1"))
 
             data_product_yml_str = neat.to.yaml()
 

--- a/tests/tests_integration/test_session/test_create_enterprise.py
+++ b/tests/tests_integration/test_session/test_create_enterprise.py
@@ -11,7 +11,7 @@ class TestCreateAPI:
         neat = NeatSession(cognite_client)
         neat.read.examples.pump_example()
 
-        neat.create.enterprise_model(("my_space", "MySpace", "v1"))
+        neat.template.enterprise_model(("my_space", "MySpace", "v1"))
 
         result_path = tmp_path / "result.xlsx"
         neat.to.excel(result_path, include_reference=True, include_properties="same-space")

--- a/tests/tests_integration/test_session/test_graph_flow.py
+++ b/tests/tests_integration/test_session/test_graph_flow.py
@@ -53,7 +53,7 @@ class TestExtractToLoadFlow:
 
         rules_str = neat.to.yaml(format="neat")
 
-        neat.create.data_product_model(("sp_data_product", "DataProduct", "v1"))
+        neat.template.data_product_model(("sp_data_product", "DataProduct", "v1"))
 
         data_product_dict = yaml.safe_load(neat.to.yaml(format="neat"))
 

--- a/tests/tests_integration/test_session/test_read.py
+++ b/tests/tests_integration/test_session/test_read.py
@@ -26,7 +26,7 @@ class TestRead:
         issues = neat.read.yaml(data.REFERENCING_CORE, format="toolkit")
         assert not issues.has_errors, issues
 
-        neat.create.data_product_model(("sp_my_space", "MyProduct", "v1"))
+        neat.template.data_product_model(("sp_my_space", "MyProduct", "v1"))
 
         exported_yaml_str = neat.to.yaml()
         exported_rules = yaml.safe_load(exported_yaml_str)


### PR DESCRIPTION
# Description

We realized that `create` is misleading, thus renaming this API to template as what we are creating is a template. For example `neat.template.solution_model(...)` reads more precisely what we are doing instead of `neat.create.solution_model(...)`. 

## Bump

- [ ] Patch
- [x] Minor
- [ ] Skip

## Changelog
### Changed

- [BREAKING] Renamed the `neat.create` to `neat.template`. 
