### PR TITLE
Improve OWL importer by quoting IDs

### DIFF
--- a/cognite/neat/core/_data_model/importers/_rdf/_shared.py
+++ b/cognite/neat/core/_data_model/importers/_rdf/_shared.py
@@ -1,4 +1,5 @@
 from typing import cast
+from urllib.parse import quote
 
 from rdflib import BNode, Graph
 from rdflib.plugins.sparql import prepareQuery
@@ -32,6 +33,9 @@ def parse_concepts(graph: Graph, query: str, language: str, issue_list: IssueLis
     for raw in graph.query(query):
         res: dict = convert_rdflib_content(cast(ResultRow, raw).asdict(), True)
         res = {key: res.get(key, None) for key in expected_keys}
+
+        # Quote the concept id to ensure it is web-safe
+        res["concept"] = quote(res["concept"], safe="")
 
         concept_id = res["concept"]
 
@@ -91,6 +95,8 @@ def parse_properties(graph: Graph, query: str, language: str, issue_list: IssueL
         res: dict = convert_rdflib_content(cast(ResultRow, raw).asdict(), True)
         res = {key: res.get(key, None) for key in expected_keys}
 
+        # Quote the concept id to ensure it is web-safe
+        res["property_"] = quote(res["property_"], safe="")
         property_id = res["property_"]
 
         # Safeguarding against incomplete semantic definitions
@@ -114,6 +120,10 @@ def parse_properties(graph: Graph, query: str, language: str, issue_list: IssueL
                 )
             )
             continue
+
+        # Quote the concept and value_type to ensure they are web-safe
+        res["concept"] = quote(res["concept"], safe="")
+        res["value_type"] = quote(res["value_type"], safe="")
 
         id_ = f"{res['concept']}.{res['property_']}"
 

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -49,6 +49,7 @@ class SchemaData:
         information_unknown_value_type_xlsx = _conceptual / "information-unknown-value-type.xlsx"
         info_with_cdm_ref_xlsx = _conceptual / "info_with_cdm_ref.xlsx"
         broken_concepts_xlsx = _conceptual / "broken_concepts.xlsx"
+        ontology_with_regex_warnings = _conceptual / "ontology.ttl"
 
     class NonNeatFormats:
         class DTDL:

--- a/tests/data/_schema/conceptual/ontology.ttl
+++ b/tests/data/_schema/conceptual/ontology.ttl
@@ -1,0 +1,42 @@
+@prefix : <http://example.com/industrial#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://example.com/industrial>
+    a owl:Ontology .
+
+### Classes
+
+<http://example.com/industrial/Machine.Type-A(01)~?@!$&'*+,;=%[]>
+    a owl:Class ;
+    rdfs:label "Machine Type A" .
+
+<http://example.com/industrial/Sensor.Unit_01(Temp)~?@!$&'*+,;=%[]>
+    a owl:Class ;
+    rdfs:label "Temperature Sensor Unit" .
+
+<http://example.com/industrial/Control.Panel-1(Safety)~?@!$&'*+,;=%[]>
+    a owl:Class ;
+    rdfs:label "Safety Control Panel" .
+
+### Object Properties with special characters in URIs
+
+<http://example.com/industrial/has.Sensor-Unit(01):Temp~?@!$&'*+,;=%[]>
+    a owl:ObjectProperty ;
+    rdfs:domain <http://example.com/industrial/Machine.Type-A(01)~?@!$&'*+,;=%[]> ;
+    rdfs:range <http://example.com/industrial/Sensor.Unit_01(Temp)~?@!$&'*+,;=%[]> ;
+    rdfs:label "has sensor unit" .
+
+<http://example.com/industrial/is.Controlled-By(Panel):Safety~?@!$&'*+,;=%[]>
+    a owl:ObjectProperty ;
+    rdfs:domain <http://example.com/industrial/Machine.Type-A(01)~?@!$&'*+,;=%[]> ;
+    rdfs:range <http://example.com/industrial/Control.Panel-1(Safety)~?@!$&'*+,;=%[]> ;
+    rdfs:label "is controlled by" .
+
+<http://example.com/industrial/is.Connected-To(Control):Panel~?@!$&'*+,;=%[]>
+    a owl:ObjectProperty ;
+    rdfs:domain <http://example.com/industrial/Sensor.Unit_01(Temp)~?@!$&'*+,;=%[]> ;
+    rdfs:range <http://example.com/industrial/Control.Panel-1(Safety)~?@!$&'*+,;=%[]> ;
+    rdfs:label "is connected to" .


### PR DESCRIPTION
# Description

OWL importer has been improved allowing for class and property ids which contain "non-web-safe" characters, which can exist since OWL allows defining ids using IRIs , which are allow for more characters than URIs.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Improved

- OWL importer got improved flexibility for ids of entities that making ontology
