### PR TITLE
Enabling restrictions in conceptual data model: adding restriction entities 

### DIFF
--- a/cognite/neat/core/_data_model/_constants.py
+++ b/cognite/neat/core/_data_model/_constants.py
@@ -43,6 +43,10 @@ class EntityTypes(StrEnum):
     prefix = "prefix"
     space = "space"
     container_index = "container_index"
+    concept_restriction = "conceptRestriction"
+    value_constraint = "valueConstraint"
+    cardinality_constraint = "cardinalityConstraint"
+    named_individual = "named_individual"
 
 
 def get_reserved_words(

--- a/cognite/neat/core/_data_model/models/entities/__init__.py
+++ b/cognite/neat/core/_data_model/models/entities/__init__.py
@@ -1,6 +1,7 @@
 from ._constants import Undefined, Unknown
 from ._loaders import load_connection, load_dms_value_type, load_value_type
 from ._multi_value import MultiValueTypeInfo
+from ._restrictions import ConceptPropertyCardinalityConstraint, ConceptPropertyValueConstraint, parse_restriction
 from ._single_value import (
     AssetEntity,
     AssetFields,
@@ -31,6 +32,8 @@ __all__ = [
     "CdfResourceEntityList",
     "ClassEntityList",
     "ConceptEntity",
+    "ConceptPropertyCardinalityConstraint",
+    "ConceptPropertyValueConstraint",
     "ConceptualEntity",
     "ContainerEntity",
     "ContainerEntityList",
@@ -61,4 +64,5 @@ __all__ = [
     "load_connection",
     "load_dms_value_type",
     "load_value_type",
+    "parse_restriction",
 ]

--- a/cognite/neat/core/_data_model/models/entities/_restrictions.py
+++ b/cognite/neat/core/_data_model/models/entities/_restrictions.py
@@ -1,0 +1,210 @@
+import re
+from abc import ABC
+from typing import Any, ClassVar, Final, Literal, TypeAlias, TypeVar, cast, get_args
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from rdflib import Literal as RDFLiteral
+from rdflib import URIRef
+
+from cognite.neat.core._data_model._constants import EntityTypes
+from cognite.neat.core._data_model.models.data_types import _XSD_TYPES, DataType
+from cognite.neat.core._data_model.models.entities._constants import _PARSE
+from cognite.neat.core._data_model.models.entities._single_value import ConceptEntity, ConceptualEntity
+from cognite.neat.core._issues.errors._general import NeatValueError
+from cognite.neat.core._utils.rdf_ import remove_namespace_from_uri
+
+ValueConstraints = Literal["allValuesFrom", "someValuesFrom", "hasValue"]
+CardinalityConstraints = Literal["minCardinality", "maxCardinality", "cardinality", "qualifiedCardinality"]
+
+
+VALUE_CONSTRAINT_REGEX = re.compile(
+    rf"^{EntityTypes.value_constraint}:(?P<property>[a-zA-Z0-9._~?@!$&'*+,;=%-]+)\((?P<constraint>{'|'.join(get_args(ValueConstraints))}),(?P<value>.+)\)$"
+)
+
+CARDINALITY_CONSTRAINT_REGEX = re.compile(
+    rf"^{EntityTypes.cardinality_constraint}:(?P<property>[a-zA-Z0-9._~?@!$&'*+,;=%-]+)\((?P<constraint>{'|'.join(get_args(CardinalityConstraints))}),(?P<value>\d+)(?:,(?P<on>[^(]*))?\)$"
+)
+
+
+# Constants for regex patterns - more maintainable
+PROPERTY_PATTERN: Final[str] = r"[a-zA-Z0-9._~?@!$&'*+,;=%-]+"
+VALUE_PATTERN: Final[str] = r".+"
+CARDINALITY_VALUE_PATTERN: Final[str] = r"\d+"
+ON_PATTERN: Final[str] = r"[^(]*"
+
+VALUE_CONSTRAINT_REGEX = re.compile(
+    rf"^{EntityTypes.value_constraint}:(?P<property>{PROPERTY_PATTERN})\((?P<constraint>{'|'.join(get_args(ValueConstraints))}),(?P<value>{VALUE_PATTERN})\)$"
+)
+
+CARDINALITY_CONSTRAINT_REGEX = re.compile(
+    rf"^{EntityTypes.cardinality_constraint}:(?P<property>{PROPERTY_PATTERN})\((?P<constraint>{'|'.join(get_args(CardinalityConstraints))}),(?P<value>{CARDINALITY_VALUE_PATTERN})(?:,(?P<on>{ON_PATTERN}))?\)$"
+)
+
+
+class NamedIndividualEntity(ConceptualEntity):
+    type_: ClassVar[EntityTypes] = EntityTypes.named_individual
+
+    @model_validator(mode="after")
+    def reset_prefix(self) -> Any:
+        self.prefix = "ni"
+        return self
+
+
+class ConceptPropertyRestriction(ABC, BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        str_strip_whitespace=True,
+        arbitrary_types_allowed=True,
+        strict=False,
+        extra="ignore",
+    )
+    type_: ClassVar[EntityTypes] = EntityTypes.concept_restriction
+    property_: str
+
+    @classmethod
+    def load(cls: "type[T_ConceptPropertyRestriction]", data: Any, **defaults: Any) -> "T_ConceptPropertyRestriction":
+        if isinstance(data, cls):
+            return data
+        elif not isinstance(data, str):
+            raise ValueError(f"Cannot load {cls.__name__} from {data}")
+
+        return cls.model_validate({_PARSE: data, "defaults": defaults})
+
+    @model_validator(mode="before")
+    def _load(cls, data: Any) -> dict:
+        defaults = {}
+        if isinstance(data, dict) and _PARSE in data:
+            defaults = data.get("defaults", {})
+            data = data[_PARSE]
+        if isinstance(data, dict):
+            data.update(defaults)
+            return data
+
+        if not isinstance(data, str):
+            raise ValueError(f"Cannot load {cls.__name__} from {data}")
+
+        return cls._parse(data, defaults)
+
+    @classmethod
+    def _parse(cls, data: str, defaults: dict) -> dict:
+        raise NotImplementedError(f"{cls.__name__} must implement _parse method")
+
+    def dump(self) -> str:
+        return self.__str__()
+
+    def as_tuple(self) -> tuple[str, ...]:
+        # We haver overwritten the serialization to str, so we need to do it manually
+        extra: tuple[str, ...] = tuple(
+            [
+                str(v or "")
+                for field_name in self.model_fields.keys()
+                if (v := getattr(self, field_name)) and field_name not in {"property_"}
+            ]
+        )
+
+        return self.property_, *extra
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, ConceptPropertyRestriction):
+            return NotImplemented
+        return self.as_tuple() < other.as_tuple()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ConceptPropertyRestriction):
+            return NotImplemented
+        return self.as_tuple() == other.as_tuple()
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+
+T_ConceptPropertyRestriction = TypeVar("T_ConceptPropertyRestriction", bound="ConceptPropertyRestriction")
+
+
+class ConceptPropertyValueConstraint(ConceptPropertyRestriction):
+    type_: ClassVar[EntityTypes] = EntityTypes.value_constraint
+    constraint: ValueConstraints
+    value: RDFLiteral | ConceptEntity | NamedIndividualEntity
+
+    @field_validator("value")
+    def validate_value(cls, value: Any) -> Any:
+        if isinstance(value, RDFLiteral) and value.datatype is None:
+            raise NeatValueError("RDFLiteral must have a datatype set, which must be one of the XSD types.")
+        return value
+
+    def __str__(self) -> str:
+        value_str = (
+            f"{self.value.value}^^{remove_namespace_from_uri(cast(URIRef, self.value.datatype))}"
+            if isinstance(self.value, RDFLiteral)
+            else str(self.value)
+        )
+        return f"{self.type_}:{self.property_}({self.constraint},{value_str})"
+
+    @classmethod
+    def _parse(cls, data: str, defaults: dict) -> dict:
+        if not (result := VALUE_CONSTRAINT_REGEX.match(data)):
+            raise NeatValueError(f"Invalid value constraint format: {data}")
+
+        property_ = result.group("property")
+        constraint = result.group("constraint")
+        raw_value = result.group("value")
+
+        value: NamedIndividualEntity | RDFLiteral | ConceptEntity
+        # scenarion 1: NamedIndividual as value restriction
+        if raw_value.startswith("ni:"):
+            value = NamedIndividualEntity.load(raw_value)
+        # scenario 2: Datatype as value restriction
+        elif "^^" in raw_value:
+            if len(value_components := raw_value.split("^^")) == 2 and value_components[1] in _XSD_TYPES:
+                value = RDFLiteral(value_components[0], datatype=DataType.load(value_components[1]).as_xml_uri_ref())
+            else:
+                raise NeatValueError(f"Invalid value format for datatype: {raw_value}")
+
+        # scenario 3: ConceptEntity as value restriction
+        else:
+            value = ConceptEntity.load(raw_value, **defaults)
+
+        return dict(property_=property_, constraint=constraint, value=value)
+
+
+class ConceptPropertyCardinalityConstraint(ConceptPropertyRestriction):
+    type_: ClassVar[EntityTypes] = EntityTypes.cardinality_constraint
+    constraint: CardinalityConstraints
+    value: int = Field(ge=0)
+    on: DataType | ConceptEntity | None = None
+
+    def __str__(self) -> str:
+        on_str = f",{self.on}" if self.on else ""
+        return f"cardinalityConstraint:{self.property_}({self.constraint},{self.value}{on_str})"
+
+    @classmethod
+    def _parse(cls, data: str, defaults: dict) -> dict:
+        if not (result := CARDINALITY_CONSTRAINT_REGEX.match(data)):
+            print(f"Failed to match regex: {result}")
+            raise NeatValueError(f"Invalid cardinality constraint format: {data}")
+
+        property_ = result.group("property")
+        constraint = result.group("constraint")
+        value = result.group("value")
+        on = result.group("on")
+        if on:
+            if on in _XSD_TYPES:
+                on = DataType.load(on)
+            else:
+                on = cast(ConceptEntity, ConceptEntity.load(on, **defaults))
+
+        return dict(property_=property_, constraint=constraint, value=value, on=on)
+
+
+def parse_restriction(data: str, **defaults: Any) -> ConceptPropertyRestriction:
+    """Parse a string to create either a value or cardinality restriction."""
+    try:
+        return ConceptPropertyValueConstraint.load(data, **defaults)
+    except Exception:
+        try:
+            return ConceptPropertyCardinalityConstraint.load(data, **defaults)
+        except Exception as e:
+            raise NeatValueError(f"Unable to parse restriction: {data}") from e
+
+
+ConceptRestriction: TypeAlias = ConceptPropertyValueConstraint | ConceptPropertyCardinalityConstraint
+T_ConceptRestriction = TypeVar("T_ConceptRestriction", bound=ConceptRestriction)

--- a/tests/tests_unit/test_rules/test_models/test_restrictions.py
+++ b/tests/tests_unit/test_rules/test_models/test_restrictions.py
@@ -1,0 +1,143 @@
+import pytest
+from pydantic import ValidationError
+from rdflib import XSD
+from rdflib import Literal as RDFLiteral
+
+from cognite.neat.core._data_model.models.data_types import DataType
+from cognite.neat.core._data_model.models.entities._restrictions import (
+    ConceptPropertyCardinalityConstraint,
+    ConceptPropertyValueConstraint,
+    NamedIndividualEntity,
+    parse_restriction,
+)
+from cognite.neat.core._data_model.models.entities._single_value import ConceptEntity
+from cognite.neat.core._issues.errors._general import NeatValueError
+
+
+class TestConceptPropertyValueConstraint:
+    @pytest.mark.parametrize(
+        "data,expected_property,expected_constraint,expected_value_type",
+        [
+            ("valueConstraint:hasOwner(hasValue,ni:John)", "hasOwner", "hasValue", NamedIndividualEntity),
+            ("valueConstraint:hasAge(hasValue,25^^integer)", "hasAge", "hasValue", RDFLiteral),
+            ("valueConstraint:hasType(allValuesFrom,Vehicle)", "hasType", "allValuesFrom", ConceptEntity),
+            ("valueConstraint:hasColor(someValuesFrom,Color)", "hasColor", "someValuesFrom", ConceptEntity),
+            (
+                "valueConstraint:has.complex_property-123(hasValue,test)",
+                "has.complex_property-123",
+                "hasValue",
+                ConceptEntity,
+            ),
+        ],
+    )
+    def test_parse_value_constraints(self, data, expected_property, expected_constraint, expected_value_type):
+        defaults = {"prefix": "ex"} if "Vehicle" in data or "Color" in data or "test" in data else {}
+        result = ConceptPropertyValueConstraint._parse(data, defaults)
+
+        assert result["property_"] == expected_property
+        assert result["constraint"] == expected_constraint
+        assert isinstance(result["value"], expected_value_type)
+
+    def test_parse_named_individual_specific(self):
+        data = "valueConstraint:hasOwner(hasValue,ni:John)"
+        result = ConceptPropertyValueConstraint._parse(data, {})
+        assert str(result["value"]) == "ni:John"
+
+    def test_parse_datatype_specific(self):
+        data = "valueConstraint:hasAge(hasValue,25^^integer)"
+        result = ConceptPropertyValueConstraint.load(data)
+        assert result.value.value == 25
+        assert result.value.datatype == XSD.integer
+
+    @pytest.mark.parametrize(
+        "invalid_data,expected_error",
+        [
+            ("valueConstraint:hasAge(hasValue,25^^invalidtype)", "Invalid value format for datatype"),
+            ("invalidConstraint:hasAge(hasValue,25)", "Invalid value constraint format"),
+        ],
+    )
+    def test_parse_invalid_formats(self, invalid_data, expected_error):
+        with pytest.raises(ValidationError, match=expected_error):
+            ConceptPropertyValueConstraint.load(invalid_data)
+
+
+class TestConceptPropertyCardinalityConstraint:
+    @pytest.mark.parametrize(
+        "data,expected_property,expected_constraint,expected_value,expected_on",
+        [
+            ("cardinalityConstraint:hasChild(minCardinality,2)", "hasChild", "minCardinality", 2, None),
+            ("cardinalityConstraint:hasParent(maxCardinality,2)", "hasParent", "maxCardinality", 2, None),
+            ("cardinalityConstraint:hasSpouse(cardinality,1)", "hasSpouse", "cardinality", 1, None),
+            ("cardinalityConstraint:hasProperty(minCardinality,0)", "hasProperty", "minCardinality", 0, None),
+            (
+                "cardinalityConstraint:has.complex_property-123(maxCardinality,5)",
+                "has.complex_property-123",
+                "maxCardinality",
+                5,
+                None,
+            ),
+        ],
+    )
+    def test_parse_basic_cardinality_constraints(
+        self, data, expected_property, expected_constraint, expected_value, expected_on
+    ):
+        result = ConceptPropertyCardinalityConstraint.load(data)
+
+        assert result.property_ == expected_property
+        assert result.constraint == expected_constraint
+        assert result.value == expected_value
+        assert result.on == expected_on
+
+    @pytest.mark.parametrize(
+        "data,expected_on_type",
+        [
+            ("cardinalityConstraint:hasAge(qualifiedCardinality,1,integer)", DataType),
+            ("cardinalityConstraint:hasVehicle(qualifiedCardinality,3,Car)", ConceptEntity),
+        ],
+    )
+    def test_parse_qualified_cardinality_constraints(self, data, expected_on_type):
+        defaults = {"prefix": "ex"} if "Car" in data else {}
+        result = ConceptPropertyCardinalityConstraint.load(data, **defaults)
+
+        assert result.constraint == "qualifiedCardinality"
+        assert isinstance(result.on, expected_on_type)
+
+    def test_parse_invalid_cardinality_format(self):
+        data = "invalidConstraint:hasProperty(minCardinality,1)"
+        with pytest.raises(ValidationError, match="Invalid cardinality constraint format"):
+            ConceptPropertyCardinalityConstraint.load(data)
+
+
+class TestParseRestriction:
+    @pytest.mark.parametrize(
+        "data,expected_type,expected_property",
+        [
+            ("valueConstraint:hasOwner(hasValue,ni:John)", ConceptPropertyValueConstraint, "hasOwner"),
+            ("cardinalityConstraint:hasChild(minCardinality,2)", ConceptPropertyCardinalityConstraint, "hasChild"),
+            ("valueConstraint:hasType(allValuesFrom,Vehicle)", ConceptPropertyValueConstraint, "hasType"),
+        ],
+    )
+    def test_parse_valid_restrictions(self, data, expected_type, expected_property):
+        defaults = {"prefix": "test"} if "Vehicle" in data else {}
+        result = parse_restriction(data, **defaults)
+
+        assert isinstance(result, expected_type)
+        assert result.property_ == expected_property
+
+    @pytest.mark.parametrize(
+        "invalid_data",
+        [
+            "invalidRestriction:hasProperty(someConstraint,value)",
+            "",
+        ],
+    )
+    def test_parse_invalid_restrictions(self, invalid_data):
+        with pytest.raises(NeatValueError, match="Unable to parse restriction"):
+            parse_restriction(invalid_data)
+
+
+class TestNamedIndividualEntity:
+    def test_reset_prefix(self):
+        entity = NamedIndividualEntity(suffix="test", prefix="one-that-gets-reset")
+        entity.reset_prefix()
+        assert entity.prefix == "ni"


### PR DESCRIPTION
# Description

This is first of a few PRs that are tackling importing of data model restrictions often found in ontologies. PR brings definition of two basic forms of restrictions:
- Concept property constraint on values
- Concept property constraint on cardinality and value type

In addition to the definition of the two new entities, a short form of how those entities are represented as a string is provided. 

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip

## Changelog
### Added

- Added new neat entities: `ConceptPropertyValueConstraint` and `ConceptPropertyCardinalityConstraint` setting foundation for parsing of OWL restrictions
