### PR TITLE
Merge conceptual

### DIFF
--- a/cognite/neat/core/_data_model/transformers/__init__.py
+++ b/cognite/neat/core/_data_model/transformers/__init__.py
@@ -26,6 +26,7 @@ from ._converters import (
     ToSolutionModel,
 )
 from ._mapping import AsParentPropertyId, MapOneToOne, PhysicalDataModelMapper
+from ._merge_conceptual import MergeConceptualDataModel
 from ._verification import (
     VerifyAnyDataModel,
     VerifyConceptualDataModel,
@@ -45,6 +46,7 @@ __all__ = [
     "DropModelViews",
     "IncludeReferenced",
     "MapOneToOne",
+    "MergeConceptualDataModel",
     "MergeConceptualDataModels",
     "MergePhysicalDataModels",
     "PhysicalDataModelMapper",

--- a/cognite/neat/core/_data_model/transformers/_merge_conceptual.py
+++ b/cognite/neat/core/_data_model/transformers/_merge_conceptual.py
@@ -1,0 +1,240 @@
+from collections.abc import Iterable, Set
+from typing import Literal
+
+from cognite.neat.core._data_model.models import ConceptualDataModel, SheetList
+from cognite.neat.core._data_model.models.conceptual import Concept, ConceptualProperty
+from cognite.neat.core._data_model.models.data_types import DataType
+from cognite.neat.core._data_model.models.entities import (
+    ConceptEntity,
+    MultiValueTypeInfo,
+    UnknownEntity,
+)
+from cognite.neat.core._data_model.transformers import VerifiedDataModelTransformer
+from cognite.neat.core._issues.errors import NeatValueError
+
+
+class MergeConceptualDataModel(VerifiedDataModelTransformer[ConceptualDataModel, ConceptualDataModel]):
+    """Merges two conceptual models into one.
+    Args:
+        secondary: The secondary model. The primary model is the one that is passed to the transform method.
+        join: The join strategy for merging classes. To only keep classes from the primary model, use "primary".
+            To only keep classes from the secondary model, use "secondary". To keep all classes, use "combined".
+        priority: For properties that exist in both models, the priority determines which model's property is kept.
+            For example, if 'name' of a property exists in both models, and the priority is set to "primary",
+            the property from the primary model will be kept.
+        conflict_resolution: Applies to properties that can be combined. For example, if a property exists in both model
+            with different value types, then, if set to "priority", the model with the higher priority will be kept,
+            while if set to "combined", it will become a multivalued property.
+    """
+
+    def __init__(
+        self,
+        secondary: ConceptualDataModel,
+        join: Literal["primary", "secondary", "combined"] = "combined",
+        priority: Literal["primary", "secondary"] = "primary",
+        conflict_resolution: Literal["priority", "combined"] = "priority",
+    ) -> None:
+        self.secondary = secondary
+        self.join = join
+        self.priority = priority
+        self.conflict_resolution = conflict_resolution
+
+    def transform(self, rules: ConceptualDataModel) -> ConceptualDataModel:
+        if self.join in ["primary", "combined"]:
+            output = rules.model_copy(deep=True)
+            secondary_classes = {cls.concept: cls for cls in self.secondary.concepts}
+            secondary_properties = {(prop.concept, prop.property_): prop for prop in self.secondary.properties}
+        elif self.join == "secondary":
+            output = self.secondary.model_copy(deep=True)
+            secondary_classes = {cls.concept: cls for cls in rules.concepts}
+            secondary_properties = {(prop.concept, prop.property_): prop for prop in rules.properties}
+        else:
+            raise NeatValueError(
+                f"Invalid join strategy: {self.join}. Must be one of ['primary', 'secondary', 'combined']"
+            )
+
+        merged_concepts_by_id = self._merge_concepts(output.concepts, secondary_classes)
+        output.concepts = SheetList[Concept](merged_concepts_by_id.values())
+
+        merged_properties = self._merge_properties(
+            output.properties, secondary_properties, set(merged_concepts_by_id.keys())
+        )
+        output.properties = SheetList[ConceptualProperty](merged_properties.values())
+
+        return output
+
+    def _merge_concepts(
+        self, primary_classes: Iterable[Concept], new_classes: dict[ConceptEntity, Concept]
+    ) -> dict[ConceptEntity, Concept]:
+        merged_classes = {cls.concept: cls for cls in primary_classes}
+        for cls_, primary_cls in merged_classes.items():
+            if cls_ not in new_classes:
+                continue
+            secondary_cls = new_classes[cls_]
+            if self._swap_priority:
+                primary_cls, secondary_cls = secondary_cls, primary_cls
+            merged_classes[cls_] = self.merge_classes(
+                primary=primary_cls,
+                secondary=secondary_cls,
+                conflict_resolution=self.conflict_resolution,
+            )
+
+        if self.join == "combined":
+            for cls_, secondary_cls in new_classes.items():
+                if cls_ not in merged_classes:
+                    merged_classes[cls_] = secondary_cls
+        return merged_classes
+
+    def _merge_properties(
+        self,
+        primary_properties: Iterable[ConceptualProperty],
+        secondary_properties: dict[tuple[ConceptEntity, str], ConceptualProperty],
+        used_classes: Set[ConceptEntity],
+    ) -> dict[tuple[ConceptEntity, str], ConceptualProperty]:
+        merged_properties = {(prop.concept, prop.property_): prop for prop in primary_properties}
+        for (cls_, prop_id), primary_property in merged_properties.items():
+            if (cls_ not in used_classes) or (cls_, prop_id) not in secondary_properties:
+                continue
+            secondary_property = secondary_properties[(cls_, prop_id)]
+            if self._swap_priority:
+                primary_property, secondary_property = secondary_property, primary_property
+            merged_properties[(cls_, prop_id)] = self.merge_properties(
+                primary=primary_property,
+                secondary=secondary_property,
+                conflict_resolution=self.conflict_resolution,
+            )
+
+        if self.join == "combined":
+            for (cls_, prop_id), prop in secondary_properties.items():
+                if (cls_, prop_id) not in merged_properties and cls_ in used_classes:
+                    merged_properties[(cls_, prop_id)] = prop
+        return merged_properties
+
+    @property
+    def _swap_priority(self) -> bool:
+        """We swap the priority if 'join' and 'priority' are mismatched. For example, if
+        we use a 'primary' join strategy, i.e., selecting classes from the primary model, but prioritize the
+        secondary classes that matches the primary classes.
+        """
+
+        return (self.priority == "secondary" and (self.join in ["primary", "combined"])) or (
+            self.priority == "primary" and (self.join == "secondary")
+        )
+
+    @classmethod
+    def merge_classes(
+        cls,
+        primary: Concept,
+        secondary: Concept,
+        conflict_resolution: Literal["priority", "combined"] = "priority",
+    ) -> Concept:
+        # Combined = merge implements for both classes
+        # Priority = keep the primary with fallback to secondary
+        implements = (primary.implements or secondary.implements or []).copy()
+        if conflict_resolution == "combined":
+            seen = set(implements)
+            for cls_ in secondary.implements or []:
+                if cls_ not in seen:
+                    seen.add(cls_)
+                    implements.append(cls_)
+        return Concept(
+            neatId=primary.neatId,
+            concept=primary.concept,
+            name=primary.name or secondary.name,
+            description=primary.description or secondary.description,
+            implements=implements,
+            instance_source=primary.instance_source or secondary.instance_source,
+            physical=primary.physical,
+        )
+
+    @classmethod
+    def merge_properties(
+        cls,
+        primary: ConceptualProperty,
+        secondary: ConceptualProperty,
+        conflict_resolution: Literal["priority", "combined"] = "priority",
+    ) -> ConceptualProperty:
+        # Combined = merge value types and instance sources
+        # Priority = keep the primary with fallback to secondary
+        instance_source = (primary.instance_source or secondary.instance_source or []).copy()
+        if conflict_resolution == "combined":
+            seen = set(instance_source)
+            for source in secondary.instance_source or []:
+                if source not in seen:
+                    seen.add(source)
+                    instance_source.append(source)
+
+        use_primary = conflict_resolution == "priority"
+        return ConceptualProperty(
+            neatId=primary.neatId,
+            concept=primary.concept,
+            property_=primary.property_,
+            name=primary.name or secondary.name,
+            description=primary.description or secondary.description,
+            min_count=primary.min_count
+            if use_primary
+            else cls._merge_min_count(primary.min_count, secondary.min_count),
+            max_count=primary.max_count
+            if use_primary
+            else cls._merge_max_count(primary.max_count, secondary.max_count),
+            default=primary.default or secondary.default,
+            value_type=primary.value_type
+            if use_primary
+            else cls._merge_value_type(primary.value_type, secondary.value_type),
+            instance_source=instance_source,
+            inherited=primary.inherited,
+            physical=primary.physical,
+        )
+
+    @staticmethod
+    def _merge_min_count(primary: int | None, secondary: int | None) -> int | None:
+        if primary is None:
+            return secondary
+        if secondary is None:
+            return primary
+        return min(primary, secondary)
+
+    @staticmethod
+    def _merge_max_count(primary: int | float | None, secondary: int | float | None) -> int | float | None:
+        if primary is None:
+            return secondary
+        if secondary is None:
+            return primary
+        output = max(primary, secondary)
+        try:
+            return int(output)
+        except (OverflowError, ValueError):
+            # The value is float('inf') or float('-inf')
+            return output
+
+    @staticmethod
+    def _merge_value_type(
+        primary: DataType | ConceptEntity | MultiValueTypeInfo | UnknownEntity,
+        secondary: DataType | ConceptEntity | MultiValueTypeInfo | UnknownEntity,
+    ) -> DataType | ConceptEntity | MultiValueTypeInfo | UnknownEntity:
+        # We use a set and list to preserve the order of the types
+        # and to avoid duplicates
+        seen_types: set[DataType | ConceptEntity] = set()
+        ordered_types: list[DataType | ConceptEntity] = []
+        for type_ in (primary, secondary):
+            if isinstance(type_, MultiValueTypeInfo):
+                for t in type_.types:
+                    if t not in seen_types:
+                        seen_types.add(t)
+                        ordered_types.append(t)
+            elif isinstance(type_, ConceptEntity):
+                if type_ not in seen_types:
+                    seen_types.add(type_)
+                    ordered_types.append(type_)
+            elif isinstance(type_, DataType):
+                if type_ not in seen_types:
+                    seen_types.add(type_)
+                    ordered_types.append(type_)
+            else:
+                raise NotImplementedError(f"Unsupported type: {type_}")
+        if len(ordered_types) == 1:
+            return ordered_types[0]
+        elif len(ordered_types) > 1:
+            return MultiValueTypeInfo(types=ordered_types)
+        else:
+            return UnknownEntity()

--- a/tests/tests_unit/test_rules/test_transformers/test_merge_conceptual.py
+++ b/tests/tests_unit/test_rules/test_transformers/test_merge_conceptual.py
@@ -1,0 +1,172 @@
+from collections.abc import Iterable
+
+import pytest
+from rdflib import URIRef
+
+from cognite.neat.core._data_model.models import data_types as dt
+from cognite.neat.core._data_model.models.conceptual import (
+    Concept,
+    ConceptualProperty,
+    UnverifiedConcept,
+    UnverifiedConceptualDataModel,
+    UnverifiedConceptualMetadata,
+    UnverifiedConceptualProperty,
+)
+from cognite.neat.core._data_model.models.entities import ConceptEntity, MultiValueTypeInfo
+from cognite.neat.core._data_model.transformers import MergeConceptualDataModel
+
+
+def merge_model_test_cases() -> Iterable:
+    metadata = UnverifiedConceptualMetadata("my_space", "my_model", "v1", "doctrino")
+
+    single_cls1 = UnverifiedConceptualDataModel(
+        metadata=metadata,
+        concepts=[UnverifiedConcept("PrimaryClass")],
+        properties=[UnverifiedConceptualProperty("PrimaryClass", "primary_property", "text")],
+    )
+    single_cls2 = UnverifiedConceptualDataModel(
+        metadata=metadata,
+        concepts=[UnverifiedConcept("SecondaryClass")],
+        properties=[UnverifiedConceptualProperty("SecondaryClass", "secondary_property", "text")],
+    )
+    combined = UnverifiedConceptualDataModel(
+        metadata=metadata,
+        concepts=[UnverifiedConcept("PrimaryClass"), UnverifiedConcept("SecondaryClass")],
+        properties=[
+            UnverifiedConceptualProperty("PrimaryClass", "primary_property", "text"),
+            UnverifiedConceptualProperty("SecondaryClass", "secondary_property", "text"),
+        ],
+    )
+
+    yield pytest.param(
+        single_cls1,
+        single_cls2,
+        {"join": "primary", "priority": "primary", "conflict_resolution": "priority"},
+        single_cls1,
+        id="Merge with primary only",
+    )
+    yield pytest.param(
+        single_cls1,
+        single_cls2,
+        {"join": "secondary", "priority": "primary", "conflict_resolution": "priority"},
+        single_cls2,
+        id="Merge with secondary only",
+    )
+    yield pytest.param(
+        single_cls1,
+        single_cls2,
+        {"join": "combined", "priority": "primary", "conflict_resolution": "priority"},
+        combined,
+        id="Merge with combined",
+    )
+
+
+def merge_properties_test_cases() -> Iterable:
+    cls_ = ConceptEntity.load("my_space:Car")
+    first = ConceptualProperty(concept=cls_, property_="my_property", value_type=dt.String(), min_count=0, max_count=1)
+    second = ConceptualProperty(
+        concept=cls_,
+        property_="my_property",
+        value_type=dt.Integer(),
+        min_count=0,
+        max_count=5,
+        instance_source=[URIRef("my_source")],
+    )
+    yield pytest.param(
+        first,
+        second,
+        {"conflict_resolution": "priority"},
+        ConceptualProperty(
+            concept=cls_,
+            property_="my_property",
+            value_type=dt.String(),
+            min_count=0,
+            max_count=1,
+            instance_source=[URIRef("my_source")],
+        ),
+        id="Merge with priority",
+    )
+    yield pytest.param(
+        first,
+        second,
+        {"conflict_resolution": "combined"},
+        ConceptualProperty(
+            concept=cls_,
+            property_="my_property",
+            value_type=MultiValueTypeInfo(types=[dt.String(), dt.Integer()]),
+            min_count=0,
+            max_count=5,
+            instance_source=[URIRef("my_source")],
+        ),
+        id="Merge with combined",
+    )
+
+
+def merge_classes_test_cases() -> Iterable:
+    cls_ = ConceptEntity.load("my_space:Car")
+    first = Concept(concept=cls_, implements=[ConceptEntity.load("my_space:Vehicle")])
+    second = Concept(
+        concept=cls_, implements=[ConceptEntity.load("my_space:Thing")], instance_source=URIRef("my_source")
+    )
+    yield pytest.param(
+        first,
+        second,
+        {"conflict_resolution": "priority"},
+        Concept(concept=cls_, implements=[ConceptEntity.load("my_space:Vehicle")], instance_source=URIRef("my_source")),
+        id="Merge with priority",
+    )
+    yield pytest.param(
+        first,
+        second,
+        {"conflict_resolution": "combined"},
+        Concept(
+            concept=cls_,
+            implements=[ConceptEntity.load("my_space:Vehicle"), ConceptEntity.load("my_space:Thing")],
+            instance_source=URIRef("my_source"),
+        ),
+        id="Merge with combined",
+    )
+
+
+class TestMergeConceptual:
+    @pytest.mark.parametrize("primary, secondary, args, expected", list(merge_model_test_cases()))
+    def test_merge_models(
+        self,
+        primary: UnverifiedConceptualDataModel,
+        secondary: UnverifiedConceptualDataModel,
+        args: dict[str, object],
+        expected: UnverifiedConceptualDataModel,
+    ):
+        primary_model = primary.as_verified_data_model()
+        secondary_model = secondary.as_verified_data_model()
+        expected_model = expected.as_verified_data_model()
+
+        transformer = MergeConceptualDataModel(secondary_model, **args)
+        merged = transformer.transform(primary_model)
+
+        exclude = {"metadata": {"created", "updated"}}
+        assert merged.dump(exclude=exclude) == expected_model.dump(exclude=exclude)
+
+    @pytest.mark.parametrize("primary, secondary, args, expected", list(merge_properties_test_cases()))
+    def test_merge_properties(
+        self,
+        primary: ConceptualProperty,
+        secondary: ConceptualProperty,
+        args: dict[str, object],
+        expected: ConceptualProperty,
+    ) -> None:
+        actual = MergeConceptualDataModel.merge_properties(primary, secondary, **args)
+
+        assert actual.model_dump() == expected.model_dump()
+
+    @pytest.mark.parametrize("primary, secondary, args, expected", list(merge_classes_test_cases()))
+    def test_merge_classes(
+        self,
+        primary: Concept,
+        secondary: Concept,
+        args: dict[str, object],
+        expected: Concept,
+    ) -> None:
+        actual = MergeConceptualDataModel.merge_classes(primary, secondary, **args)
+
+        assert actual.model_dump() == expected.model_dump()


### PR DESCRIPTION
# Description

Added new transformer `MergeConceptual`. This transformer takes in two conceptual data models and merge them into one. This will, for example, be used when merging two data models from different sources, or to merge an existing model with an inferred model from data.

Note that we have a `MergeConceptualDataModels` today that is used in the subinference importer. This will be removed when this is added, and the inference importer is updated.


## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip
