### PR TITLE
Generic context on Imported Data Model

### DIFF
--- a/cognite/neat/core/_data_model/_shared.py
+++ b/cognite/neat/core/_data_model/_shared.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Generic, TypeAlias, TypeVar
 
@@ -11,7 +12,6 @@ from cognite.neat.core._data_model.models.conceptual._unverified import (
 from cognite.neat.core._data_model.models.physical._unverified import (
     UnverifiedPhysicalDataModel,
 )
-from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 
 VerifiedDataModel: TypeAlias = ConceptualDataModel | PhysicalDataModel
 
@@ -32,7 +32,7 @@ class ImportedDataModel(Generic[T_UnverifiedDataModel]):
     """
 
     unverified_data_model: T_UnverifiedDataModel | None
-    context: dict[str, SpreadsheetRead]
+    context: Mapping[str, object]
 
     @classmethod
     def display_type_name(cls) -> str:

--- a/cognite/neat/core/_data_model/_shared.py
+++ b/cognite/neat/core/_data_model/_shared.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Hashable, ItemsView, Iterator, KeysView, Mapping, ValuesView
 from dataclasses import dataclass
 from typing import Generic, TypeAlias, TypeVar
 
@@ -12,12 +12,65 @@ from cognite.neat.core._data_model.models.conceptual._unverified import (
 from cognite.neat.core._data_model.models.physical._unverified import (
     UnverifiedPhysicalDataModel,
 )
+from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 
 VerifiedDataModel: TypeAlias = ConceptualDataModel | PhysicalDataModel
 
 T_VerifiedDataModel = TypeVar("T_VerifiedDataModel", bound=VerifiedDataModel)
 UnverifiedDataModel: TypeAlias = UnverifiedPhysicalDataModel | UnverifiedConceptualDataModel
 T_UnverifiedDataModel = TypeVar("T_UnverifiedDataModel", bound=UnverifiedDataModel)
+
+T_Key = TypeVar("T_Key", bound=Hashable)
+T_Value = TypeVar("T_Value")
+
+
+class ImportContext(dict, Mapping[T_Key, T_Value]):
+    # The below methods are included to make better type hints in the IDE
+    def __getitem__(self, k: T_Key) -> T_Value:
+        return super().__getitem__(k)
+
+    def __setitem__(self, k: T_Key, v: T_Value) -> None:
+        super().__setitem__(k, v)
+
+    def __delitem__(self, k: T_Key) -> None:
+        super().__delitem__(k)
+
+    def __iter__(self) -> Iterator[T_Key]:
+        return super().__iter__()
+
+    def keys(self) -> KeysView[T_Key]:  # type: ignore[override]
+        return super().keys()
+
+    def values(self) -> ValuesView[T_Value]:  # type: ignore[override]
+        return super().values()
+
+    def items(self) -> ItemsView[T_Key, T_Value]:  # type: ignore[override]
+        return super().items()
+
+    def get(self, __key: T_Key, __default: T_Value = ...) -> T_Value:  # type: ignore[override, assignment]
+        return super().get(__key, __default)
+
+    def pop(self, __key: T_Key, __default: T_Value = ...) -> T_Value:  # type: ignore[override, assignment]
+        return super().pop(__key, __default)
+
+    def popitem(self) -> tuple[T_Key, T_Value]:
+        return super().popitem()
+
+
+class SpreadsheetContext(ImportContext[str, SpreadsheetRead]):
+    def __init__(self, data: dict[str, SpreadsheetRead] | None = None) -> None:
+        """Initialize the SpreadsheetContext with a dictionary of SpreadsheetRead objects.
+
+        Args:
+            data (dict[str, SpreadsheetRead]): A dictionary where keys are sheet names and values are
+                SpreadsheetRead objects containing the read data.
+        """
+        super().__init__(data or {})
+        for k, v in self.items():
+            if not isinstance(k, str):
+                raise TypeError(f"Expected string key, got {type(k).__name__}")
+            if not isinstance(v, SpreadsheetRead):
+                raise TypeError(f"Expected SpreadsheetRead for key '{k}', got {type(v).__name__}")
 
 
 @dataclass
@@ -32,7 +85,7 @@ class ImportedDataModel(Generic[T_UnverifiedDataModel]):
     """
 
     unverified_data_model: T_UnverifiedDataModel | None
-    context: Mapping[str, object]
+    context: ImportContext | None = None
 
     @classmethod
     def display_type_name(cls) -> str:

--- a/cognite/neat/core/_data_model/_shared.py
+++ b/cognite/neat/core/_data_model/_shared.py
@@ -1,4 +1,3 @@
-from collections.abc import Hashable, ItemsView, Iterator, KeysView, Mapping, ValuesView
 from dataclasses import dataclass
 from typing import Generic, TypeAlias, TypeVar
 
@@ -6,71 +5,19 @@ from cognite.neat.core._data_model.models import (
     ConceptualDataModel,
     PhysicalDataModel,
 )
+from cognite.neat.core._data_model.models._import_contexts import ImportContext
 from cognite.neat.core._data_model.models.conceptual._unverified import (
     UnverifiedConceptualDataModel,
 )
 from cognite.neat.core._data_model.models.physical._unverified import (
     UnverifiedPhysicalDataModel,
 )
-from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 
 VerifiedDataModel: TypeAlias = ConceptualDataModel | PhysicalDataModel
 
 T_VerifiedDataModel = TypeVar("T_VerifiedDataModel", bound=VerifiedDataModel)
 UnverifiedDataModel: TypeAlias = UnverifiedPhysicalDataModel | UnverifiedConceptualDataModel
 T_UnverifiedDataModel = TypeVar("T_UnverifiedDataModel", bound=UnverifiedDataModel)
-
-T_Key = TypeVar("T_Key", bound=Hashable)
-T_Value = TypeVar("T_Value")
-
-
-class ImportContext(dict, Mapping[T_Key, T_Value]):
-    # The below methods are included to make better type hints in the IDE
-    def __getitem__(self, k: T_Key) -> T_Value:
-        return super().__getitem__(k)
-
-    def __setitem__(self, k: T_Key, v: T_Value) -> None:
-        super().__setitem__(k, v)
-
-    def __delitem__(self, k: T_Key) -> None:
-        super().__delitem__(k)
-
-    def __iter__(self) -> Iterator[T_Key]:
-        return super().__iter__()
-
-    def keys(self) -> KeysView[T_Key]:  # type: ignore[override]
-        return super().keys()
-
-    def values(self) -> ValuesView[T_Value]:  # type: ignore[override]
-        return super().values()
-
-    def items(self) -> ItemsView[T_Key, T_Value]:  # type: ignore[override]
-        return super().items()
-
-    def get(self, __key: T_Key, __default: T_Value = ...) -> T_Value:  # type: ignore[override, assignment]
-        return super().get(__key, __default)
-
-    def pop(self, __key: T_Key, __default: T_Value = ...) -> T_Value:  # type: ignore[override, assignment]
-        return super().pop(__key, __default)
-
-    def popitem(self) -> tuple[T_Key, T_Value]:
-        return super().popitem()
-
-
-class SpreadsheetContext(ImportContext[str, SpreadsheetRead]):
-    def __init__(self, data: dict[str, SpreadsheetRead] | None = None) -> None:
-        """Initialize the SpreadsheetContext with a dictionary of SpreadsheetRead objects.
-
-        Args:
-            data (dict[str, SpreadsheetRead]): A dictionary where keys are sheet names and values are
-                SpreadsheetRead objects containing the read data.
-        """
-        super().__init__(data or {})
-        for k, v in self.items():
-            if not isinstance(k, str):
-                raise TypeError(f"Expected string key, got {type(k).__name__}")
-            if not isinstance(v, SpreadsheetRead):
-                raise TypeError(f"Expected SpreadsheetRead for key '{k}', got {type(v).__name__}")
 
 
 @dataclass

--- a/cognite/neat/core/_data_model/importers/_dict2data_model.py
+++ b/cognite/neat/core/_data_model/importers/_dict2data_model.py
@@ -128,4 +128,4 @@ class DictImporter(BaseImporter[T_UnverifiedDataModel]):
         if self._read_issues.has_errors:
             raise MultiValueError(self._read_issues.errors)
 
-        return ImportedDataModel[T_UnverifiedDataModel](data_model, {})
+        return ImportedDataModel[T_UnverifiedDataModel](data_model)

--- a/cognite/neat/core/_data_model/importers/_dms2data_model.py
+++ b/cognite/neat/core/_data_model/importers/_dms2data_model.py
@@ -276,7 +276,7 @@ class DMSImporter(BaseImporter[UnverifiedPhysicalDataModel]):
         self.issue_list.trigger_warnings()
         if self.issue_list.has_errors:
             raise MultiValueError(self.issue_list.errors)
-        return ImportedDataModel(user_data_model, {})
+        return ImportedDataModel(user_data_model, None)
 
     def _create_data_model_components(
         self,

--- a/cognite/neat/core/_data_model/importers/_rdf/_base.py
+++ b/cognite/neat/core/_data_model/importers/_rdf/_base.py
@@ -130,7 +130,7 @@ class BaseRDFImporter(BaseImporter[UnverifiedConceptualDataModel]):
 
         data_model = UnverifiedConceptualDataModel.load(data_model_dict)
         self.issue_list.trigger_warnings()
-        return ImportedDataModel(data_model, {})
+        return ImportedDataModel(data_model)
 
     def _to_data_model_components(self) -> dict:
         raise NotImplementedError()

--- a/cognite/neat/core/_data_model/importers/_spreadsheet2data_model.py
+++ b/cognite/neat/core/_data_model/importers/_spreadsheet2data_model.py
@@ -14,6 +14,7 @@ from rdflib import Namespace, URIRef
 
 from cognite.neat.core._data_model._shared import (
     ImportedDataModel,
+    SpreadsheetContext,
     T_UnverifiedDataModel,
 )
 from cognite.neat.core._data_model.models import (
@@ -271,7 +272,7 @@ class ExcelImporter(BaseImporter[T_UnverifiedDataModel]):
             raise MultiValueError(issue_list.errors)
 
         if user_read is None:
-            return ImportedDataModel(None, {})
+            return ImportedDataModel(None, None)
 
         sheets = user_read.sheets
         original_role = user_read.role
@@ -287,7 +288,7 @@ class ExcelImporter(BaseImporter[T_UnverifiedDataModel]):
             except Exception as e:
                 issue_list.append(FileReadError(self.filepath, f"Failed to delete temporary file: {e}"))
 
-        return ImportedDataModel(data_model, read_info_by_sheet)
+        return ImportedDataModel(data_model, SpreadsheetContext(read_info_by_sheet))
 
     @property
     def description(self) -> str:

--- a/cognite/neat/core/_data_model/importers/_spreadsheet2data_model.py
+++ b/cognite/neat/core/_data_model/importers/_spreadsheet2data_model.py
@@ -14,7 +14,6 @@ from rdflib import Namespace, URIRef
 
 from cognite.neat.core._data_model._shared import (
     ImportedDataModel,
-    SpreadsheetContext,
     T_UnverifiedDataModel,
 )
 from cognite.neat.core._data_model.models import (
@@ -23,6 +22,7 @@ from cognite.neat.core._data_model.models import (
     RoleTypes,
     SchemaCompleteness,
 )
+from cognite.neat.core._data_model.models._import_contexts import SpreadsheetContext
 from cognite.neat.core._issues import IssueList, MultiValueError
 from cognite.neat.core._issues.errors import (
     FileMissingRequiredFieldError,

--- a/cognite/neat/core/_data_model/models/_import_contexts.py
+++ b/cognite/neat/core/_data_model/models/_import_contexts.py
@@ -8,6 +8,9 @@ T_Value = TypeVar("T_Value")
 
 
 class ImportContext(dict, Mapping[T_Key, T_Value]):
+    def __init__(self, data: Mapping[T_Key, T_Value] | None = None) -> None:
+        super().__init__(data or {})
+
     # The below methods are included to make better type hints in the IDE
     def __getitem__(self, k: T_Key) -> T_Value:
         return super().__getitem__(k)
@@ -30,10 +33,10 @@ class ImportContext(dict, Mapping[T_Key, T_Value]):
     def items(self) -> ItemsView[T_Key, T_Value]:  # type: ignore[override]
         return super().items()
 
-    def get(self, __key: T_Key, __default: T_Value = ...) -> T_Value:  # type: ignore[override, assignment]
+    def get(self, __key: T_Key, __default: T_Value | None = None) -> T_Value:  # type: ignore[override]
         return super().get(__key, __default)
 
-    def pop(self, __key: T_Key, __default: T_Value = ...) -> T_Value:  # type: ignore[override, assignment]
+    def pop(self, __key: T_Key, __default: T_Value | None = None) -> T_Value:  # type: ignore[override]
         return super().pop(__key, __default)
 
     def popitem(self) -> tuple[T_Key, T_Value]:

--- a/cognite/neat/core/_data_model/models/_import_contexts.py
+++ b/cognite/neat/core/_data_model/models/_import_contexts.py
@@ -1,0 +1,56 @@
+from collections.abc import Hashable, ItemsView, Iterator, KeysView, Mapping, ValuesView
+from typing import TypeVar
+
+from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
+
+T_Key = TypeVar("T_Key", bound=Hashable)
+T_Value = TypeVar("T_Value")
+
+
+class ImportContext(dict, Mapping[T_Key, T_Value]):
+    # The below methods are included to make better type hints in the IDE
+    def __getitem__(self, k: T_Key) -> T_Value:
+        return super().__getitem__(k)
+
+    def __setitem__(self, k: T_Key, v: T_Value) -> None:
+        super().__setitem__(k, v)
+
+    def __delitem__(self, k: T_Key) -> None:
+        super().__delitem__(k)
+
+    def __iter__(self) -> Iterator[T_Key]:
+        return super().__iter__()
+
+    def keys(self) -> KeysView[T_Key]:  # type: ignore[override]
+        return super().keys()
+
+    def values(self) -> ValuesView[T_Value]:  # type: ignore[override]
+        return super().values()
+
+    def items(self) -> ItemsView[T_Key, T_Value]:  # type: ignore[override]
+        return super().items()
+
+    def get(self, __key: T_Key, __default: T_Value = ...) -> T_Value:  # type: ignore[override, assignment]
+        return super().get(__key, __default)
+
+    def pop(self, __key: T_Key, __default: T_Value = ...) -> T_Value:  # type: ignore[override, assignment]
+        return super().pop(__key, __default)
+
+    def popitem(self) -> tuple[T_Key, T_Value]:
+        return super().popitem()
+
+
+class SpreadsheetContext(ImportContext[str, SpreadsheetRead]):
+    def __init__(self, data: dict[str, SpreadsheetRead] | None = None) -> None:
+        """Initialize the SpreadsheetContext with a dictionary of SpreadsheetRead objects.
+
+        Args:
+            data (dict[str, SpreadsheetRead]): A dictionary where keys are sheet names and values are
+                SpreadsheetRead objects containing the read data.
+        """
+        super().__init__(data or {})
+        for k, v in self.items():
+            if not isinstance(k, str):
+                raise TypeError(f"Expected string key, got {type(k).__name__}")
+            if not isinstance(v, SpreadsheetRead):
+                raise TypeError(f"Expected SpreadsheetRead for key '{k}', got {type(v).__name__}")

--- a/cognite/neat/core/_data_model/models/conceptual/_validation.py
+++ b/cognite/neat/core/_data_model/models/conceptual/_validation.py
@@ -1,9 +1,9 @@
 import itertools
 from collections import Counter, defaultdict
-from collections.abc import Iterable, Mapping
 
 from cognite.neat.core._constants import get_base_concepts
 from cognite.neat.core._data_model._constants import PATTERNS, EntityTypes
+from cognite.neat.core._data_model._shared import ImportContext, SpreadsheetContext
 from cognite.neat.core._data_model.models.entities import ConceptEntity, UnknownEntity
 from cognite.neat.core._data_model.models.entities._multi_value import MultiValueTypeInfo
 from cognite.neat.core._issues import IssueList
@@ -22,7 +22,6 @@ from cognite.neat.core._issues.warnings._resources import (
     ResourceNotDefinedWarning,
     ResourceRegexViolationWarning,
 )
-from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 from cognite.neat.core._utils.text import humanize_collection
 
 from ._verified import ConceptualDataModel
@@ -35,16 +34,14 @@ class ConceptualValidation:
     def __init__(
         self,
         data_model: ConceptualDataModel,
-        context: Mapping[str, object] | None = None,
+        context: ImportContext | None = None,
     ):
         # import here to avoid circular import issues
         from cognite.neat.core._data_model.analysis._base import DataModelAnalysis
 
         self.data_model = data_model
         self.analysis = DataModelAnalysis(self.data_model)
-        self._read_info_by_spreadsheet = {
-            key: value for key, value in (context or {}).items() if isinstance(value, SpreadsheetRead)
-        }
+        self._read_info_by_spreadsheet = context if isinstance(context, SpreadsheetContext) else SpreadsheetContext({})
         self._metadata = data_model.metadata
         self._properties = data_model.properties
         self._concepts = data_model.concepts

--- a/cognite/neat/core/_data_model/models/conceptual/_validation.py
+++ b/cognite/neat/core/_data_model/models/conceptual/_validation.py
@@ -3,7 +3,7 @@ from collections import Counter, defaultdict
 
 from cognite.neat.core._constants import get_base_concepts
 from cognite.neat.core._data_model._constants import PATTERNS, EntityTypes
-from cognite.neat.core._data_model._shared import ImportContext, SpreadsheetContext
+from cognite.neat.core._data_model.models._import_contexts import ImportContext, SpreadsheetContext
 from cognite.neat.core._data_model.models.entities import ConceptEntity, UnknownEntity
 from cognite.neat.core._data_model.models.entities._multi_value import MultiValueTypeInfo
 from cognite.neat.core._issues import IssueList

--- a/cognite/neat/core/_data_model/models/conceptual/_validation.py
+++ b/cognite/neat/core/_data_model/models/conceptual/_validation.py
@@ -1,5 +1,6 @@
 import itertools
 from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
 
 from cognite.neat.core._constants import get_base_concepts
 from cognite.neat.core._data_model._constants import PATTERNS, EntityTypes
@@ -34,14 +35,16 @@ class ConceptualValidation:
     def __init__(
         self,
         data_model: ConceptualDataModel,
-        read_info_by_spreadsheet: dict[str, SpreadsheetRead] | None = None,
+        context: Mapping[str, object] | None = None,
     ):
         # import here to avoid circular import issues
         from cognite.neat.core._data_model.analysis._base import DataModelAnalysis
 
         self.data_model = data_model
         self.analysis = DataModelAnalysis(self.data_model)
-        self._read_info_by_spreadsheet = read_info_by_spreadsheet or {}
+        self._read_info_by_spreadsheet = {
+            key: value for key, value in (context or {}).items() if isinstance(value, SpreadsheetRead)
+        }
         self._metadata = data_model.metadata
         self._properties = data_model.properties
         self._concepts = data_model.concepts

--- a/cognite/neat/core/_data_model/models/physical/_validation.py
+++ b/cognite/neat/core/_data_model/models/physical/_validation.py
@@ -22,7 +22,7 @@ from cognite.neat.core._constants import (
     DMS_CONTAINER_PROPERTY_SIZE_LIMIT,
     DMS_VIEW_CONTAINER_SIZE_LIMIT,
 )
-from cognite.neat.core._data_model._shared import ImportContext, SpreadsheetContext
+from cognite.neat.core._data_model.models._import_contexts import ImportContext, SpreadsheetContext
 from cognite.neat.core._data_model.models.data_types import DataType
 from cognite.neat.core._data_model.models.entities import ContainerEntity, RawFilter
 from cognite.neat.core._data_model.models.entities._single_value import (

--- a/cognite/neat/core/_data_model/models/physical/_validation.py
+++ b/cognite/neat/core/_data_model/models/physical/_validation.py
@@ -81,7 +81,7 @@ class PhysicalValidation:
         self,
         data_model: PhysicalDataModel,
         client: NeatClient | None = None,
-        read_info_by_spreadsheet: dict[str, SpreadsheetRead] | None = None,
+        context: Mapping[str, object] | None = None,
     ) -> None:
         self._data_model = data_model
         self._client = client
@@ -89,7 +89,9 @@ class PhysicalValidation:
         self._properties = data_model.properties
         self._containers = data_model.containers
         self._views = data_model.views
-        self._read_info_by_spreadsheet = read_info_by_spreadsheet or {}
+        self._read_info_by_spreadsheet = {
+            key: value for key, value in (context or {}).items() if isinstance(value, SpreadsheetRead)
+        }
 
     def imported_views_and_containers_ids(
         self, include_views_with_no_properties: bool = True

--- a/cognite/neat/core/_data_model/models/physical/_validation.py
+++ b/cognite/neat/core/_data_model/models/physical/_validation.py
@@ -22,6 +22,7 @@ from cognite.neat.core._constants import (
     DMS_CONTAINER_PROPERTY_SIZE_LIMIT,
     DMS_VIEW_CONTAINER_SIZE_LIMIT,
 )
+from cognite.neat.core._data_model._shared import ImportContext, SpreadsheetContext
 from cognite.neat.core._data_model.models.data_types import DataType
 from cognite.neat.core._data_model.models.entities import ContainerEntity, RawFilter
 from cognite.neat.core._data_model.models.entities._single_value import (
@@ -52,7 +53,6 @@ from cognite.neat.core._issues.warnings.user_modeling import (
     DirectRelationMissingSourceWarning,
     NotNeatSupportedFilterWarning,
 )
-from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 from cognite.neat.core._utils.text import humanize_collection
 
 from ._verified import PhysicalDataModel, PhysicalProperty
@@ -81,7 +81,7 @@ class PhysicalValidation:
         self,
         data_model: PhysicalDataModel,
         client: NeatClient | None = None,
-        context: Mapping[str, object] | None = None,
+        context: ImportContext | None = None,
     ) -> None:
         self._data_model = data_model
         self._client = client
@@ -89,9 +89,7 @@ class PhysicalValidation:
         self._properties = data_model.properties
         self._containers = data_model.containers
         self._views = data_model.views
-        self._read_info_by_spreadsheet = {
-            key: value for key, value in (context or {}).items() if isinstance(value, SpreadsheetRead)
-        }
+        self._read_info_by_spreadsheet = context if isinstance(context, SpreadsheetContext) else SpreadsheetContext()
 
     def imported_views_and_containers_ids(
         self, include_views_with_no_properties: bool = True

--- a/cognite/neat/core/_data_model/transformers/_converters.py
+++ b/cognite/neat/core/_data_model/transformers/_converters.py
@@ -31,6 +31,7 @@ from cognite.neat.core._constants import (
 )
 from cognite.neat.core._data_model._constants import PATTERNS, get_reserved_words
 from cognite.neat.core._data_model._shared import (
+    ImportContext,
     ImportedDataModel,
     ImportedUnverifiedDataModel,
     VerifiedDataModel,
@@ -2411,13 +2412,13 @@ class AddCogniteProperties(
                 concepts=new_classes,
                 prefixes=input_.prefixes,
             ),
-            context={},
+            context=None,
         )
 
     @staticmethod
     def _get_properties_by_concepts(
         properties: list[UnverifiedConceptualProperty],
-        read_context: Mapping[str, object],
+        read_context: ImportContext | None,
         default_space: str,
     ) -> dict[ConceptEntity, dict[str, UnverifiedConceptualProperty]]:
         issues = IssueList()
@@ -2437,7 +2438,7 @@ class AddCogniteProperties(
     @staticmethod
     def _get_dependencies_by_concepts(
         concepts: list[UnverifiedConcept],
-        read_context: Mapping[str, object],
+        read_context: ImportContext | None,
         default_space: str,
     ) -> dict[ConceptEntity, set[ConceptEntity]]:
         dependencies_by_concepts: dict[ConceptEntity, set[ConceptEntity]] = {}

--- a/cognite/neat/core/_data_model/transformers/_converters.py
+++ b/cognite/neat/core/_data_model/transformers/_converters.py
@@ -93,7 +93,6 @@ from cognite.neat.core._issues.warnings._models import (
     SolutionModelBuildOnTopOfCDMWarning,
 )
 from cognite.neat.core._utils.rdf_ import get_inheritance_path
-from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 from cognite.neat.core._utils.text import (
     NamingStandardization,
     humanize_collection,
@@ -2418,7 +2417,7 @@ class AddCogniteProperties(
     @staticmethod
     def _get_properties_by_concepts(
         properties: list[UnverifiedConceptualProperty],
-        read_context: dict[str, SpreadsheetRead],
+        read_context: Mapping[str, object],
         default_space: str,
     ) -> dict[ConceptEntity, dict[str, UnverifiedConceptualProperty]]:
         issues = IssueList()
@@ -2438,7 +2437,7 @@ class AddCogniteProperties(
     @staticmethod
     def _get_dependencies_by_concepts(
         concepts: list[UnverifiedConcept],
-        read_context: dict[str, SpreadsheetRead],
+        read_context: Mapping[str, object],
         default_space: str,
     ) -> dict[ConceptEntity, set[ConceptEntity]]:
         dependencies_by_concepts: dict[ConceptEntity, set[ConceptEntity]] = {}

--- a/cognite/neat/core/_issues/_contextmanagers.py
+++ b/cognite/neat/core/_issues/_contextmanagers.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 from pydantic import ValidationError
 
-from cognite.neat.core._data_model._shared import ImportContext
+from cognite.neat.core._data_model.models._import_contexts import ImportContext
 
 from ._base import IssueList, MultiValueError, NeatError
 from ._factory import from_pydantic_errors, from_warning

--- a/cognite/neat/core/_issues/_contextmanagers.py
+++ b/cognite/neat/core/_issues/_contextmanagers.py
@@ -1,10 +1,8 @@
 import warnings
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 
 from pydantic import ValidationError
-
-from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 
 from ._base import IssueList, MultiValueError, NeatError
 from ._factory import from_pydantic_errors, from_warning
@@ -26,12 +24,12 @@ def catch_warnings() -> Iterator[IssueList]:
 
 
 @contextmanager
-def catch_issues(read_info_by_sheet: dict[str, SpreadsheetRead] | None = None) -> Iterator[IssueList]:
+def catch_issues(context: Mapping[str, object] | None = None) -> Iterator[IssueList]:
     """This is an internal help function to handle issues and warnings.
 
     Args:
-        read_info_by_sheet (dict[str, SpreadsheetRead]): The read information by sheet. This is used to adjust
-            the row numbers in the errors/warnings.
+        context (Mapping[str, object]): The read context. This is used to adjust
+            the row numbers in the errors/warnings if the data is read from a spreadsheet.
 
     Returns:
         IssueList: The list of issues.
@@ -41,7 +39,7 @@ def catch_issues(read_info_by_sheet: dict[str, SpreadsheetRead] | None = None) -
         try:
             yield issues
         except ValidationError as e:
-            issues.extend(from_pydantic_errors(e.errors(), read_info_by_sheet))
+            issues.extend(from_pydantic_errors(e.errors(), context))
         except NeatError as single:
             issues.append(single)
         except MultiValueError as multi:

--- a/cognite/neat/core/_issues/_contextmanagers.py
+++ b/cognite/neat/core/_issues/_contextmanagers.py
@@ -1,8 +1,10 @@
 import warnings
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
 from contextlib import contextmanager
 
 from pydantic import ValidationError
+
+from cognite.neat.core._data_model._shared import ImportContext
 
 from ._base import IssueList, MultiValueError, NeatError
 from ._factory import from_pydantic_errors, from_warning
@@ -24,11 +26,11 @@ def catch_warnings() -> Iterator[IssueList]:
 
 
 @contextmanager
-def catch_issues(context: Mapping[str, object] | None = None) -> Iterator[IssueList]:
+def catch_issues(context: ImportContext | None = None) -> Iterator[IssueList]:
     """This is an internal help function to handle issues and warnings.
 
     Args:
-        context (Mapping[str, object]): The read context. This is used to adjust
+        context (ImportContext): The read context. This is used to adjust
             the row numbers in the errors/warnings if the data is read from a spreadsheet.
 
     Returns:

--- a/cognite/neat/core/_issues/_contextmanagers.py
+++ b/cognite/neat/core/_issues/_contextmanagers.py
@@ -1,13 +1,15 @@
 import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
 
-from cognite.neat.core._data_model.models._import_contexts import ImportContext
-
 from ._base import IssueList, MultiValueError, NeatError
 from ._factory import from_pydantic_errors, from_warning
+
+if TYPE_CHECKING:
+    from cognite.neat.core._data_model.models._import_contexts import ImportContext
 
 
 @contextmanager
@@ -26,7 +28,7 @@ def catch_warnings() -> Iterator[IssueList]:
 
 
 @contextmanager
-def catch_issues(context: ImportContext | None = None) -> Iterator[IssueList]:
+def catch_issues(context: "ImportContext | None" = None) -> Iterator[IssueList]:
     """This is an internal help function to handle issues and warnings.
 
     Args:

--- a/cognite/neat/core/_issues/_factory.py
+++ b/cognite/neat/core/_issues/_factory.py
@@ -1,17 +1,16 @@
-from collections.abc import Mapping
 from typing import cast
 from warnings import WarningMessage
 
 from pydantic_core import ErrorDetails
 
+from cognite.neat.core._data_model._shared import ImportContext, SpreadsheetContext
 from cognite.neat.core._issues._base import NeatError, NeatWarning
-from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 
 from .errors import NeatValueError, SpreadsheetError
 
 
-def from_pydantic_errors(errors: list[ErrorDetails], context: Mapping[str, object] | None = None) -> list[NeatError]:
-    read_info_by_sheet = {key: value for key, value in (context or {}).items() if isinstance(value, SpreadsheetRead)}
+def from_pydantic_errors(errors: list[ErrorDetails], context: ImportContext | None = None) -> list[NeatError]:
+    read_info_by_sheet = context if isinstance(context, SpreadsheetContext) else SpreadsheetContext({})
     return [
         _from_pydantic_error(error, read_info_by_sheet)
         for error in errors
@@ -28,7 +27,7 @@ def from_warning(warning: WarningMessage) -> NeatWarning | None:
     return None
 
 
-def _from_pydantic_error(error: ErrorDetails, read_info_by_sheet: dict[str, SpreadsheetRead]) -> NeatError:
+def _from_pydantic_error(error: ErrorDetails, read_info_by_sheet: SpreadsheetContext) -> NeatError:
     neat_error = _create_neat_value_error(error)
     location = error["loc"]
 

--- a/cognite/neat/core/_issues/_factory.py
+++ b/cognite/neat/core/_issues/_factory.py
@@ -1,15 +1,20 @@
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from warnings import WarningMessage
 
 from pydantic_core import ErrorDetails
 
-from cognite.neat.core._data_model.models._import_contexts import ImportContext, SpreadsheetContext
 from cognite.neat.core._issues._base import NeatError, NeatWarning
 
 from .errors import NeatValueError, SpreadsheetError
 
+if TYPE_CHECKING:
+    from cognite.neat.core._data_model.models._import_contexts import ImportContext, SpreadsheetContext
 
-def from_pydantic_errors(errors: list[ErrorDetails], context: ImportContext | None = None) -> list[NeatError]:
+
+def from_pydantic_errors(errors: list[ErrorDetails], context: "ImportContext | None" = None) -> list[NeatError]:
+    # To avoid circular import, we import SpreadsheetContext here.
+    from cognite.neat.core._data_model.models._import_contexts import SpreadsheetContext
+
     read_info_by_sheet = context if isinstance(context, SpreadsheetContext) else SpreadsheetContext({})
     return [
         _from_pydantic_error(error, read_info_by_sheet)
@@ -27,7 +32,7 @@ def from_warning(warning: WarningMessage) -> NeatWarning | None:
     return None
 
 
-def _from_pydantic_error(error: ErrorDetails, read_info_by_sheet: SpreadsheetContext) -> NeatError:
+def _from_pydantic_error(error: ErrorDetails, read_info_by_sheet: "SpreadsheetContext") -> NeatError:
     neat_error = _create_neat_value_error(error)
     location = error["loc"]
 

--- a/cognite/neat/core/_issues/_factory.py
+++ b/cognite/neat/core/_issues/_factory.py
@@ -3,7 +3,7 @@ from warnings import WarningMessage
 
 from pydantic_core import ErrorDetails
 
-from cognite.neat.core._data_model._shared import ImportContext, SpreadsheetContext
+from cognite.neat.core._data_model.models._import_contexts import ImportContext, SpreadsheetContext
 from cognite.neat.core._issues._base import NeatError, NeatWarning
 
 from .errors import NeatValueError, SpreadsheetError

--- a/cognite/neat/core/_issues/_factory.py
+++ b/cognite/neat/core/_issues/_factory.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import cast
 from warnings import WarningMessage
 
@@ -9,10 +10,8 @@ from cognite.neat.core._utils.spreadsheet import SpreadsheetRead
 from .errors import NeatValueError, SpreadsheetError
 
 
-def from_pydantic_errors(
-    errors: list[ErrorDetails], read_info_by_sheet: dict[str, SpreadsheetRead] | None = None
-) -> list[NeatError]:
-    read_info_by_sheet = read_info_by_sheet or {}
+def from_pydantic_errors(errors: list[ErrorDetails], context: Mapping[str, object] | None = None) -> list[NeatError]:
+    read_info_by_sheet = {key: value for key, value in (context or {}).items() if isinstance(value, SpreadsheetRead)}
     return [
         _from_pydantic_error(error, read_info_by_sheet)
         for error in errors

--- a/cognite/neat/core/_store/_instance.py
+++ b/cognite/neat/core/_store/_instance.py
@@ -347,7 +347,7 @@ class NeatInstanceStore:
             )
             return issue_list
         _start = datetime.now(timezone.utc)
-        with catch_issues({}) as transform_issues:
+        with catch_issues() as transform_issues:
             transformer.transform(self.graph(named_graph))
         issue_list.extend(transform_issues)
         self.provenance.append(

--- a/cognite/neat/core/_utils/auxiliary.py
+++ b/cognite/neat/core/_utils/auxiliary.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from cognite.client.exceptions import CogniteDuplicatedError, CogniteReadTimeout
 
-from cognite.neat.core._issues.errors import NeatImportError
+from cognite.neat.core._issues.errors._general import NeatImportError
 
 
 def local_import(module: str, extra: str) -> ModuleType:


### PR DESCRIPTION
# Description

`ImportedDataModel` is an internal data structure we use to import data models from different sources such as spreadsheet, CDF, ontologies and so on. We use the context today when the source is a spreadsheet to tell the user exactly which row have warnings/errors to make it easy for them to fix. This is similar to a `metadata` field used in the CDF API.

This PR changes the type of context from one that is only valid for a spreadsheet source to a more generic one. This is because in an upcoming PR we will use the context in a different importers that are not importing form spreadsheet, but for example a Graph or Ontology. Then we will use this context for different purposes.  

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip
