### PR TITLE
fix: Capture correct information for IMF-types.

### DIFF
--- a/cognite/neat/_rules/importers/_base.py
+++ b/cognite/neat/_rules/importers/_base.py
@@ -24,27 +24,32 @@ class BaseImporter(ABC, Generic[T_InputRules]):
         raise NotImplementedError()
 
     def _default_metadata(self) -> dict[str, Any]:
-        creator = "UNKNOWN"
-        with suppress(KeyError, ImportError):
-            import getpass
-
-            creator = getpass.getuser()
-
         return {
             "schema": "partial",
             "space": "neat",
             "external_id": "NeatImportedDataModel",
             "version": "0.1.0",
             "name": "Neat Imported Data Model",
-            "created": datetime.now().replace(microsecond=0).isoformat(),
-            "updated": datetime.now().replace(microsecond=0).isoformat(),
-            "creator": creator,
+            "created": self._get_current_time(),
+            "updated": self._get_current_time(),
+            "creator": self._get_username(),
             "description": f"Imported using {type(self).__name__}",
         }
 
     @classmethod
     def _repr_html_(cls) -> str:
         return class_html_doc(cls)
+
+    @classmethod
+    def _get_username(cls) -> str:
+        with suppress(KeyError, ImportError):
+            import getpass
+            return getpass.getuser()
+        return "UNKNOWN"
+
+    @classmethod
+    def _get_current_time(cls) -> str:
+        return datetime.now().replace(microsecond=0).isoformat()
 
     @property
     def agent(self) -> "ProvenanceAgent":

--- a/cognite/neat/_rules/importers/_rdf/_base.py
+++ b/cognite/neat/_rules/importers/_rdf/_base.py
@@ -123,8 +123,8 @@ class BaseRDFImporter(BaseImporter[InformationInputRules]):
             raise MultiValueError(self.issue_list.errors)
 
         rules_dict = self._to_rules_components()
-
         rules = InformationInputRules.load(rules_dict)
+
         self.issue_list.trigger_warnings()
         return ReadRules(rules, {})
 
@@ -145,12 +145,13 @@ class BaseRDFImporter(BaseImporter[InformationInputRules]):
     @property
     def _metadata(self) -> dict:
         return {
+            "schema": "partial",
             "role": RoleTypes.information,
             "space": self.data_model_id.space,
             "external_id": self.data_model_id.external_id,
             "version": self.data_model_id.version,
-            "created": datetime.now().replace(microsecond=0),
-            "updated": datetime.now().replace(microsecond=0),
+            "created": self._get_current_time(),
+            "updated": self._get_current_time(),
             "name": None,
             "description": f"Data model imported using {type(self).__name__}",
             "creator": "Neat",

--- a/tests/tests_unit/rules/test_importers/test_imf_importer.py
+++ b/tests/tests_unit/rules/test_importers/test_imf_importer.py
@@ -12,7 +12,7 @@ def test_imf_importer():
 
     regex_violations = [issue for issue in issues if isinstance(issue, ResourceRegexViolationWarning)]
 
-    assert len(rules.classes) == 63
-    assert len(rules.properties) == 62
-    assert len(issues) == 207
-    assert len(regex_violations) == 129
+    assert len(rules.classes) == 7
+    assert len(rules.properties) == 75
+    assert len(issues) == 2
+    assert len(regex_violations) == 0


### PR DESCRIPTION
An IMF_base_model has been introduced in CDF to capture core information about IMF-types as well as provide the link to the IMF_Standard_model.

This commit updates the classes and properties extracted from the IMF- types, so that it is in accordance with the IMF_base_model. It also include a mapping from:
    imf:Terminal -> imf:base:Terminal(version=v1)
    imf:Block -> imf:base:Block(version=v1)

Minor additional changes are:
- Custom strategy for making identifiers CDF compliant
- IMF related metadata

# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Improved

The `IMF Importer` produces cleaner and more accurate IMF instance models
