### PR TITLE
Ci: update coverage threshold

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -152,7 +152,7 @@ jobs:
         with:
             coverageFile: coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
-            thresholdAll: 0.6
+            thresholdAll: 0.8
 
   validate-description:
     name: Validate PR description


### PR DESCRIPTION
# Description

We introduced the coverage test a year ago, and then I set a low threshold as we had a lot of uncovered code. Suggest we now increase it to 80% which is a good target for coverage. 

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip
