### PR TITLE
NEAT-900 Fix missing update of data model name via set.data_model_id

### DIFF
--- a/cognite/neat/_session/_set.py
+++ b/cognite/neat/_session/_set.py
@@ -48,7 +48,7 @@ class SetAPI:
                     "Cannot change the data model ID of a Cognite Data Model in NeatSession"
                     " due to temporarily issue with the reverse direct relation interpretation"
                 )
-        return self._state.rule_transform(SetIDDMSModel(new_model_id))
+        return self._state.rule_transform(SetIDDMSModel(new_model_id, name))
 
     def client(self, client: CogniteClient) -> None:
         """Sets the client to be used in the session."""

--- a/tests/tests_integration/test_session/test_graph_flow.py
+++ b/tests/tests_integration/test_session/test_graph_flow.py
@@ -50,7 +50,7 @@ class TestExtractToLoadFlow:
         assert not issues.has_errors
         issues = neat.mapping.data_model.classic_to_core("Classic")
         assert not issues.has_errors
-        neat.set.data_model_id(("sp_windfarm", "WindFarm", "v1"))
+        neat.set.data_model_id(("sp_windfarm", "WindFarm", "v1"), name="Nikola is NEAT janitor")
         instances, issues = neat.to._python.instances("sp_windfarm_dataset", space_from_property="dataSetId")
         assert not issues.has_errors
         rules_str = neat.to.yaml(format="neat")

--- a/tests/tests_integration/test_session/test_graph_flow/test_snapshot_workflow_ids_to_python.yml
+++ b/tests/tests_integration/test_session/test_graph_flow/test_snapshot_workflow_ids_to_python.yml
@@ -707,7 +707,7 @@ rules:
     creator: Cognite
     external_id: WindFarm
     logical: http://purl.org/cognite/neat/data-model/verified/logical/neat_space/ClassicDataModel/v1
-    name: Wind Farm
+    name: Nikola is NEAT janitor
     role: DMS Architect
     source_id: http://purl.org/cognite/neat/data-model/verified/physical/sp_windfarm/WindFarm/v1
     space: sp_windfarm


### PR DESCRIPTION
# Description

neat.set.data_model_id was not updating name of data model

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- neat.set.data_model_id properly updated name of data model
