### PR TITLE
Neat 1007 skip setting node type for instances of system space views

### DIFF
--- a/cognite/neat/core/_instances/loaders/_rdf2dms.py
+++ b/cognite/neat/core/_instances/loaders/_rdf2dms.py
@@ -22,6 +22,7 @@ from rdflib import RDF, URIRef
 from cognite.neat.core._client import NeatClient
 from cognite.neat.core._client._api_client import SchemaAPI
 from cognite.neat.core._constants import (
+    COGNITE_SPACES,
     DMS_DIRECT_RELATION_LIST_DEFAULT_LIMIT,
     is_readonly_property,
 )
@@ -585,7 +586,12 @@ class DMSLoader(CDFLoader[dm.InstanceApply]):
             yield dm.NodeApply(
                 space=space,
                 external_id=external_id,
-                type=(projection.view_id.space, projection.view_id.external_id),
+                # Currently there are no node types for schemas in cognite schema spaces
+                type=(
+                    (projection.view_id.space, projection.view_id.external_id)
+                    if projection.view_id.space not in COGNITE_SPACES
+                    else None
+                ),
                 sources=sources,
             )
         yield from self._create_edges_without_properties(space, external_id, properties, projection, stop_on_exception)

--- a/tests/tests_integration/test_session/test_graph_flow.py
+++ b/tests/tests_integration/test_session/test_graph_flow.py
@@ -14,6 +14,7 @@ from cognite.client.data_classes.data_modeling import (
 from pytest_regressions.data_regression import DataRegressionFixture
 
 from cognite.neat import NeatSession
+from cognite.neat.core._constants import COGNITE_SPACES
 from cognite.neat.core._data_model.models.entities import ContainerEntity
 from cognite.neat.core._instances.loaders import DMSLoader
 from tests.data import GraphData, SchemaData
@@ -152,6 +153,24 @@ class TestExtractToLoadFlow:
         instance_result = neat.to.cdf._instances(use_source_space=True)
         errors = {res.name: res.error_messages for res in instance_result if res.error_messages}
         assert not errors, errors
+
+    def test_no_node_type_on_system_views_instances(self, cognite_client: CogniteClient) -> None:
+        neat = NeatSession(cognite_client, storage="oxigraph")
+        neat.read.cdf._graph(
+            ("sp_windfarm", "WindFarm", "v1"),
+            instance_space=["sp_windfarm_dataset", "usecase_01", "source_ds", "maintenance"],
+            unpack_json=True,
+            str_to_ideal_type=True,
+            skip_cognite_views=False,
+        )
+        instances, _ = neat.to._python.instances(use_source_space=True)
+
+        check = []
+        for instance in instances:
+            if instance.instance_type == "node" and instance.sources[0].source.space in COGNITE_SPACES:
+                check.append(instance.type is None)
+
+        assert all(check), "System views should not have node type"
 
     def test_convert_info_with_cdm_ref(self, cognite_client: CogniteClient) -> None:
         neat = NeatSession(cognite_client, storage="oxigraph")


### PR DESCRIPTION
# Description

CDF system (schema) space (e.g. cdm) does not contain definition of node types. This leads to error when we try to create instances with neat, as neat is automatically set node type for every instance , where node type has same id (space,external_id) of view instances is being written through. 

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- When generating instances through views from system space(s) node type is no longer set
