### PR TITLE
[NEAT-836] Misleading error when running NEAT in a local notebook

### DIFF
--- a/cognite/neat/_utils/auth.py
+++ b/cognite/neat/_utils/auth.py
@@ -342,7 +342,9 @@ def _prompt_cluster_and_project() -> EnvironmentVariables:
 def _repo_root() -> Path | None:
     # Redirecting stderr to suppress the error message if the command fails
     with suppress(Exception), redirect_stderr(StringIO()), redirect_stdout(StringIO()):
-        result = subprocess.run("git rev-parse --show-toplevel".split(), stdout=subprocess.PIPE)
+        result = subprocess.run(
+            "git rev-parse --show-toplevel".split(), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+        )
         if (output := result.stdout.decode().strip()) != "":
             return Path(output)
     return None


### PR DESCRIPTION
# Description

Supressing stderr messages when running check to see if root is a git repo
## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- Added "subprocess.DEVNULL" parameter when calling the command to check if folder is git repo
