### PR TITLE
[NEAT-924] 🗒Read Files

### DIFF
--- a/cognite/neat/session/_read.py
+++ b/cognite/neat/session/_read.py
@@ -468,6 +468,28 @@ class CDFClassicAPI(BaseReadAPI):
 
         return extract_issues
 
+    def file_metadata(self, data_set_external_id: str, identifier: Literal["id", "externalId"] = "id") -> IssueList:
+        """Read the file metadata from CDF into NEAT.
+
+        Note all files that have InstanceId set will be silently skipped. This method is for extracting
+        non-contextualized file medata only. If you want to include the potential connection from file metadata
+        to assets, use the `neat.read.cdf.graph()` method instead and select the asset hierarchy connected to this file.
+
+        Args:
+            data_set_external_id: The external id of the data set
+            identifier: The identifier to use for the file metadata. Note selecting "id" can cause issues
+                if the external ID of the file metadata is missing. Default is "id".
+
+        Returns:
+            IssueList: A list of issues that occurred during the extraction.
+
+        Example:
+            ```python
+            neat.read.cdf.time_series("data_set_external_id")
+            ```
+        """
+        raise NotImplementedError()
+
 
 @session_class_wrapper
 class ExcelReadAPI(BaseReadAPI):

--- a/tests/data/_instances/asset_centric_cdf/files.yaml
+++ b/tests/data/_instances/asset_centric_cdf/files.yaml
@@ -10,3 +10,15 @@
   assetIds:
     - 5132527530441957
     - 78504378486679
+- externalId: geo_location_area2
+  name: geo_location_area2.nc
+  source: ACME
+  dataSetId: 6931754270713290
+  id: 146805958863362
+  createdTime: 1668777262326
+  lastUpdatedTime: 1668778466394
+  uploaded: true
+  uploadedTime: 1668778540224
+  assetIds:
+    - 5132527530441957
+    - 78504378486679

--- a/tests/tests_unit/test_graph/test_extractors/test_files_extractor.py
+++ b/tests/tests_unit/test_graph/test_extractors/test_files_extractor.py
@@ -15,4 +15,4 @@ def test_timeseries_extractor():
     for triple in FilesExtractor.from_dataset(client_mock, data_set_external_id="some data set").extract():
         g.add(triple)
 
-    assert len(g) == 11
+    assert len(g) == 13


### PR DESCRIPTION
# Description

In addition, added skipping of files that have `instanceId` set. These have a counterpart in DMS that should be ingested instead.

## Bump

- [ ] Patch
- [x] Minor
- [ ] Skip

## Changelog
### Added

- Support for reading file metadata. `neat.read.cdf.classic.file_metdata(...)`
