### PR TITLE
Remove unnecessary method and check

### DIFF
--- a/cognite/neat/core/_data_model/exporters/_data_model2ontology.py
+++ b/cognite/neat/core/_data_model/exporters/_data_model2ontology.py
@@ -17,10 +17,8 @@ from cognite.neat.core._data_model.models.conceptual import (
     ConceptualMetadata,
     ConceptualProperty,
 )
-from cognite.neat.core._data_model.models.conceptual._validation import duplicated_properties
 from cognite.neat.core._data_model.models.data_types import DataType
 from cognite.neat.core._data_model.models.entities import ConceptEntity
-from cognite.neat.core._issues import MultiValueError
 from cognite.neat.core._issues.errors import (
     PropertyDefinitionDuplicatedError,
 )
@@ -106,21 +104,6 @@ class Ontology(OntologyModel):
         Returns:
             An instance of Ontology.
         """
-        if duplicates := duplicated_properties(data_model.properties):
-            errors = []
-            for (concept, property_), definitions in duplicates.items():
-                errors.append(
-                    PropertyDefinitionDuplicatedError(
-                        concept,
-                        "concept",
-                        property_,
-                        frozenset({str(definition[1].value_type) for definition in definitions}),
-                        tuple(definition[0] for definition in definitions),
-                        "rows",
-                    )
-                )
-            raise MultiValueError(errors)
-
         analysis = DataModelAnalysis(data_model)
         concept_by_suffix = analysis.concept_by_suffix()
         return cls(

--- a/cognite/neat/core/_data_model/models/conceptual/_validation.py
+++ b/cognite/neat/core/_data_model/models/conceptual/_validation.py
@@ -1,6 +1,5 @@
 import itertools
 from collections import Counter, defaultdict
-from collections.abc import Iterable
 
 from cognite.neat.core._constants import get_base_concepts
 from cognite.neat.core._data_model._constants import PATTERNS, EntityTypes
@@ -24,7 +23,7 @@ from cognite.neat.core._issues.warnings._resources import (
 from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 from cognite.neat.core._utils.text import humanize_collection
 
-from ._verified import ConceptualDataModel, ConceptualProperty
+from ._verified import ConceptualDataModel
 
 
 class ConceptualValidation:
@@ -282,12 +281,3 @@ class ConceptualValidation:
                     "\nMake sure that each unique namespace is assigned to a unique prefix"
                 )
             )
-
-
-def duplicated_properties(
-    properties: Iterable[ConceptualProperty],
-) -> dict[tuple[ConceptEntity, str], list[tuple[int, ConceptualProperty]]]:
-    concept_properties_by_id: dict[tuple[ConceptEntity, str], list[tuple[int, ConceptualProperty]]] = defaultdict(list)
-    for prop_no, prop in enumerate(properties):
-        concept_properties_by_id[(prop.concept, prop.property_)].append((prop_no, prop))
-    return {k: v for k, v in concept_properties_by_id.items() if len(v) > 1}


### PR DESCRIPTION
# Description

Previously we allowed for re-definition of properties. This has not been case for a long time. However, a method and check that looking for the redefinitions pertained when a conceptual data model is exported to ontology. This PR removes them as they are no longer necessary.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Removed

- Remove method and check for properties redefinitions for ontology exporter 
