### PR TITLE
Physical dm not possible warning

### DIFF
--- a/cognite/neat/core/_data_model/models/conceptual/_validation.py
+++ b/cognite/neat/core/_data_model/models/conceptual/_validation.py
@@ -69,10 +69,8 @@ class ConceptualValidation:
 
     def _physical_data_model_conversion(self) -> None:
         if (
-            (
-                self.issue_list.has_warning_type(ConceptOnlyDataModelWarning)
-                and self.issue_list.has_warning_type(ResourceRegexViolationWarning)
-            )
+            self.issue_list.has_warning_type(ConceptOnlyDataModelWarning)
+            or self.issue_list.has_warning_type(ResourceRegexViolationWarning)
             or self.issue_list.has_warning_type(ResourceNotDefinedWarning)
             or self.issue_list.has_warning_type(UndefinedConceptWarning)
             or self.issue_list.has_warning_type(DanglingPropertyWarning)

--- a/cognite/neat/core/_data_model/models/conceptual/_validation.py
+++ b/cognite/neat/core/_data_model/models/conceptual/_validation.py
@@ -68,6 +68,8 @@ class ConceptualValidation:
         return self.issue_list
 
     def _physical_data_model_conversion(self) -> None:
+        """Check if the conceptual data model has issues that will likely lead
+        to problems when converting to a physical data model."""
         if (
             self.issue_list.has_warning_type(ConceptOnlyDataModelWarning)
             or self.issue_list.has_warning_type(ResourceRegexViolationWarning)

--- a/cognite/neat/core/_data_model/models/conceptual/_validation.py
+++ b/cognite/neat/core/_data_model/models/conceptual/_validation.py
@@ -78,8 +78,14 @@ class ConceptualValidation:
             DanglingPropertyWarning,
         ]
 
-        if any(self.issue_list.has_warning_type(warning_type) for warning_type in warning_types_preventing_conversion):
-            self.issue_list.append_if_not_exist(ConversionToPhysicalModelImpossibleWarning())
+        if seen_warnings := [
+            warning_type.__name__
+            for warning_type in warning_types_preventing_conversion
+            if self.issue_list.has_warning_type(warning_type)
+        ]:
+            self.issue_list.append_if_not_exist(
+                ConversionToPhysicalModelImpossibleWarning(issue_types=", ".join(seen_warnings))
+            )
 
     def _concept_only_data_model(self) -> None:
         """Check if the data model only consists of concepts without any properties."""

--- a/cognite/neat/core/_data_model/models/conceptual/_validation.py
+++ b/cognite/neat/core/_data_model/models/conceptual/_validation.py
@@ -70,13 +70,15 @@ class ConceptualValidation:
     def _physical_data_model_conversion(self) -> None:
         """Check if the conceptual data model has issues that will likely lead
         to problems when converting to a physical data model."""
-        if (
-            self.issue_list.has_warning_type(ConceptOnlyDataModelWarning)
-            or self.issue_list.has_warning_type(ResourceRegexViolationWarning)
-            or self.issue_list.has_warning_type(ResourceNotDefinedWarning)
-            or self.issue_list.has_warning_type(UndefinedConceptWarning)
-            or self.issue_list.has_warning_type(DanglingPropertyWarning)
-        ):
+        warning_types_preventing_conversion = [
+            ConceptOnlyDataModelWarning,
+            ResourceRegexViolationWarning,
+            ResourceNotDefinedWarning,
+            UndefinedConceptWarning,
+            DanglingPropertyWarning,
+        ]
+
+        if any(self.issue_list.has_warning_type(warning_type) for warning_type in warning_types_preventing_conversion):
             self.issue_list.append_if_not_exist(ConversionToPhysicalModelImpossibleWarning())
 
     def _concept_only_data_model(self) -> None:

--- a/cognite/neat/core/_data_model/models/conceptual/_validation.py
+++ b/cognite/neat/core/_data_model/models/conceptual/_validation.py
@@ -14,6 +14,7 @@ from cognite.neat.core._issues.errors._resources import (
 )
 from cognite.neat.core._issues.warnings._models import (
     ConceptOnlyDataModelWarning,
+    ConversionToPhysicalModelImpossibleWarning,
     DanglingPropertyWarning,
     UndefinedConceptWarning,
 )
@@ -62,8 +63,21 @@ class ConceptualValidation:
 
         self._concept_only_data_model()
         self._regex_compliance_with_physical_data_model()
+        self._physical_data_model_conversion()
 
         return self.issue_list
+
+    def _physical_data_model_conversion(self) -> None:
+        if (
+            (
+                self.issue_list.has_warning_type(ConceptOnlyDataModelWarning)
+                and self.issue_list.has_warning_type(ResourceRegexViolationWarning)
+            )
+            or self.issue_list.has_warning_type(ResourceNotDefinedWarning)
+            or self.issue_list.has_warning_type(UndefinedConceptWarning)
+            or self.issue_list.has_warning_type(DanglingPropertyWarning)
+        ):
+            self.issue_list.append_if_not_exist(ConversionToPhysicalModelImpossibleWarning())
 
     def _concept_only_data_model(self) -> None:
         """Check if the data model only consists of concepts without any properties."""

--- a/cognite/neat/core/_issues/warnings/__init__.py
+++ b/cognite/neat/core/_issues/warnings/__init__.py
@@ -23,6 +23,7 @@ from ._general import (
 from ._models import (
     BreakingModelingPrincipleWarning,
     CDFNotSupportedWarning,
+    ConversionToPhysicalModelImpossibleWarning,
     NotSupportedHasDataFilterLimitWarning,
     NotSupportedViewContainerLimitWarning,
     PrincipleMatchingSpaceAndVersionWarning,
@@ -58,6 +59,7 @@ __all__ = [
     "CDFAuthWarning",
     "CDFMaxIterationsWarning",
     "CDFNotSupportedWarning",
+    "ConversionToPhysicalModelImpossibleWarning",
     "DeprecatedWarning",
     "FileItemNotSupportedWarning",
     "FileMissingRequiredFieldWarning",

--- a/cognite/neat/core/_issues/warnings/_models.py
+++ b/cognite/neat/core/_issues/warnings/_models.py
@@ -110,6 +110,13 @@ class ConceptOnlyDataModelWarning(UserModelingWarning):
 
 
 @dataclass(unsafe_hash=True)
+class ConversionToPhysicalModelImpossibleWarning(UserModelingWarning):
+    """Conceptual data model has issues that will likely lead to problems when converting to a physical data model."""
+
+    fix = "Fix the issues in the conceptual data model before attempting to convert it to a physical data model."
+
+
+@dataclass(unsafe_hash=True)
 class DanglingPropertyWarning(UserModelingWarning):
     """Property {property_id} is not defined for any concept.
     This will likely cause issues when converting to a physical data model."""

--- a/cognite/neat/core/_issues/warnings/_models.py
+++ b/cognite/neat/core/_issues/warnings/_models.py
@@ -111,9 +111,10 @@ class ConceptOnlyDataModelWarning(UserModelingWarning):
 
 @dataclass(unsafe_hash=True)
 class ConversionToPhysicalModelImpossibleWarning(UserModelingWarning):
-    """Conceptual data model has issues that will likely lead to problems when converting to a physical data model."""
+    """Conceptual data model has {issue_types} that will lead to problems when converting to a physical data model."""
 
     fix = "Fix the issues in the conceptual data model before attempting to convert it to a physical data model."
+    issue_types: str
 
 
 @dataclass(unsafe_hash=True)

--- a/cognite/neat/session/_base.py
+++ b/cognite/neat/session/_base.py
@@ -173,6 +173,7 @@ class NeatSession:
             "Convert to physical",
             has_physical_data_model=False,
             has_conceptual_data_model=True,
+            can_convert_to_physical_data_model=True,
         )
         converter = ConceptualToPhysical(reserved_properties=reserved_properties, client=self._state.client)
 

--- a/cognite/neat/session/_state.py
+++ b/cognite/neat/session/_state.py
@@ -74,7 +74,7 @@ class SessionState:
         instances_required: bool = False,
         client_required: bool = False,
         has_conceptual_data_model: bool | None = None,
-        can_convert_to_physical_data_model: bool = True,
+        can_convert_to_physical_data_model: bool = False,
         has_physical_data_model: bool | None = None,
     ) -> None:
         """Set conditions for raising an error in the session that are used by various methods in the session."""

--- a/tests/tests_end_to_end/test_rules_flow.py
+++ b/tests/tests_end_to_end/test_rules_flow.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 from pathlib import Path
 
 import pytest
@@ -25,6 +27,18 @@ class TestImportersToYAMLExporter:
 
         exported_rules = yaml.safe_load(exported_yaml_str)
         data_regression.check(exported_rules)
+
+    def test_prohibiting_conversion_with_nice_message(self) -> None:
+        neat = NeatSession()
+
+        neat.read.rdf.ontology(SchemaData.Conceptual.ontology_with_regex_warnings)
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            neat.convert()
+
+        printed_statements = output.getvalue()
+        assert "[ERROR] Cannot convert" in printed_statements
 
     @pytest.mark.freeze_time("2017-05-21")
     @pytest.mark.skip("Needs NEAT-608 to be completed")

--- a/tests/tests_unit/test_rules/test_importers/test_owl_importer.py
+++ b/tests/tests_unit/test_rules/test_importers/test_owl_importer.py
@@ -14,7 +14,7 @@ def test_ill_formed_owl_importer():
     with catch_issues() as issues:
         _ = VerifyAnyDataModel().transform(input)
 
-    assert len(issues) == 6
+    assert len(issues) == 7
     assert issues.has_errors
     assert str(issues.errors[0].identifier) == "neat_space:Award"
 

--- a/tests/tests_unit/test_rules/test_models/test_conceptual_model.py
+++ b/tests/tests_unit/test_rules/test_models/test_conceptual_model.py
@@ -35,7 +35,12 @@ from cognite.neat.core._issues._base import MultiValueError
 from cognite.neat.core._issues._contextmanagers import catch_issues
 from cognite.neat.core._issues.errors import ResourceNotDefinedError
 from cognite.neat.core._issues.errors._resources import ResourceDuplicatedError
-from cognite.neat.core._issues.warnings._models import ConceptOnlyDataModelWarning, DanglingPropertyWarning
+from cognite.neat.core._issues.warnings._models import (
+    ConceptOnlyDataModelWarning,
+    ConversionToPhysicalModelImpossibleWarning,
+    DanglingPropertyWarning,
+    UndefinedConceptWarning,
+)
 
 
 def case_insensitive_value_types():
@@ -328,8 +333,9 @@ class TestInformationRules:
             _ = VerifyAnyDataModel(validate=True).transform(input_rules)
 
         assert not issues.has_errors
-        assert len(issues) == 3
-        assert len([issue for issue in issues if isinstance(issue, ConceptOnlyDataModelWarning)]) == 1
+        assert issues.has_warning_type(ConceptOnlyDataModelWarning)
+        assert issues.has_warning_type(ConversionToPhysicalModelImpossibleWarning)
+        assert issues.has_warning_type(UndefinedConceptWarning)
 
     def test_load_valid_jon_rules(self, david_spreadsheet: dict[str, dict[str, Any]]) -> None:
         valid_rules = ConceptualDataModel.model_validate(UnverifiedConceptualDataModel.load(david_spreadsheet).dump())


### PR DESCRIPTION
# Description

Improved user-friendliness when attempting to convert conceptual data model to physical for cases when that is not possible. Previously python traceback was thrown at users:

<img width="1130" height="837" alt="Screenshot 2025-07-24 at 17 38 35" src="https://github.com/user-attachments/assets/b2274f98-5c54-4d4d-9347-8c4ae27b3c30" />

now we indicate that conversion is not possible to perform
<img width="1076" height="587" alt="Screenshot 2025-07-24 at 17 39 00" src="https://github.com/user-attachments/assets/d618f87b-3965-4836-b427-4d1b56f91783" />

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Improved

- Added additional "overall" warning that is indicating wether conceptual data model is possible to convert to physical or not, which is used as flag to trigger stop on conversion process in `NeatSession`
