### PR TITLE
fix: incorrect call when defining remote store

### DIFF
--- a/cognite/neat/_store/_graph_store.py
+++ b/cognite/neat/_store/_graph_store.py
@@ -157,7 +157,7 @@ class NeatGraphStore:
         return cls(
             dataset=Dataset(
                 store=SPARQLUpdateStore(
-                    query_endpoint=f"{remote_url}/query", update_endpoint=f"{remote_url}/query", autocommit=autocommit
+                    query_endpoint=f"{remote_url}/query", update_endpoint=f"{remote_url}/update", autocommit=autocommit
                 ),
                 default_union=True,
             )


### PR DESCRIPTION
# Description

Remote triplestore (running oxigraph on Docker) was not getting updated.
Context for reviewers: Remote triplestore is an experimental feature under development, not released. 
## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip

## Changelog
### Fixed
- Incorrect parameter "update_endpoint" when instantiating SPARQL Update store.
