### PR TITLE
[NEAT-852] 𓀎 Raw filter filter with special character fix.

### DIFF
--- a/cognite/neat/_rules/models/entities/_wrapped.py
+++ b/cognite/neat/_rules/models/entities/_wrapped.py
@@ -42,7 +42,7 @@ class WrappedEntity(BaseModel, ABC):
         # raw filter case:
         if cls.__name__ == "RawFilter":
             if data.startswith("rawFilter(") and data.endswith(")"):
-                return {"filter": data.removeprefix("rawFilter(").removesuffix(")"), "inner": None}
+                return {"filter": data[10:-1], "inner": None}
             else:
                 raise ValueError(f"Cannot parse {cls.name} from {data}. Ill formatted raw filter.")
 

--- a/cognite/neat/_rules/models/entities/_wrapped.py
+++ b/cognite/neat/_rules/models/entities/_wrapped.py
@@ -192,7 +192,7 @@ class RawFilter(DMSFilter):
     filter: str
     inner: None = None  # type: ignore[assignment]
 
-    def as_dms_filter(self, default: Any | None = None) -> dm.Filter:  # type: ignore[override]
+    def as_dms_filter(self, default: Any | None = None) -> dm.Filter:
         try:
             return dm.Filter.load(json.loads(self.filter))
         except json.JSONDecodeError as e:

--- a/cognite/neat/_rules/models/entities/_wrapped.py
+++ b/cognite/neat/_rules/models/entities/_wrapped.py
@@ -193,7 +193,7 @@ class RawFilter(DMSFilter):
     filter: str
     inner: None = None  # type: ignore[assignment]
 
-    def as_dms_filter(self) -> dm.Filter:  # type: ignore[override]
+    def as_dms_filter(self, default: Any | None = None) -> dm.Filter:  # type: ignore[override]
         try:
             return dm.Filter.load(json.loads(self.filter))
         except json.JSONDecodeError as e:

--- a/cognite/neat/_rules/models/entities/_wrapped.py
+++ b/cognite/neat/_rules/models/entities/_wrapped.py
@@ -1,5 +1,4 @@
 import json
-import re
 from abc import ABC, abstractmethod
 from collections.abc import Collection
 from functools import total_ordering
@@ -42,8 +41,8 @@ class WrappedEntity(BaseModel, ABC):
 
         # raw filter case:
         if cls.__name__ == "RawFilter":
-            if match := re.search(r"rawFilter\(([\s\S]*?)\)", data):
-                return {"filter": match.group(1), "inner": None}
+            if data.startswith("rawFilter(") and data.endswith(")"):
+                return {"filter": data.removeprefix("rawFilter(").removesuffix(")"), "inner": None}
             else:
                 raise ValueError(f"Cannot parse {cls.name} from {data}. Ill formatted raw filter.")
 

--- a/tests/tests_unit/rules/test_models/test_wrapped_entities.py
+++ b/tests/tests_unit/rules/test_models/test_wrapped_entities.py
@@ -27,6 +27,10 @@ RAW_FILTER_EXAMPLE = """{"and": [
   ]}"""
 
 RAW_FILTER_CELL_EXAMPLE = f"""rawFilter({RAW_FILTER_EXAMPLE})"""
+RAW_FILTER_WITH_AMPERSAND = (
+    'rawFilter({"equals": {"property": ["ne-013-i4-neat-g-m-spc", "Tag/1", '
+    '"TagCategoryDescription"], "value": "FIRE & GAS FIELD EQUIPMENT"}})'
+)
 
 
 class TestWrappedEntities:
@@ -70,6 +74,7 @@ class TestWrappedEntities:
                 RAW_FILTER_CELL_EXAMPLE,
                 RawFilter(filter=RAW_FILTER_EXAMPLE),
             ),
+            (RawFilter, RAW_FILTER_WITH_AMPERSAND, RawFilter(filter=RAW_FILTER_WITH_AMPERSAND)),
         ],
     )
     def test_load(self, cls_: type[WrappedEntity], raw: Any, expected: WrappedEntity) -> None:

--- a/tests/tests_unit/rules/test_models/test_wrapped_entities.py
+++ b/tests/tests_unit/rules/test_models/test_wrapped_entities.py
@@ -28,8 +28,8 @@ RAW_FILTER_EXAMPLE = """{"and": [
 
 RAW_FILTER_CELL_EXAMPLE = f"""rawFilter({RAW_FILTER_EXAMPLE})"""
 RAW_FILTER_WITH_AMPERSAND = (
-    'rawFilter({"equals": {"property": ["ne-013-i4-neat-g-m-spc", "Tag/1", '
-    '"TagCategoryDescription"], "value": "FIRE & GAS FIELD EQUIPMENT"}})'
+    '{"equals": {"property": ["ne-013-i4-neat-g-m-spc", "Tag/1", "TagCategoryDescription"], '
+    '"value": "FIRE & GAS FIELD EQUIPMENT"}}'
 )
 
 
@@ -74,7 +74,11 @@ class TestWrappedEntities:
                 RAW_FILTER_CELL_EXAMPLE,
                 RawFilter(filter=RAW_FILTER_EXAMPLE),
             ),
-            (RawFilter, RAW_FILTER_WITH_AMPERSAND, RawFilter(filter=RAW_FILTER_WITH_AMPERSAND)),
+            (
+                RawFilter,
+                f"rawFilter({RAW_FILTER_WITH_AMPERSAND})",
+                RawFilter(filter=RAW_FILTER_WITH_AMPERSAND),
+            ),
         ],
     )
     def test_load(self, cls_: type[WrappedEntity], raw: Any, expected: WrappedEntity) -> None:


### PR DESCRIPTION
# Description

Caused by a naive use of regex. Replace it with startswith and endswith for more robust parsing. 

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- Running `neat.read.cdf.data_model(...)` to fetch a data model no longer raises a `ValueError` if one of the views in the model contains a filter that uses a special characters such as `&`. 
