### PR TITLE
Add JSON option in drop-down of Excel

### DIFF
--- a/cognite/neat/core/_data_model/exporters/_data_model2excel.py
+++ b/cognite/neat/core/_data_model/exporters/_data_model2excel.py
@@ -344,7 +344,7 @@ class ExcelExporter(BaseExporter[VerifiedDataModel, Workbook]):
         for value_type_counter, value_type in enumerate(_DATA_TYPE_BY_DMS_TYPE.values()):
             value_type_as_str = value_type.dms._type.casefold() if role == RoleTypes.dms else value_type.xsd
             # skip types which require special handling or are surpassed by CDM
-            if value_type_as_str in ["enum", "timeseries", "sequence", "file", "json"]:
+            if value_type_as_str in ["enum", "timeseries", "sequence", "file"]:
                 continue
             workbook[self._helper_sheet_name].cell(
                 row=value_type_counter + 1,

--- a/tests/tests_unit/test_rules/test_exporters/test_rules2excel.py
+++ b/tests/tests_unit/test_rules/test_exporters/test_rules2excel.py
@@ -110,6 +110,12 @@ class TestExcelExporter:
         assert expected["_helper"]["B11"].value == '=IF(ISBLANK(Concepts!A3), "", Concepts!A3)'
         assert resulted["_helper"]["B11"].value == '=IF(ISBLANK(Concepts!A3), "", Concepts!A3)'
 
+        # Get all values from a specific column (e.g., column A) in Properties sheet
+        column_values = [cell.value for cell in resulted["_helper"]["C"] if cell.value is not None]
+
+        # Check if "json" is in the values
+        assert "json" in column_values, "Expected 'json' to be found in Properties sheet column A"
+
     def test_conceptual_data_model_template_fail(self):
         exporter = ExcelExporter(base_model="NeatModel")
 

--- a/tests/tests_unit/test_rules/test_exporters/test_rules2excel.py
+++ b/tests/tests_unit/test_rules/test_exporters/test_rules2excel.py
@@ -110,8 +110,13 @@ class TestExcelExporter:
         assert expected["_helper"]["B11"].value == '=IF(ISBLANK(Concepts!A3), "", Concepts!A3)'
         assert resulted["_helper"]["B11"].value == '=IF(ISBLANK(Concepts!A3), "", Concepts!A3)'
 
-        # Get all values from a column C in _helper sheet where value types are stored
-        column_values = [cell.value for cell in resulted["_helper"]["C"] if cell.value is not None]
+        # Get all values from the "Value Type" column in the _helper sheet
+        value_type_col_idx = exporter._helper_sheet_column_indexes_by_names["Value Type"]
+        column_values = [
+            row[value_type_col_idx - 1].value
+            for row in resulted["_helper"].iter_rows()
+            if row[value_type_col_idx - 1].value is not None
+        ]
 
         # Check if "json" is in the values
         assert "json" in column_values, "Expected 'json' to be found in _helper sheet column C"

--- a/tests/tests_unit/test_rules/test_exporters/test_rules2excel.py
+++ b/tests/tests_unit/test_rules/test_exporters/test_rules2excel.py
@@ -111,15 +111,10 @@ class TestExcelExporter:
         assert resulted["_helper"]["B11"].value == '=IF(ISBLANK(Concepts!A3), "", Concepts!A3)'
 
         # Get all values from the "Value Type" column in the _helper sheet
+        # Check if "json" is in the values from the "Value Type" column in the _helper sheet
         value_type_col_idx = exporter._helper_sheet_column_indexes_by_names["Value Type"]
-        column_values = [
-            row[value_type_col_idx - 1].value
-            for row in resulted["_helper"].iter_rows()
-            if row[value_type_col_idx - 1].value is not None
-        ]
-
-        # Check if "json" is in the values
-        assert "json" in column_values, "Expected 'json' to be found in _helper sheet column C"
+        has_json = any(row[value_type_col_idx - 1].value == "json" for row in resulted["_helper"].iter_rows())
+        assert has_json, "Expected 'json' to be found in _helper sheet column C"
 
     def test_conceptual_data_model_template_fail(self):
         exporter = ExcelExporter(base_model="NeatModel")

--- a/tests/tests_unit/test_rules/test_exporters/test_rules2excel.py
+++ b/tests/tests_unit/test_rules/test_exporters/test_rules2excel.py
@@ -110,11 +110,11 @@ class TestExcelExporter:
         assert expected["_helper"]["B11"].value == '=IF(ISBLANK(Concepts!A3), "", Concepts!A3)'
         assert resulted["_helper"]["B11"].value == '=IF(ISBLANK(Concepts!A3), "", Concepts!A3)'
 
-        # Get all values from a specific column (e.g., column A) in Properties sheet
+        # Get all values from a column C in _helper sheet where value types are stored
         column_values = [cell.value for cell in resulted["_helper"]["C"] if cell.value is not None]
 
         # Check if "json" is in the values
-        assert "json" in column_values, "Expected 'json' to be found in Properties sheet column A"
+        assert "json" in column_values, "Expected 'json' to be found in _helper sheet column C"
 
     def test_conceptual_data_model_template_fail(self):
         exporter = ExcelExporter(base_model="NeatModel")


### PR DESCRIPTION
# Description

Added a new **JSON** to the drop-down menu in Excel, allowing users to select it as a value type for properties of concepts and views

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Added

- Added **JSON** as a selectable option in the Excel drop-down menu.