### PR TITLE
[NEAT-1115]  Unbound local error

### DIFF
--- a/cognite/neat/core/_store/_data_model.py
+++ b/cognite/neat/core/_store/_data_model.py
@@ -355,7 +355,7 @@ class NeatDataModelStore:
 
         agent = exporter.agent
         start = datetime.now(timezone.utc)
-        result = None
+        result: UploadResultList | Path | URIRef | None = None
         with catch_issues() as issue_list:
             # Validate the type of the result
             result = action(input_, *exporter_args)

--- a/cognite/neat/core/_store/_data_model.py
+++ b/cognite/neat/core/_store/_data_model.py
@@ -355,6 +355,7 @@ class NeatDataModelStore:
 
         agent = exporter.agent
         start = datetime.now(timezone.utc)
+        result = None
         with catch_issues() as issue_list:
             # Validate the type of the result
             result = action(input_, *exporter_args)


### PR DESCRIPTION
# Description

See below

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- Running `neat.to.cdf.data_model()` no longer gives a `UnboundLocalError` if there is an error in the deployment.
