### PR TITLE
Remove upper bound on packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "networkx>=3.4.2, <4.0.0",
     "mixpanel>=4.10.1, <5.0.0",
     # Used for loading neat engine
-    "packaging>=22.0, <25.0",
+    "packaging>=22.0",
     # NeatEngine dependencies
     "jsonpath-python>=1.0.6, <2.0.0",
     "elementpath>=4.0.0, <5.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -450,7 +450,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.4.2,<4.0.0" },
     { name = "openpyxl", specifier = ">=3.0.10,<4.0.0" },
     { name = "oxrdflib", marker = "extra == 'oxi'", specifier = ">=0.4.0,<0.5.0" },
-    { name = "packaging", specifier = ">=22.0,<25.0" },
+    { name = "packaging", specifier = ">=22.0" },
     { name = "pandas", specifier = ">=1.5.3,<3.0.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.14.3,<11.0.0" },


### PR DESCRIPTION
# Description

This third-party dependency had an upper bound that caused compatibility issues with `cognite-toolkit` due to differing upper and lower bounds. The upper bound was recently removed with this change in `cognite-toolkit`: https://github.com/cognitedata/toolkit/commit/2d0ef1383325e2a074e607b9fbaf06fc24a0e1de

This commit removes the upper bound in Neat as well, ensuring both packages can now be installed in the same repo. Verified locally with an install with `cognite-toolkit=0.6.26` and using this branch as target for `cognite-neat`.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog

### Fixed

- Removed upper bound on third-party dependency `packaging`. This makes
Neat compatible with toolkit.

- My change.
