### PR TITLE
[NEAT-868] 😇 Setup new test framework for validating DMS Rules

### DIFF
--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from pathlib import Path
 
 from ._graph import car as _car
@@ -81,3 +82,17 @@ class SchemaData:
         invalid_property_dms_rules_xlsx = _physical_invalid / "invalid_property_dms_rules.xlsx"
         missing_view_container_dms_rules_xlsx = _physical_invalid / "missing_view_container_dms_rules.xlsx"
         too_many_container_per_view_xlsx = _physical_invalid / "too_many_containers_per_view.xlsx"
+
+    class PhysicalYamls:
+        _physical_yaml = _schema_dir / "physical_yamls"
+
+        @classmethod
+        def iterate(cls) -> Iterable[tuple[Path, Path | None]]:
+            path: Path
+            for path in cls._physical_yaml.glob("*.yaml"):
+                if path.is_dir():
+                    continue
+                if path.stem.endswith(".expected_issues"):
+                    continue
+                issues = path.with_stem(f"{path.stem}.expected_issues")
+                yield path, issues if issues.exists() else None

--- a/tests/data/_schema/physical_yamls/invalid_yaml.expected_issues.yaml
+++ b/tests/data/_schema/physical_yamls/invalid_yaml.expected_issues.yaml
@@ -1,0 +1,4 @@
+- NeatIssue: FileReadError
+  reason: "Invalid YAML: while scanning a simple key\n  in \"<unicode string>\", line\
+   \ 2, column 1:\n    key2 value2\n    ^\ncould not find expected ':'\n  in \"<unicode\
+   \ string>\", line 3, column 1:\n    key3:\n    ^"

--- a/tests/data/_schema/physical_yamls/invalid_yaml.yaml
+++ b/tests/data/_schema/physical_yamls/invalid_yaml.yaml
@@ -1,0 +1,8 @@
+key1: value1
+key2 value2
+key3:
+  - item1
+  - item2
+  - item3
+key4: [item1, item2, item3
+key5: {keyA: valueA, keyB: valueB

--- a/tests/tests_integration/test_api/test_validate_rules.py
+++ b/tests/tests_integration/test_api/test_validate_rules.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cognite.neat._client import NeatClient
+from cognite.neat._issues import catch_issues
+from cognite.neat._rules.importers import YAMLImporter
+from cognite.neat._rules.transformers import VerifyDMSRules
+from tests.data import SchemaData
+
+
+class TestValidate:
+    @pytest.mark.parametrize(
+        "rule_filepath, expected_issues",
+        [pytest.param(rules, issues, id=rules.stem) for rules, issues in SchemaData.PhysicalYamls.iterate()],
+    )
+    def test_validate_dms_rules(
+        self, rule_filepath: Path, expected_issues: Path | None, neat_client: NeatClient
+    ) -> None:
+        with catch_issues() as issues:
+            rules = YAMLImporter.from_file(rule_filepath, source_name=rule_filepath.name).to_rules()
+            _ = VerifyDMSRules(validate=True, client=neat_client).transform(rules)
+
+        if expected_issues is None:
+            assert not issues.has_errors
+            assert not issues.has_warnings
+        else:
+            actual = [issue.dump() for issue in sorted(issues)]
+            expected = yaml.safe_load(expected_issues.read_text())
+            assert actual == expected, f"Expected issues: {expected}, but got: {actual}"

--- a/tests/tests_integration/test_api/test_validate_rules.py
+++ b/tests/tests_integration/test_api/test_validate_rules.py
@@ -25,6 +25,7 @@ class TestValidate:
             _ = VerifyDMSRules(validate=True, client=neat_client).transform(rules)
 
         if expected_issues is None:
+            # If there are no issues, then this model should read without any errors or warnings.
             assert not issues.has_errors
             assert not issues.has_warnings
         else:

--- a/tests/tests_integration/test_api/test_validate_rules.py
+++ b/tests/tests_integration/test_api/test_validate_rules.py
@@ -1,4 +1,6 @@
+from collections.abc import Iterable
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -26,6 +28,14 @@ class TestValidate:
             assert not issues.has_errors
             assert not issues.has_warnings
         else:
-            actual = [issue.dump() for issue in sorted(issues)]
+            actual = list(self._clean_issues(issue.dump() for issue in sorted(issues)))
+
             expected = yaml.safe_load(expected_issues.read_text())
-            assert actual == expected, f"Expected issues: {expected}, but got: {actual}"
+            assert actual == expected, f"Expected issues: {expected}, but got:\n{yaml.safe_dump(actual)}"
+
+    @staticmethod
+    def _clean_issues(issues: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
+        for issue in issues:
+            # Filepaths are absolute and will differ between runs
+            issue.pop("filepath", None)
+            yield issue


### PR DESCRIPTION
# Description

Introducing a new test for checking the reading of DMS models. Found one small bug which I fixed.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- The `neat.read.yaml()` now gives a `FileReadError` if the yaml is invalid.