### PR TITLE
↩Fix reverse issue (#1193)

### DIFF
--- a/cognite/neat/core/_data_model/models/dms/_validation.py
+++ b/cognite/neat/core/_data_model/models/dms/_validation.py
@@ -40,6 +40,7 @@ from cognite.neat.core._issues.errors._external import CDFMissingResourcesError
 from cognite.neat.core._issues.warnings import (
     NotSupportedHasDataFilterLimitWarning,
     NotSupportedViewContainerLimitWarning,
+    ReversedConnectionNotFeasibleWarning,
     UndefinedViewWarning,
     user_modeling,
 )
@@ -589,7 +590,7 @@ class DMSValidation:
                 )
             ):
                 issue_list.append(
-                    ReversedConnectionNotFeasibleError(
+                    ReversedConnectionNotFeasibleWarning(
                         view_id,
                         "reversed connection",
                         prop_id,

--- a/cognite/neat/core/_issues/warnings/__init__.py
+++ b/cognite/neat/core/_issues/warnings/__init__.py
@@ -40,6 +40,7 @@ from ._properties import (
     PropertyOverwritingWarning,
     PropertyTypeNotSupportedWarning,
     PropertyValueTypeUndefinedWarning,
+    ReversedConnectionNotFeasibleWarning,
 )
 from ._resources import (
     ResourceNeatWarning,
@@ -85,6 +86,7 @@ __all__ = [
     "ResourceTypeNotSupportedWarning",
     "ResourceUnknownWarning",
     "ResourcesDuplicatedWarning",
+    "ReversedConnectionNotFeasibleWarning",
     "UndefinedViewWarning",
     "UserModelingWarning",
     "user_modeling",

--- a/cognite/neat/core/_issues/warnings/_properties.py
+++ b/cognite/neat/core/_issues/warnings/_properties.py
@@ -88,3 +88,10 @@ class PropertyMultipleValueWarning(PropertyWarning[T_Identifier]):
     Selecting the first value {value}, the rest will be ignored."""
 
     value: str
+
+
+@dataclass(unsafe_hash=True)
+class ReversedConnectionNotFeasibleWarning(PropertyWarning[T_Identifier]):
+    """The {resource_type} {identifier}.{property_name} cannot be created: {reason}"""
+
+    reason: str

--- a/tests/data/_schema/physical_yamls/reverse_direct_relation_missing_target.expected_issues.yaml
+++ b/tests/data/_schema/physical_yamls/reverse_direct_relation_missing_target.expected_issues.yaml
@@ -1,0 +1,10 @@
+- NeatIssue: ReversedConnectionNotFeasibleWarning
+  identifier:
+    externalId: Asset
+    space: my_space
+    type: view
+    version: v1
+  propertyName: equipment
+  reason: ViewId(space='my_space', external_id='Equipment', version='v1') asset is not
+    pointing to ViewId(space='my_space', external_id='Asset', version='v1')
+  resourceType: reversed connection

--- a/tests/data/_schema/physical_yamls/reverse_direct_relation_missing_target.yaml
+++ b/tests/data/_schema/physical_yamls/reverse_direct_relation_missing_target.yaml
@@ -1,0 +1,59 @@
+containers:
+- container: CogniteDescriable
+  used_for: node
+- container: Equipment
+  used_for: node
+metadata:
+  created: 2025-05-12 10:25:12.414295
+  creator: me
+  external_id: MyModel
+  role: DMS Architect
+  space: my_space
+  updated: 2025-05-12 10:25:12.414295
+  version: v1
+properties:
+- container: CogniteDescriable
+  container_property: name
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/my_space/MyModel/v1/Asset/name
+  value_type: text
+  view: Asset
+  view_property: name
+- connection: reverse(property=asset)
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/my_space/MyModel/v1/Asset/equipment
+  value_type: Equipment
+  view: Asset
+  view_property: equipment
+- container: CogniteDescriable
+  container_property: name
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/my_space/MyModel/v1/Equipment/name
+  value_type: text
+  view: Equipment
+  view_property: name
+- connection: direct
+  container: Equipment
+  container_property: asset
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/my_space/MyModel/v1/Equipment/asset
+  value_type: Asset2
+  view: Equipment
+  view_property: asset
+- container: CogniteDescriable
+  container_property: name
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/my_space/MyModel/v1/Asset2/name
+  value_type: text
+  view: Asset2
+  view_property: name
+- connection: reverse(property=asset)
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/my_space/MyModel/v1/Asset2/equipment
+  value_type: Equipment
+  view: Asset2
+  view_property: equipment
+views:
+- in_model: true
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/my_space/MyModel/v1/Asset
+  view: Asset
+- in_model: true
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/my_space/MyModel/v1/Equipment
+  view: Equipment
+- in_model: true
+  neatId: http://purl.org/cognite/neat/data-model/verified/physical/my_space/MyModel/v1/Asset2
+  view: Asset2


### PR DESCRIPTION
# Description

Unfortunately it is possible to deploy invalid models to CDF with reverse direct pointing direct relations that does not point in the opposite way. This makes it impossible to read these models into CDF (and fix them). Thus replacing the error with a warning in the validation. 

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- Reading a data model from CDF with `neat.read.cdf.data_model(...)` with a reverse direct relation that points to a direct relation that is not pointing in the opposite direction now gives a warning instead of an error.
