### PR TITLE
[THIS-15] 🗽Improved error message

### DIFF
--- a/cognite/neat/core/_data_model/models/entities/_single_value.py
+++ b/cognite/neat/core/_data_model/models/entities/_single_value.py
@@ -59,7 +59,15 @@ class ConceptualEntity(BaseModel, extra="ignore"):
 
     @classmethod
     @overload
-    def load(cls: "type[T_Entity]", data: Any, strict: Literal[True], **defaults: Any) -> "T_Entity": ...
+    def load(
+        cls: "type[T_Entity]", data: Any, strict: Literal[True], return_on_failure: Literal[False], **defaults: Any
+    ) -> "T_Entity": ...
+
+    @classmethod
+    @overload
+    def load(
+        cls: "type[T_Entity]", data: Any, strict: Literal[True], return_on_failure: Literal[True], **defaults: Any
+    ) -> "T_Entity | str": ...
 
     @classmethod
     @overload
@@ -67,25 +75,53 @@ class ConceptualEntity(BaseModel, extra="ignore"):
         cls: "type[T_Entity]",
         data: Any,
         strict: Literal[False] = False,
+        return_on_failure: Literal[False] = False,
         **defaults: Any,
     ) -> "T_Entity | UnknownEntity": ...
 
     @classmethod
-    def load(cls: "type[T_Entity]", data: Any, strict: bool = False, **defaults: Any) -> "T_Entity | UnknownEntity":
+    @overload
+    def load(
+        cls: "type[T_Entity]",
+        data: Any,
+        strict: Literal[False] = False,
+        return_on_failure: Literal[True] = True,
+        **defaults: Any,
+    ) -> "T_Entity | UnknownEntity | str": ...
+
+    @classmethod
+    def load(
+        cls: "type[T_Entity]", data: Any, strict: bool = False, return_on_failure: bool = False, **defaults: Any
+    ) -> "T_Entity | UnknownEntity | str":
+        """Loads an entity from a string or dict representation.
+
+        Args:
+            data: The data to load the entity from. Can be a string or a dict.
+            strict: If True, will raise an error if the data is "unknown".
+            return_on_failure: If True, will return the input data if loading fails.
+                This is used when you want to defer error handling to a later stage.
+            defaults: Default values to use when loading the entity. These will be used if the corresponding
+
+        """
         if isinstance(data, cls):
             return data
         elif isinstance(data, str) and data == str(Unknown):
             if strict:
                 raise NeatValueError(f"Failed to load entity {data!s}")
             return UnknownEntity(prefix=Undefined, suffix=Unknown)
-        if defaults and isinstance(defaults, dict):
-            # This is a trick to pass in default values
-            try:
-                return cls.model_validate({_PARSE: data, "defaults": defaults})
-            except ValueError:
-                raise
-        else:
-            return cls.model_validate(data)
+        try:
+            if defaults and isinstance(defaults, dict):
+                # This is a trick to pass in default values
+                try:
+                    return cls.model_validate({_PARSE: data, "defaults": defaults})
+                except ValueError:
+                    raise
+            else:
+                return cls.model_validate(data)
+        except ValueError:
+            if return_on_failure:
+                return data
+            raise
 
     @model_validator(mode="before")
     def _load(cls, data: Any) -> "dict | ConceptualEntity":
@@ -342,7 +378,15 @@ class PhysicalEntity(ConceptualEntity, Generic[T_ID], ABC):
 
     @classmethod  # type: ignore[override]
     @overload
-    def load(cls: "type[T_DMSEntity]", data: Any, strict: Literal[True], **defaults: Any) -> "T_DMSEntity": ...
+    def load(
+        cls: "type[T_DMSEntity]", data: Any, strict: Literal[True], return_on_failure: Literal[False], **defaults: Any
+    ) -> "T_DMSEntity": ...
+
+    @classmethod
+    @overload
+    def load(
+        cls: "type[T_DMSEntity]", data: Any, strict: Literal[True], return_on_failure: Literal[True], **defaults: Any
+    ) -> "T_DMSEntity | PhysicalUnknownEntity | str": ...
 
     @classmethod
     @overload
@@ -350,18 +394,29 @@ class PhysicalEntity(ConceptualEntity, Generic[T_ID], ABC):
         cls: "type[T_DMSEntity]",
         data: Any,
         strict: Literal[False] = False,
+        return_on_failure: Literal[False] = False,
         **defaults: Any,
     ) -> "T_DMSEntity | PhysicalUnknownEntity": ...
 
     @classmethod
+    @overload
     def load(
-        cls: "type[T_DMSEntity]", data: Any, strict: bool = False, **defaults: Any
+        cls: "type[T_DMSEntity]",
+        data: Any,
+        strict: Literal[False] = False,
+        return_on_failure: Literal[True] = True,
+        **defaults: Any,
+    ) -> "T_DMSEntity | PhysicalUnknownEntity | str": ...
+
+    @classmethod
+    def load(
+        cls: "type[T_DMSEntity]", data: Any, strict: bool = False, return_on_failure: bool = False, **defaults: Any
     ) -> "T_DMSEntity | PhysicalUnknownEntity":  # type: ignore
         if isinstance(data, str) and data == str(Unknown):
             if strict:
                 raise NeatValueError(f"Failed to load entity {data!s}")
             return PhysicalUnknownEntity.from_id(None)
-        return cast(T_DMSEntity, super().load(data, **defaults))
+        return cast(T_DMSEntity, super().load(data, return_on_failure=return_on_failure, **defaults))
 
     @property
     def space(self) -> str:

--- a/cognite/neat/core/_data_model/models/physical/_unverified.py
+++ b/cognite/neat/core/_data_model/models/physical/_unverified.py
@@ -170,7 +170,7 @@ class UnverifiedPhysicalProperty(UnverifiedComponent[PhysicalProperty]):
             else None
         )
         if isinstance(self.index, ContainerIndexEntity) or (isinstance(self.index, str) and "," not in self.index):
-            output["Index"] = [ContainerIndexEntity.load(self.index)]
+            output["Index"] = [ContainerIndexEntity.load(self.index, return_on_failure=True)]
         elif isinstance(self.index, str):
             output["Index"] = [
                 ContainerIndexEntity.load(index.strip())
@@ -198,10 +198,10 @@ class UnverifiedPhysicalProperty(UnverifiedComponent[PhysicalProperty]):
         return output
 
     def referenced_view(self, default_space: str, default_version: str) -> ViewEntity:
-        return ViewEntity.load(self.view, strict=True, space=default_space, version=default_version)
+        return ViewEntity.load(self.view, strict=True, space=default_space, version=default_version, return_on_failure=True)
 
     def referenced_container(self, default_space: str) -> ContainerEntity | None:
-        return ContainerEntity.load(self.container, strict=True, space=default_space) if self.container else None
+        return ContainerEntity.load(self.container, strict=True, space=default_space, return_on_failure=True) if self.container else None
 
     @classmethod
     def _load(cls, data: dict[str, Any]) -> Self:

--- a/tests/tests_unit/test_rules/test_models/test_physical_data_model.py
+++ b/tests/tests_unit/test_rules/test_models/test_physical_data_model.py
@@ -43,7 +43,7 @@ from cognite.neat.core._data_model.transformers import (
     VerifyPhysicalDataModel,
 )
 from cognite.neat.core._issues import MultiValueError, NeatError, catch_issues
-from cognite.neat.core._issues.errors import NeatValueError, PropertyDefinitionDuplicatedError
+from cognite.neat.core._issues.errors import PropertyDefinitionDuplicatedError, PropertyValueError
 from cognite.neat.core._issues.errors._resources import ResourceDuplicatedError
 from cognite.neat.core._issues.warnings.user_modeling import (
     ViewsAndDataModelNotInSameSpaceWarning,
@@ -1617,16 +1617,15 @@ class TestDMSRules:
             views=[
                 UnverifiedPhysicalView("myView"),
             ],
-            containers=[UnverifiedPhysicalContainer("cdf_cmd::myContainer")],
+            containers=[UnverifiedPhysicalContainer("cdf_cmd:myContainer")],
         )
         with pytest.raises(MultiValueError) as exc_info:
             VerifyPhysicalDataModel(validate=False).transform(ImportedDataModel(model))
 
         exception = exc_info.value
         assert isinstance(exception, MultiValueError)
-        assert len(exception.errors) == 1
-        error = exception.errors[0]
-        assert isinstance(error, NeatValueError)
+        unexpected_types = [error for error in exception.errors if not isinstance(error, PropertyValueError)]
+        assert not unexpected_types, f"Unexpected errors: {unexpected_types}"
 
 
 def edge_types_by_view_property_id_test_cases() -> Iterable[ParameterSet]:


### PR DESCRIPTION
# Description

The issue is that we have a `.dump` method for the imported data models. When an error is raised in this context, Neat fails to have the appropriate context such that it can provide an informative error message. 

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Improved

- When you have an entity syntax error, Neat will now give you a more informative error. 
