### PR TITLE
add python 3.13 to ci build

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -55,6 +55,7 @@ jobs:
           - "3.10"
           # Python 3.11 is assumed to be covered by testing 3.10 and 3.12
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
# Description

Adding Python 3.13 to Python version matrix in CI build.

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip

## Changelog
### Added

- Adding Python 3.13 to Python version matrix in CI build.
