### PR TITLE
Fix naming Standaridzation

### DIFF
--- a/cognite/neat/core/_utils/text.py
+++ b/cognite/neat/core/_utils/text.py
@@ -83,7 +83,7 @@ def _to_camel_case(string: str, is_all_upper: bool, is_first_upper: bool) -> str
 
     string_split = []
     for part in cleaned:
-        string_split.extend(re.findall(r"[A-Z][a-z0-9]*", part))
+        string_split.extend(re.findall(r"[A-Z0-9][a-z0-9]*", part))
     if not string_split:
         string_split = [string]
     if len(string_split) == 0:

--- a/tests/tests_unit/test_utils/test_text.py
+++ b/tests/tests_unit/test_utils/test_text.py
@@ -49,3 +49,9 @@ class TestNamingStandardization:
     )
     def test_space_standardization(self, raw: str, expected: str) -> None:
         assert NamingStandardization.standardize_space_str(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw, expected", [("094 [HeatExchanger] Equipment Weight", "property094HeatExchangerEquipmentWeight")]
+    )
+    def test_property_standardization(self, raw: str, expected: str) -> None:
+        assert NamingStandardization.standardize_property_str(raw) == expected


### PR DESCRIPTION
# Description

Numbers gets removed in the to_camel function.

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip

