### PR TITLE
Bug neat 818

### DIFF
--- a/cognite/neat/_graph/extractors/_classic_cdf/_classic.py
+++ b/cognite/neat/_graph/extractors/_classic_cdf/_classic.py
@@ -389,7 +389,7 @@ class ClassicGraphExtractor(KnowledgeGraphExtractor):
             for chunk in self._chunk(
                 list(self._asset_parent_uri_by_id.keys()), description="Extracting asset parent data sets"
             ):
-                assets = self._client.assets.retrieve_multiple(id=list(chunk), ignore_unknown_ids=True)
+                assets = self._client.assets.retrieve_multiple(ids=list(chunk), ignore_unknown_ids=True)
                 for asset in assets:
                     if asset.data_set_id is None:
                         continue

--- a/tests/tests_integration/test_session/test_read.py
+++ b/tests/tests_integration/test_session/test_read.py
@@ -80,3 +80,10 @@ class TestRead:
         issues = neat.read.examples.core_data_model()
 
         assert len(issues) == 0
+
+    def test_read_classic_graph(self, cognite_client: CogniteClient) -> None:
+        neat = NeatSession(client=cognite_client)
+
+        issues = neat.read.cdf.classic.graph(root_asset_external_id="dad2a40917a")
+
+        assert len(issues) == 0

--- a/tests/tests_integration/test_session/test_read.py
+++ b/tests/tests_integration/test_session/test_read.py
@@ -84,6 +84,6 @@ class TestRead:
     def test_read_classic_graph(self, cognite_client: CogniteClient) -> None:
         neat = NeatSession(client=cognite_client)
 
-        issues = neat.read.cdf.classic.graph(root_asset_external_id="dad2a40917a")
+        issues = neat.read.cdf.classic.graph(root_asset_external_id="Utsira")
 
         assert len(issues) == 0


### PR DESCRIPTION
# Description

TypeError: AssetsAPI.retrieve_multiple() got an unexpected keyword argument 'id error when running
neat.read.cdf.classic.graph(root_asset_external_id=xxx, identifier="externalId")

## Bump

- [ ] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Added/Changed/Improved/Removed/Fixed

- My change.
