### PR TITLE
[prep NEAT-852]🕵🏼DMSSchema from read model

### DIFF
--- a/cognite/neat/_client/data_classes/schema.py
+++ b/cognite/neat/_client/data_classes/schema.py
@@ -318,6 +318,7 @@ class DMSSchema:
             model (dm.DataModel): The read model to load the schema from.
         """
         write_model = model.as_write()
+        write_model.views = [view.as_id() for view in model.views or []]
         views = ViewApplyDict([view.as_write() for view in model.views])
         containers = ContainerApplyDict()
         for view in model.views:


### PR DESCRIPTION
# Description

Added an internal helper method to the `DMSSchema` that creates the schema from a read version of a data model. This is useful when we get model from a user and need this for debugging.

I used this one to hunt down the bug in #1059 

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip