### PR TITLE
[prep NEAT-1018] Create shared deploy logic.

### DIFF
--- a/cognite/neat/core/_client/_api/crud.py
+++ b/cognite/neat/core/_client/_api/crud.py
@@ -1,0 +1,94 @@
+from abc import abstractmethod
+from collections.abc import Hashable
+from types import MappingProxyType
+from typing import Any, Generic, TypeVar
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes._base import CogniteResourceList, T_CogniteResource, T_CogniteResourceList
+from cognite.client.data_classes.data_modeling import SpaceApply, SpaceApplyList
+
+from cognite.neat.core._client.data_classes.deploy_result import ResourceDifference
+
+T_ID = TypeVar("T_ID", bound=Hashable)
+
+
+class CrudAPI(Generic[T_ID, T_CogniteResource, T_CogniteResourceList]):
+    list_cls: type[T_CogniteResourceList]  # The class of the resource list
+
+    def __init__(self, client: CogniteClient) -> None:
+        self._client = client
+
+    @classmethod
+    def get_crud_api_cls(cls, list_cls: type[T_CogniteResourceList]) -> "type[CrudAPI]":
+        """Load the appropriate CrudAPI class based on the list_cls."""
+        if list_cls not in _CRUDAPI_CLASS_BY_LIST_TYPE:
+            raise ValueError(f"The {list_cls.__name__} does not have a corresponding CrudAPI class.")
+        return _CRUDAPI_CLASS_BY_LIST_TYPE[list_cls]
+
+    @abstractmethod
+    def create(self, resources: T_CogniteResourceList) -> T_CogniteResourceList:
+        """Create a resource or a list of resources."""
+        raise NotImplementedError("This method should be implemented in a subclass.")
+
+    @abstractmethod
+    def retrieve(self, ids: list[T_ID]) -> T_CogniteResourceList:
+        """Retrieve a single resource by its ID."""
+        raise NotImplementedError("This method should be implemented in a subclass.")
+
+    @abstractmethod
+    def update(self, resources: T_CogniteResourceList) -> T_CogniteResourceList:
+        """Update a resource by its ID."""
+        raise NotImplementedError("This method should be implemented in a subclass.")
+
+    @abstractmethod
+    def delete(self, ids: list[T_ID]) -> list[T_ID]:
+        """Delete a resource by its ID."""
+        raise NotImplementedError("This method should be implemented in a subclass.")
+
+    @abstractmethod
+    def diffs(self, cdf_resources: T_CogniteResource, local_resources: T_CogniteResource) -> Any:
+        """Compare CDF resources with local resources and return the differences."""
+        raise NotImplementedError("This method should be implemented in a subclass.")
+
+    @abstractmethod
+    def as_id(self, resource: T_CogniteResource) -> T_ID:
+        raise NotImplementedError
+
+    def as_ids(self, resources: T_CogniteResourceList) -> list[T_ID]:
+        """Extract IDs from a resource or a list of resources."""
+        return [self.as_id(resource) for resource in resources]
+
+
+class SpaceCrudAPI(CrudAPI[str, SpaceApply, SpaceApplyList]):
+    """CRUD API for SpaceApply resources."""
+
+    list_cls = SpaceApplyList
+
+    def create(self, resources: SpaceApplyList) -> SpaceApplyList:
+        """Create a space or a list of spaces."""
+        return self._client.data_modeling.spaces.apply(resources).as_write()
+
+    def retrieve(self, ids: list[str]) -> SpaceApplyList:
+        """Retrieve spaces by their IDs."""
+        return self._client.data_modeling.spaces.retrieve(ids).as_write()
+
+    def update(self, resources: SpaceApplyList) -> SpaceApplyList:
+        """Update spaces."""
+        return self._client.data_modeling.spaces.apply(resources).as_write()
+
+    def delete(self, ids: list[str]) -> list[str]:
+        """Delete spaces by their IDs."""
+        return self._client.data_modeling.spaces.delete(ids)
+
+    def as_id(self, resource: SpaceApply) -> str:
+        """Extract IDs from a SpaceApplyList."""
+        return resource.as_id()
+
+    def diffs(self, cdf_resources: SpaceApply, local_resources: SpaceApply) -> ResourceDifference:
+        """Compare CDF resources with local resources and return the differences."""
+        raise NotImplementedError()
+
+
+_CRUDAPI_CLASS_BY_LIST_TYPE: MappingProxyType[type[CogniteResourceList], type[CrudAPI]] = MappingProxyType(
+    {crud.list_cls: crud for crud in CrudAPI.__subclasses__()}  # type: ignore[type-abstract, misc]
+)

--- a/cognite/neat/core/_client/_api_client.py
+++ b/cognite/neat/core/_client/_api_client.py
@@ -1,11 +1,11 @@
-from collections.abc import Sequence
 from typing import Literal, TypeAlias
 
 from cognite.client import ClientConfig, CogniteClient
-from cognite.client.data_classes._base import CogniteResource
+from cognite.client.data_classes._base import CogniteResourceList
 
 from cognite.neat.core._utils.auth import _CLIENT_NAME
 
+from ._api.crud import CrudAPI
 from ._api.data_modeling_loaders import DataModelLoaderAPI
 from ._api.location_filters import LocationFiltersAPI
 from ._api.neat_instances import NeatInstancesAPI
@@ -31,18 +31,18 @@ class NeatClient(CogniteClient):
 
     def deploy(
         self,
-        resource: CogniteResource | Sequence[CogniteResource],
+        resources: CogniteResourceList,
         existing: ExistingResource,
         dry_run: bool = False,
-        restore: bool = False,
+        restore_on_failure: bool = False,
     ) -> DeployResult:
         """Deploy a resource or a sequence of resources to CDF.
 
         Args:
-            resource: The resource or resources to deploy.
+            resources: The  resources to deploy.
             existing: How to handle existing resources. Options are "skip", "fail", "update", "force", and "recreate".
             dry_run: If True, only simulate the deployment without making any changes.
-            restore: If True, restore the resource if it fails to deploy. This is only applicable if
+            restore_on_failure: If True, restore the resource if it fails to deploy. This is only applicable if
                 `existing` is set to "update.
 
         ... note::
@@ -52,7 +52,47 @@ class NeatClient(CogniteClient):
         - "update": Update the resource if it already exists. This has different behavior depending
             on the resource type.
         - "force": Tries to update the resource, but if it fails, it will recreate the resource.
-        - "recreate": Recreate the resource if it already exists, regardless of its current state.
+        - "recreate": Delete the existing resource and create a new one, regardless of whether it exists or not.
 
         """
+        crud_api_cls = CrudAPI.get_crud_api_cls(type(resources))
+        crud_api = crud_api_cls(self)
+
+        ids = crud_api.as_ids(resources)
+        existing = crud_api.retrieve(ids)
+        cdf_resource_by_id = {crud_api.as_id(resource): resource for resource in existing}
+        local_by_id = {crud_api.as_id(resource): resource for resource in resources}
+
+        to_create, to_update, to_delete, unchanged = (
+            crud_api.list_cls([]),
+            crud_api.list_cls([]),
+            [],
+            [],
+        )
+
+        result = DeployResult()
+        for id_, local in local_by_id.items():
+            cdf_resource = cdf_resource_by_id.get(id_)
+            if cdf_resource is None:
+                to_create.append(local)
+                continue
+            if existing == "skip":
+                # Log in report
+                continue
+            if existing == "fail":
+                # Log in report, mark is failing
+                raise NotImplementedError()
+            if existing == "recreate":
+                to_delete.append(id_)
+                to_create.append(local)
+
+            if diffs := crud_api.diffs(cdf_resource, local):
+                result.diffs.append(diffs)
+                to_update.append(local)
+            else:
+                unchanged.append(id_)
+
+        # 1. Delete. 2. Create. 3. Update.
+        # 3. Perform the operations in the correct order. Include dry_run.
+        # 4. If failure occurs, and restore is possible, restore the resource to its original state.
         raise NotImplementedError()

--- a/cognite/neat/core/_client/_api_client.py
+++ b/cognite/neat/core/_client/_api_client.py
@@ -1,4 +1,8 @@
+from collections.abc import Sequence
+from typing import Literal, TypeAlias
+
 from cognite.client import ClientConfig, CogniteClient
+from cognite.client.data_classes._base import CogniteResource
 
 from cognite.neat.core._utils.auth import _CLIENT_NAME
 
@@ -7,6 +11,9 @@ from ._api.location_filters import LocationFiltersAPI
 from ._api.neat_instances import NeatInstancesAPI
 from ._api.schema import SchemaAPI
 from ._api.statistics import StatisticsAPI
+from .data_classes.deploy_result import DeployResult
+
+ExistingResource: TypeAlias = Literal["skip", "fail", "update", "force", "recreate"]
 
 
 class NeatClient(CogniteClient):
@@ -21,3 +28,31 @@ class NeatClient(CogniteClient):
         self.instances = NeatInstancesAPI(self)
         self.instance_statistics = StatisticsAPI(self._config, self._config.api_subversion, self)
         self.location_filters = LocationFiltersAPI(self._config, self._API_VERSION, self)
+
+    def deploy(
+        self,
+        resource: CogniteResource | Sequence[CogniteResource],
+        existing: ExistingResource,
+        dry_run: bool = False,
+        restore: bool = False,
+    ) -> DeployResult:
+        """Deploy a resource or a sequence of resources to CDF.
+
+        Args:
+            resource: The resource or resources to deploy.
+            existing: How to handle existing resources. Options are "skip", "fail", "update", "force", and "recreate".
+            dry_run: If True, only simulate the deployment without making any changes.
+            restore: If True, restore the resource if it fails to deploy. This is only applicable if
+                `existing` is set to "update.
+
+        ... note::
+
+        - "fail": Raise an error if the resource already exists.
+        - "skip": Skip the resource if it already exists.
+        - "update": Update the resource if it already exists. This has different behavior depending
+            on the resource type.
+        - "force": Tries to update the resource, but if it fails, it will recreate the resource.
+        - "recreate": Recreate the resource if it already exists, regardless of its current state.
+
+        """
+        raise NotImplementedError()

--- a/cognite/neat/core/_client/_deploy.py
+++ b/cognite/neat/core/_client/_deploy.py
@@ -1,0 +1,213 @@
+from collections.abc import Hashable
+from typing import Literal, TypeAlias
+
+from cognite.client.data_classes._base import CogniteResourceList
+from cognite.client.exceptions import CogniteAPIError
+
+from ._api.crud import CrudAPI
+from .data_classes.deploy_result import DeployResult, FailedRequest, ForcedResource
+
+ExistingResource: TypeAlias = Literal["skip", "fail", "update", "force", "recreate"]
+
+
+def deploy(
+    crud_api: CrudAPI,
+    resources: CogniteResourceList,
+    existing: ExistingResource,
+    dry_run: bool = False,
+    restore_on_failure: bool = False,
+) -> DeployResult:
+    """Deploy a resource or a sequence of resources to CDF.
+
+    Args:
+        crud_api: The CrudAPI instance to use for deployment.
+        resources: The  resources to deploy.
+        existing: How to handle existing resources. Options are "skip", "fail", "update", "force", and "recreate".
+        dry_run: If True, only simulate the deployment without making any changes.
+        restore_on_failure: If True, restore the resource if it fails to deploy. This is only applicable if
+            `existing` is set to "update.
+
+    ... note::
+
+    - "fail": Raise an error if the resource already exists.
+    - "skip": Skip the resource if it already exists.
+    - "update": Update the resource if it already exists. This has different behavior depending
+        on the resource type.
+    - "force": Tries to update the resource, but if it fails, it will recreate the resource.
+    - "recreate": Delete the existing resource and create a new one, regardless of whether it exists or not.
+
+    """
+    if restore_on_failure and not crud_api.support_restore_on_failure:
+        raise ValueError(f"The {crud_api.list_cls.__name__} does not support restoring on failure. ")
+
+    cdf_resources = crud_api.retrieve(crud_api.as_ids(resources))
+    cdf_resource_by_id = {crud_api.as_id(resource): resource for resource in cdf_resources}
+    local_by_id = {crud_api.as_id(resource): resource for resource in resources}
+
+    to_create, to_update, to_delete = (
+        crud_api.list_cls([]),
+        crud_api.list_cls([]),
+        [],
+    )
+    result = DeployResult("dry-run" if dry_run else "success")
+    for id_, local in local_by_id.items():
+        cdf_resource = cdf_resource_by_id.get(id_)
+        if cdf_resource is None:
+            to_create.append(local)
+            result.to_create.append(id_)
+        elif existing == "skip":
+            result.skipped.append(id_)
+        elif existing == "fail":
+            result.status = "failure"
+            result.existing.append(id_)
+        elif existing == "recreate":
+            to_delete.append(id_)
+            to_create.append(local)
+            result.to_delete.append(id_)
+            result.to_create.append(id_)
+        elif diffs := crud_api.difference(local, cdf_resource):
+            result.diffs.append(diffs)
+            result.to_update.append(id_)
+            to_update.append(local)
+        else:
+            result.unchanged.append(id_)
+
+    if existing == "fail" and result.existing:
+        result.message = f"Cannot deploy {len(resources)} resources, {len(result.existing)} already exist."
+        return result
+
+    if dry_run:
+        return result
+
+    deleted_ids: list[Hashable] = []
+    if to_delete:
+        try:
+            deleted_ids = crud_api.delete(to_delete)
+        except CogniteAPIError as e:
+            result.status = "failure"
+            result.message = f"Failed to delete {len(to_delete)} resources: {e!r}"
+            result.failed_deleted.append(
+                FailedRequest(
+                    error_message=str(e),
+                    status_code=e.code,
+                    resource_ids=to_delete,
+                )
+            )
+        else:
+            result.deleted.extend(deleted_ids)
+
+    created = crud_api.list_cls([])
+    if to_create and result.status != "failure":
+        try:
+            created = crud_api.create(to_create)
+        except CogniteAPIError as e:
+            result.status = "failure"
+            result.message = f"Failed to create {len(to_create)} resources: {e!r}"
+            result.failed_created.append(
+                FailedRequest(
+                    error_message=str(e),
+                    status_code=e.code,
+                    resource_ids=crud_api.as_ids(to_create),
+                )
+            )
+        else:
+            result.created.extend(crud_api.as_ids(created))
+
+    updated = crud_api.list_cls([])
+    if to_update and result.status != "failure":
+        try:
+            updated = crud_api.update(to_update)
+        except CogniteAPIError as e1:
+            if existing == "force":
+                to_delete_ids = crud_api.as_ids(to_update)
+                try:
+                    _ = crud_api.delete(to_delete_ids)
+                except CogniteAPIError as e2:
+                    result.status = "failure"
+                    result.message = "Failed to force update resources. The delete operation failed: {e2!r}"
+                    result.failed_deleted.append(
+                        FailedRequest(
+                            error_message=str(e2),
+                            status_code=e2.code,
+                            resource_ids=to_delete_ids,
+                        )
+                    )
+                try:
+                    created = crud_api.create(to_update)
+                except CogniteAPIError as e3:
+                    result.status = "failure"
+                    result.message = f"Failed to force update resources. The create operation failed: {e3!r}"
+                    result.failed_created.append(
+                        FailedRequest(
+                            error_message=str(e3),
+                            status_code=e3.code,
+                            resource_ids=crud_api.as_ids(to_update),
+                        )
+                    )
+                else:
+                    result.forced.extend(
+                        [
+                            ForcedResource(
+                                resource_id=resource_id,
+                                reason=str(e1),
+                            )
+                            for resource_id in crud_api.as_ids(created)
+                        ]
+                    )
+                    for resource in created:
+                        id_ = crud_api.as_id(resource)
+                        previous = cdf_resource_by_id[id_]
+                        result.updated.append(crud_api.difference(resource, previous))
+            else:
+                result.status = "failure"
+                result.message = f"Failed to update {len(to_update)} resources: {e1!r}"
+                result.failed_updated.append(
+                    FailedRequest(
+                        error_message=str(e1),
+                        status_code=e1.code,
+                        resource_ids=crud_api.as_ids(to_update),
+                    )
+                )
+        else:
+            for resource in updated:
+                id_ = crud_api.as_id(resource)
+                previous = cdf_resource_by_id[id_]
+                result.updated.append(crud_api.difference(resource, previous))
+
+    if result.status == "failure" and restore_on_failure:
+        result.restored = True
+        if updated:
+            raise NotImplementedError()
+        if deleted_ids:
+            restore_create = crud_api.list_cls(
+                [cdf_resource_by_id[id_] for id_ in deleted_ids if id_ in cdf_resource_by_id]
+            )
+            try:
+                _ = crud_api.create(restore_create)
+            except CogniteAPIError as e:
+                result.message = f"Failed to restore deleted resources: {e!r}"
+                result.restored = False
+                result.failed_restored.append(
+                    FailedRequest(
+                        error_message=str(e),
+                        status_code=e.code,
+                        resource_ids=deleted_ids,
+                    )
+                )
+
+        if created:
+            restore_delete_ids = crud_api.as_ids(created)
+            try:
+                deleted_ids = crud_api.delete(restore_delete_ids)
+            except CogniteAPIError as e:
+                result.message = f"Failed to restore created resources: {e!r}"
+                result.restored = False
+                result.failed_restored.append(
+                    FailedRequest(
+                        error_message=str(e),
+                        status_code=e.code,
+                        resource_ids=deleted_ids,
+                    )
+                )
+
+    return result

--- a/cognite/neat/core/_client/_deploy.py
+++ b/cognite/neat/core/_client/_deploy.py
@@ -175,39 +175,6 @@ def deploy(
                 result.updated.append(crud_api.difference(resource, previous))
 
     if result.status == "failure" and restore_on_failure:
-        result.restored = True
-        if updated:
-            raise NotImplementedError()
-        if deleted_ids:
-            restore_create = crud_api.list_cls(
-                [cdf_resource_by_id[id_] for id_ in deleted_ids if id_ in cdf_resource_by_id]
-            )
-            try:
-                _ = crud_api.create(restore_create)
-            except CogniteAPIError as e:
-                result.message = f"Failed to restore deleted resources: {e!r}"
-                result.restored = False
-                result.failed_restored.append(
-                    FailedRequest(
-                        error_message=str(e),
-                        status_code=e.code,
-                        resource_ids=deleted_ids,
-                    )
-                )
-
-        if created:
-            restore_delete_ids = crud_api.as_ids(created)
-            try:
-                deleted_ids = crud_api.delete(restore_delete_ids)
-            except CogniteAPIError as e:
-                result.message = f"Failed to restore created resources: {e!r}"
-                result.restored = False
-                result.failed_restored.append(
-                    FailedRequest(
-                        error_message=str(e),
-                        status_code=e.code,
-                        resource_ids=deleted_ids,
-                    )
-                )
+        raise NotImplementedError()
 
     return result

--- a/cognite/neat/core/_client/data_classes/deploy_result.py
+++ b/cognite/neat/core/_client/data_classes/deploy_result.py
@@ -27,17 +27,44 @@ class ResourceDifference:
 
 
 @dataclass
-class DeployResult:
-    status: Literal["success", "failure", "dry-run"]
+class FailedRequest:
+    error_message: str
+    status_code: int
+    resource_ids: list[Hashable] = field(default_factory=list)
 
+
+@dataclass
+class ForcedResource:
+    resource_id: Hashable
+    reason: str
+
+
+@dataclass
+class DeployResult:
+    # Deployment status
+    status: Literal["success", "failure", "dry-run"] = "success"
+    restored: bool = False
+    message: str = ""
+
+    # Preparation phase
     diffs: list[ResourceDifference] = field(default_factory=list)
     to_create: list[Hashable] = field(default_factory=list)
     to_update: list[Hashable] = field(default_factory=list)
     to_delete: list[Hashable] = field(default_factory=list)
 
-    created: list[Hashable] = field(default_factory=list)
-    deleted: list[Hashable] = field(default_factory=list)
+    # No API calls are made when existing is set to "skip", "fail", or "recreate"
     skipped: list[Hashable] = field(default_factory=list)
     unchanged: list[Hashable] = field(default_factory=list)
     existing: list[Hashable] = field(default_factory=list)
+
+    # Result phase
+    created: list[Hashable] = field(default_factory=list)
+    failed_created: list[FailedRequest] = field(default_factory=list)
+    deleted: list[Hashable] = field(default_factory=list)
+    failed_deleted: list[FailedRequest] = field(default_factory=list)
+
     updated: list[ResourceDifference] = field(default_factory=list)
+    failed_updated: list[FailedRequest] = field(default_factory=list)
+    forced: list[ForcedResource] = field(default_factory=list)
+
+    failed_restored: list[FailedRequest] = field(default_factory=list)

--- a/cognite/neat/core/_client/data_classes/deploy_result.py
+++ b/cognite/neat/core/_client/data_classes/deploy_result.py
@@ -1,0 +1,5 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class DeployResult: ...

--- a/cognite/neat/core/_client/data_classes/deploy_result.py
+++ b/cognite/neat/core/_client/data_classes/deploy_result.py
@@ -1,5 +1,30 @@
-from dataclasses import dataclass
+from collections.abc import Hashable
+from dataclasses import dataclass, field
 
 
 @dataclass
-class DeployResult: ...
+class Property:
+    location: str
+    value_representation: str
+
+
+@dataclass
+class PropertyChange(Property):
+    previous_representation: str
+
+
+@dataclass
+class ResourceDifference:
+    resource_id: Hashable
+    added: list[Property] = field(default_factory=list)
+    removed: list[Property] = field(default_factory=list)
+    changed: list[PropertyChange] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        """Check if there are any differences."""
+        return bool(self.added or self.removed or self.changed)
+
+
+@dataclass
+class DeployResult:
+    diffs: list[ResourceDifference] = field(default_factory=list)

--- a/cognite/neat/core/_client/data_classes/deploy_result.py
+++ b/cognite/neat/core/_client/data_classes/deploy_result.py
@@ -29,7 +29,12 @@ class ResourceDifference:
 @dataclass
 class DeployResult:
     status: Literal["success", "failure", "dry-run"]
+
     diffs: list[ResourceDifference] = field(default_factory=list)
+    to_create: list[Hashable] = field(default_factory=list)
+    to_update: list[Hashable] = field(default_factory=list)
+    to_delete: list[Hashable] = field(default_factory=list)
+
     created: list[Hashable] = field(default_factory=list)
     deleted: list[Hashable] = field(default_factory=list)
     skipped: list[Hashable] = field(default_factory=list)

--- a/cognite/neat/core/_client/data_classes/deploy_result.py
+++ b/cognite/neat/core/_client/data_classes/deploy_result.py
@@ -1,5 +1,6 @@
 from collections.abc import Hashable
 from dataclasses import dataclass, field
+from typing import Literal
 
 
 @dataclass
@@ -27,4 +28,11 @@ class ResourceDifference:
 
 @dataclass
 class DeployResult:
+    status: Literal["success", "failure", "dry-run"]
     diffs: list[ResourceDifference] = field(default_factory=list)
+    created: list[Hashable] = field(default_factory=list)
+    deleted: list[Hashable] = field(default_factory=list)
+    skipped: list[Hashable] = field(default_factory=list)
+    unchanged: list[Hashable] = field(default_factory=list)
+    existing: list[Hashable] = field(default_factory=list)
+    updated: list[ResourceDifference] = field(default_factory=list)

--- a/cognite/neat/core/_client/testing.py
+++ b/cognite/neat/core/_client/testing.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
+from types import MethodType
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -31,6 +32,7 @@ class NeatClientMock(CogniteClientMock):
         self.loaders = DataModelLoaderAPI(self)
         self.instances = NeatInstancesAPI(self)
         self.location_filters = MagicMock(spec_set=LocationFiltersAPI)
+        self.deploy = MethodType(NeatClient.deploy, self)
 
 
 @contextmanager

--- a/tests/tests_unit/test_neat_client/test_deploy.py
+++ b/tests/tests_unit/test_neat_client/test_deploy.py
@@ -24,3 +24,44 @@ class TestDeploySpace:
         assert client.data_modeling.spaces.apply.call_count == 1
         assert client.data_modeling.spaces.apply.call_args[0][0] == dm.SpaceApplyList([two_spaces[0]])
         assert result.status == "success"
+
+    def test_deploy_space_existing_fail(self, two_spaces: dm.SpaceApplyList) -> None:
+        with monkeypatch_neat_client() as client:
+            client.data_modeling.spaces.retrieve.return_value = dm.SpaceList([as_read_space(two_spaces[1])])
+            result = client.deploy(two_spaces, existing="fail")
+
+        assert client.data_modeling.spaces.apply.call_count == 0
+        assert result.status == "failure"
+        assert result.existing == [two_spaces[1].space]
+
+    def test_deploy_space_existing_update(self, two_spaces: dm.SpaceApplyList) -> None:
+        with monkeypatch_neat_client() as client:
+            cdf_space = as_read_space(two_spaces[0])
+            cdf_space.name = "Last name"
+            cdf_space.description = "Last description"
+            client.data_modeling.spaces.retrieve.return_value = dm.SpaceList([cdf_space])
+            result = client.deploy(two_spaces, existing="update")
+
+        # The first space is created, the second is updated
+        assert client.data_modeling.spaces.apply.call_count == 2
+        # Create call
+        assert client.data_modeling.spaces.apply.call_args_list[0][0] == (dm.SpaceApplyList([two_spaces[1]]),)
+        # Update call
+        assert client.data_modeling.spaces.apply.call_args_list[1][0] == (dm.SpaceApplyList([two_spaces[0]]),)
+        assert result.status == "success"
+        assert result.to_create == [two_spaces[1].space]
+        assert len(result.diffs) == 1
+        difference = result.diffs[0]
+        assert {prop.location for prop in difference.changed} == {"name", "description"}
+
+    def test_deploy_space_existing_recreate(self, two_spaces: dm.SpaceApplyList) -> None:
+        with monkeypatch_neat_client() as client:
+            client.data_modeling.spaces.retrieve.return_value = dm.SpaceList([as_read_space(two_spaces[1])])
+            result = client.deploy(two_spaces, existing="recreate")
+
+        assert client.data_modeling.spaces.delete.call_count == 1
+        assert client.data_modeling.spaces.delete.call_args[0][0] == [two_spaces[1].space]
+        assert client.data_modeling.spaces.apply.call_count == 1
+        assert client.data_modeling.spaces.apply.call_args[0][0] == two_spaces
+
+        assert result.status == "success"

--- a/tests/tests_unit/test_neat_client/test_deploy.py
+++ b/tests/tests_unit/test_neat_client/test_deploy.py
@@ -1,0 +1,26 @@
+import pytest
+from cognite.client import data_modeling as dm
+
+from cognite.neat.core._client.testing import monkeypatch_neat_client
+from tests.utils import as_read_space
+
+
+@pytest.fixture()
+def two_spaces() -> dm.SpaceApplyList:
+    return dm.SpaceApplyList(
+        [
+            dm.SpaceApply("space1", "Description of space 1", "Space 1"),
+            dm.SpaceApply("space2", "Description of space 2", "Space 2"),
+        ]
+    )
+
+
+class TestDeploySpace:
+    def test_deploy_space_existing_skip(self, two_spaces: dm.SpaceApplyList) -> None:
+        with monkeypatch_neat_client() as client:
+            client.data_modeling.spaces.retrieve.return_value = dm.SpaceList([as_read_space(two_spaces[1])])
+            result = client.deploy(two_spaces, existing="skip")
+
+        assert client.data_modeling.spaces.apply.call_count == 1
+        assert client.data_modeling.spaces.apply.call_args[0][0] == dm.SpaceApplyList([two_spaces[0]])
+        assert result.status == "success"


### PR DESCRIPTION
# Description

This introduces a deploy method. This method builds on a CrudAPI interface. It deals with the details of how to handle existing resources. It returns a detailed deploy result which I will use in future PRs to create a UX for displaying it.

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip
