### PR TITLE
Add new object oriented endpoint for data model transformations

### DIFF
--- a/cognite/neat/session/_session/_data_model/_routes.py
+++ b/cognite/neat/session/_session/_data_model/_routes.py
@@ -6,6 +6,8 @@ from cognite.neat.session._session._data_model._write import WriteAPI
 from cognite.neat.session._state import SessionState
 from cognite.neat.session.exceptions import session_class_wrapper
 
+from ._transform import TransformAPI
+
 
 @session_class_wrapper
 class DataModelAPI:
@@ -14,6 +16,7 @@ class DataModelAPI:
     def __init__(self, state: SessionState) -> None:
         self._state = state
         self.read = ReadAPI(state)
+        self.transform = TransformAPI(state)
         self.write = WriteAPI(state)
         self.show = ShowAPI(state)
 

--- a/cognite/neat/session/_session/_data_model/_transform.py
+++ b/cognite/neat/session/_session/_data_model/_transform.py
@@ -1,0 +1,44 @@
+from cognite.neat.core._data_model.transformers._converters import (
+    PrefixEntities,
+    StandardizeNaming,
+    StandardizeSpaceAndVersion,
+    ToCompliantEntities,
+)
+from cognite.neat.core._issues._base import IssueList
+from cognite.neat.session._state import SessionState
+from cognite.neat.session.exceptions import session_class_wrapper
+
+
+@session_class_wrapper
+class TransformAPI:
+    def __init__(self, state: SessionState) -> None:
+        self._state = state
+
+    def cdf_compliant_external_ids(self) -> IssueList:
+        """Convert conceptual data model component external ids to CDF compliant ids."""
+        return self._state.data_model_transform(ToCompliantEntities())
+
+    def prefix(self, prefix: str) -> IssueList:
+        """Prefix all views in the data model with the given prefix.
+
+        Args:
+            prefix: The prefix to add to the views in the data model.
+
+        """
+
+        return self._state.data_model_transform(PrefixEntities(prefix))  # type: ignore[arg-type]
+
+    def standardize_naming(self) -> IssueList:
+        """Standardize the naming of all views/concepts/properties in the data model.
+
+        For concepts/views/containers, the naming will be standardized to PascalCase.
+        For properties, the naming will be standardized to camelCase.
+        """
+        return self._state.data_model_transform(StandardizeNaming())
+
+    def standardize_space_and_version(self) -> IssueList:
+        """Standardize space and version in the data model.
+
+        This method will standardize the space and version in the data model to the Cognite standard.
+        """
+        return self._state.data_model_transform(StandardizeSpaceAndVersion())

--- a/tests/tests_integration/test_session/test_data_model_prepare_fix.py
+++ b/tests/tests_integration/test_session/test_data_model_prepare_fix.py
@@ -84,7 +84,7 @@ class TestDataModelPrepare:
 
         neat.prepare.data_model.prefix("NeatINC")
 
-        rules_str = neat.to.yaml(format="neat")
+        rules_str = neat.to.yaml(io=None, format="neat")
 
         rules_dict = yaml.safe_load(rules_str)
         data_regression.check(
@@ -102,7 +102,7 @@ class TestDataModelPrepare:
 
         neat.data_model.transform.standardize_space_and_version()
 
-        rules_str = neat.to.yaml(format="neat")
+        rules_str = neat.to.yaml(io=None, format="neat")
 
         rules_dict = yaml.safe_load(rules_str)
         data_regression.check(

--- a/tests/tests_integration/test_session/test_data_model_prepare_fix/test_prefix_conceptual_data_model_entities_new_endpoint.yml
+++ b/tests/tests_integration/test_session/test_data_model_prepare_fix/test_prefix_conceptual_data_model_entities_new_endpoint.yml
@@ -1,0 +1,383 @@
+rules:
+  concepts:
+  - concept: NeatINCClassicAsset
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset
+  - concept: NeatINCClassicDataSet
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicDataSet
+  - concept: NeatINCClassicEvent
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent
+  - concept: NeatINCClassicFile
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile
+  - concept: NeatINCClassicLabel
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicLabel
+  - concept: NeatINCClassicRelationship
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship
+  - concept: NeatINCClassicSequence
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicSequence
+  - concept: NeatINCClassicTimeSeries
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries
+  metadata:
+    created: '2024-09-19T00:00:00Z'
+    creator: Cognite
+    description: The data model matching the classic model in CDF
+    external_id: ClassicDataModel
+    name: ClassicDataModel
+    role: information architect
+    source_id: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/Iteration_2
+    space: neat_space
+    updated: '2024-09-19T00:00:00Z'
+    version: v1
+  prefixes:
+    prefix_1: http://purl.org/cognite/cdf-classic#
+    prefix_2: http://www.w3.org/2001/XMLSchema#
+  properties:
+  - concept: NeatINCClassicAsset
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset/dataSetId
+    property_: dataSetId
+    value_type: NeatINCClassicDataSet
+  - concept: NeatINCClassicAsset
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset/description
+    property_: description
+    value_type: string
+  - concept: NeatINCClassicAsset
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset/externalId
+    property_: externalId
+    value_type: string
+  - concept: NeatINCClassicAsset
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset/geoLocation
+    property_: geoLocation
+    value_type: json
+  - concept: NeatINCClassicAsset
+    max_count: 10
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset/labels
+    property_: labels
+    value_type: NeatINCClassicLabel
+  - concept: NeatINCClassicAsset
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset/metadata
+    property_: metadata
+    value_type: json
+  - concept: NeatINCClassicAsset
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset/name
+    property_: name
+    value_type: string
+  - concept: NeatINCClassicAsset
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset/parentId
+    property_: parentId
+    value_type: NeatINCClassicAsset
+  - concept: NeatINCClassicAsset
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicAsset/source
+    property_: source
+    value_type: string
+  - concept: NeatINCClassicDataSet
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicDataSet/description
+    property_: description
+    value_type: string
+  - concept: NeatINCClassicDataSet
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicDataSet/externalId
+    property_: externalId
+    value_type: string
+  - concept: NeatINCClassicDataSet
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicDataSet/metadata
+    property_: metadata
+    value_type: json
+  - concept: NeatINCClassicDataSet
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicDataSet/name
+    property_: name
+    value_type: string
+  - concept: NeatINCClassicDataSet
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicDataSet/writeProtected
+    property_: writeProtected
+    value_type: boolean
+  - concept: NeatINCClassicEvent
+    max_count: 1000
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/assetIds
+    property_: assetIds
+    value_type: NeatINCClassicAsset
+  - concept: NeatINCClassicEvent
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/dataSetId
+    property_: dataSetId
+    value_type: NeatINCClassicDataSet
+  - concept: NeatINCClassicEvent
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/description
+    property_: description
+    value_type: string
+  - concept: NeatINCClassicEvent
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/endTime
+    property_: endTime
+    value_type: dateTime
+  - concept: NeatINCClassicEvent
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/externalId
+    property_: externalId
+    value_type: string
+  - concept: NeatINCClassicEvent
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/metadata
+    property_: metadata
+    value_type: json
+  - concept: NeatINCClassicEvent
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/source
+    property_: source
+    value_type: string
+  - concept: NeatINCClassicEvent
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/startTime
+    property_: startTime
+    value_type: dateTime
+  - concept: NeatINCClassicEvent
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/subtype
+    property_: subtype
+    value_type: string
+  - concept: NeatINCClassicEvent
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicEvent/type
+    property_: type
+    value_type: string
+  - concept: NeatINCClassicFile
+    max_count: 1000
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/assetIds
+    property_: assetIds
+    value_type: NeatINCClassicAsset
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/dataSetId
+    property_: dataSetId
+    value_type: NeatINCClassicDataSet
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/directory
+    property_: directory
+    value_type: string
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/externalId
+    property_: externalId
+    value_type: string
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/geoLocation
+    property_: geoLocation
+    value_type: json
+  - concept: NeatINCClassicFile
+    max_count: 10
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/labels
+    property_: labels
+    value_type: NeatINCClassicLabel
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/metadata
+    property_: metadata
+    value_type: json
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/mimeType
+    property_: mimeType
+    value_type: string
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/name
+    property_: name
+    value_type: string
+  - concept: NeatINCClassicFile
+    max_count: 1000
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/securityCategories
+    property_: securityCategories
+    value_type: long
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/source
+    property_: source
+    value_type: string
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/sourceCreatedTime
+    property_: sourceCreatedTime
+    value_type: long
+  - concept: NeatINCClassicFile
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicFile/sourceModifiedTime
+    property_: sourceModifiedTime
+    value_type: long
+  - concept: NeatINCClassicLabel
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicLabel/dataSetId
+    property_: dataSetId
+    value_type: NeatINCClassicDataSet
+  - concept: NeatINCClassicLabel
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicLabel/description
+    property_: description
+    value_type: string
+  - concept: NeatINCClassicLabel
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicLabel/externalId
+    property_: externalId
+    value_type: string
+  - concept: NeatINCClassicLabel
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicLabel/name
+    property_: name
+    value_type: string
+  - concept: NeatINCClassicRelationship
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/confidence
+    property_: confidence
+    value_type: double
+  - concept: NeatINCClassicRelationship
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/dataSetId
+    property_: dataSetId
+    value_type: NeatINCClassicDataSet
+  - concept: NeatINCClassicRelationship
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/endTime
+    property_: endTime
+    value_type: dateTime
+  - concept: NeatINCClassicRelationship
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/externalId
+    property_: externalId
+    value_type: string
+  - concept: NeatINCClassicRelationship
+    max_count: 10
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/labels
+    property_: labels
+    value_type: NeatINCClassicLabel
+  - concept: NeatINCClassicRelationship
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/sourceExternalId
+    property_: sourceExternalId
+    value_type: anyURI
+  - concept: NeatINCClassicRelationship
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/sourceType
+    property_: sourceType
+    value_type: string
+  - concept: NeatINCClassicRelationship
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/startTime
+    property_: startTime
+    value_type: dateTime
+  - concept: NeatINCClassicRelationship
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/targetExternalId
+    property_: targetExternalId
+    value_type: anyURI
+  - concept: NeatINCClassicRelationship
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicRelationship/targetType
+    property_: targetType
+    value_type: string
+  - concept: NeatINCClassicSequence
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicSequence/assetId
+    property_: assetId
+    value_type: NeatINCClassicAsset
+  - concept: NeatINCClassicSequence
+    max_count: 400
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicSequence/columns
+    property_: columns
+    value_type: json
+  - concept: NeatINCClassicSequence
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicSequence/dataSetId
+    property_: dataSetId
+    value_type: NeatINCClassicDataSet
+  - concept: NeatINCClassicSequence
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicSequence/description
+    property_: description
+    value_type: string
+  - concept: NeatINCClassicSequence
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicSequence/externalId
+    property_: externalId
+    value_type: string
+  - concept: NeatINCClassicSequence
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicSequence/metadata
+    property_: metadata
+    value_type: json
+  - concept: NeatINCClassicSequence
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicSequence/name
+    property_: name
+    value_type: string
+  - concept: NeatINCClassicSequence
+    max_count: 1000
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicSequence/rows
+    property_: rows
+    value_type: json
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/assetId
+    property_: assetId
+    value_type: NeatINCClassicAsset
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/dataSetId
+    property_: dataSetId
+    value_type: NeatINCClassicDataSet
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/description
+    property_: description
+    value_type: string
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/externalId
+    property_: externalId
+    value_type: string
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/isStep
+    property_: isStep
+    value_type: boolean
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/isString
+    property_: isString
+    value_type: boolean
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/metadata
+    property_: metadata
+    value_type: json
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/name
+    property_: name
+    value_type: string
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1000
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/securityCategories
+    property_: securityCategories
+    value_type: long
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/unit
+    property_: unit
+    value_type: string
+  - concept: NeatINCClassicTimeSeries
+    max_count: 1
+    neatId: http://purl.org/cognite/neat/data-model/verified/conceptual/neat_space/ClassicDataModel/v1/ClassicTimeSeries/unitExternalId
+    property_: unitExternalId
+    value_type: string

--- a/tests/tests_integration/test_session/test_data_model_prepare_fix/test_prefix_dms_rules_entities_new_endpoint.yml
+++ b/tests/tests_integration/test_session/test_data_model_prepare_fix/test_prefix_dms_rules_entities_new_endpoint.yml
@@ -1,0 +1,343 @@
+rules:
+  containers:
+  - container: NeatINCDocumentation
+    name: Documentation
+    used_for: node
+  - container: NeatINCFacility
+    name: Facility
+    used_for: node
+  - container: NeatINCPump
+    name: Pump
+    used_for: node
+  metadata:
+    created: '2024-09-19T00:00:00Z'
+    creator: Neat
+    external_id: NeatHelloWorld
+    name: Neat Hello World
+    role: DMS Architect
+    source_id: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Iteration_2
+    space: neat_playground
+    updated: '2024-09-19T00:00:00Z'
+    version: v1
+  properties:
+  - container: NeatINCDocumentation
+    container_property: doi
+    description: digital object identifier
+    immutable: false
+    max_count: 1
+    min_count: 0
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation/doi
+    value_type: text
+    view: NeatINCDocumentation
+    view_property: doi
+  - container: cdf_cdm:CogniteDescribable
+    container_property: name
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: name
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation/name
+    value_type: text
+    view: NeatINCDocumentation
+    view_property: name
+  - connection: direct
+    container: cdf_cdm:CogniteFile
+    container_property: assets
+    immutable: false
+    max_count: 100
+    min_count: 0
+    name: relatedPumps
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation/relatedPumps
+    value_type: NeatINCPump
+    view: NeatINCDocumentation
+    view_property: relatedPumps
+  - container: NeatINCFacility
+    container_property: UUID
+    description: unique identifier
+    immutable: false
+    max_count: 1
+    min_count: 0
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/UUID
+    value_type: text
+    view: NeatINCFacility
+    view_property: UUID
+  - container: cdf_cdm:CogniteDescribable
+    container_property: description
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: desc
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/desc
+    value_type: text
+    view: NeatINCFacility
+    view_property: desc
+  - connection: reverse(property=livesIn)
+    name: hasPumps
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/hasPumps
+    value_type: NeatINCPump
+    view: NeatINCFacility
+    view_property: hasPumps
+  - container: cdf_cdm:CogniteDescribable
+    container_property: name
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: name
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/name
+    value_type: text
+    view: NeatINCFacility
+    view_property: name
+  - connection: reverse(property=relatedPumps)
+    name: documentation
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/documentation
+    value_type: NeatINCDocumentation
+    view: NeatINCPump
+    view_property: documentation
+  - connection: direct
+    container: cdf_cdm:CogniteAsset
+    container_property: assetHierarchy_parent
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: livesIn
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/livesIn
+    value_type: NeatINCFacility
+    view: NeatINCPump
+    view_property: livesIn
+  - container: cdf_cdm:CogniteDescribable
+    container_property: name
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: name
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/name
+    value_type: text
+    view: NeatINCPump
+    view_property: name
+  - connection: direct
+    container: NeatINCPump
+    container_property: pressure
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: pressure
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/pressure
+    value_type: cdf_cdm:CogniteTimeSeries(version=v1)
+    view: NeatINCPump
+    view_property: pressure
+  - connection: direct
+    container: NeatINCPump
+    container_property: temperature
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: temperature
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/temperature
+    value_type: cdf_cdm:CogniteTimeSeries(version=v1)
+    view: NeatINCPump
+    view_property: temperature
+  - container: NeatINCPump
+    container_property: weight
+    description: this is a description of the field weight
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: weight
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/weight
+    value_type: float64(unit=mass:kilogm)
+    view: NeatINCPump
+    view_property: weight
+  - container: NeatINCPump
+    container_property: year
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: year
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/year
+    value_type: int32
+    view: NeatINCPump
+    view_property: year
+  views:
+  - implements: cdf_cdm:Cognite3DTransformation(version=v1),cdf_cdm:CogniteCubeMap(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360Image
+    view: cdf_cdm:Cognite360Image(version=v1)
+  - implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1),cdf_cdm:CogniteAnnotation(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageAnnotation
+    view: cdf_cdm:Cognite360ImageAnnotation(version=v1)
+  - description: Represents a logical collection of Cognite360Image instances
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:Cognite3DRevision(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageCollection
+    view: cdf_cdm:Cognite360ImageCollection(version=v1)
+  - description: Navigational aid for traversing Cognite360ImageModel instances
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:Cognite3DModel(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageModel
+    view: cdf_cdm:Cognite360ImageModel(version=v1)
+  - description: A way to group images across collections. Used for creating visual
+      scan history
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageStation
+    view: cdf_cdm:Cognite360ImageStation(version=v1)
+  - description: Groups revisions of 3D data of various kinds together (CAD, PointCloud,
+      Image360)
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DModel
+    view: cdf_cdm:Cognite3DModel(version=v1)
+  - description: This is the virtual position representation of an object in the physical
+      world, connecting an asset to one or more 3D resources
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DObject
+    view: cdf_cdm:Cognite3DObject(version=v1)
+  - description: Shared revision information for various 3D data types. Normally not
+      used directly, but through CognitePointCloudRevision, Image360Collection or
+      CogniteCADRevision
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DRevision
+    view: cdf_cdm:Cognite3DRevision(version=v1)
+  - description: The Cognite3DTransformation object defines a comprehensive 3D transformation,
+      enabling precise adjustments to an object's position, orientation, and size
+      in the 3D coordinate system. It allows for the translation of objects along
+      the three spatial axes, rotation around these axes using Euler angles, and scaling
+      along each axis to modify the object's dimensions. The object's transformation
+      is defined in "CDF space", a coordinate system where the positive Z axis is
+      the up direction
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DTransformation
+    view: cdf_cdm:Cognite3DTransformation(version=v1)
+  - description: Represents activities. Activities typically happen over a period
+      and have a start and end time.
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1),cdf_cdm:CogniteSchedulable(version=v1)
+    in_model: true
+    name: Activity
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteActivity
+    view: cdf_cdm:CogniteActivity(version=v1)
+  - description: Annotation represents contextualization results or links
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAnnotation
+    view: cdf_cdm:CogniteAnnotation(version=v1)
+  - description: Assets represent systems that support industrial functions or processes.
+      Assets are often called 'functional location'.
+    implements: cdf_cdm:CogniteVisualizable(version=v1),cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    name: Asset
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAsset
+    view: cdf_cdm:CogniteAsset(version=v1)
+  - description: Represents the class of an asset.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    name: Asset class
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAssetClass
+    view: cdf_cdm:CogniteAssetClass(version=v1)
+  - description: Represents the type of an asset.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    name: Asset type
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAssetType
+    view: cdf_cdm:CogniteAssetType(version=v1)
+  - description: Navigational aid for traversing CogniteCADModel instances
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:Cognite3DModel(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCADModel
+    view: cdf_cdm:CogniteCADModel(version=v1)
+  - description: Represents nodes from the 3D model that have been contextualized
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCADNode
+    view: cdf_cdm:CogniteCADNode(version=v1)
+  - implements: cdf_cdm:Cognite3DRevision(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCADRevision
+    view: cdf_cdm:CogniteCADRevision(version=v1)
+  - description: The cube map holds references to 6 images in used to visually represent
+      the surrounding environment
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCubeMap
+    view: cdf_cdm:CogniteCubeMap(version=v1)
+  - description: The describable core concept is used as a standard way of holding
+      the bare minimum of information about the instance
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteDescribable
+    view: cdf_cdm:CogniteDescribable(version=v1)
+  - description: Equipment represents physical supplies or devices.
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    name: Equipment
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteEquipment
+    view: cdf_cdm:CogniteEquipment(version=v1)
+  - description: Represents the type of equipment.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    name: Equipment type
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteEquipmentType
+    view: cdf_cdm:CogniteEquipmentType(version=v1)
+  - description: Represents files.
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    name: File
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteFile
+    view: cdf_cdm:CogniteFile(version=v1)
+  - description: Represents the categories of files as determined by contextualization
+      or categorization.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    name: File category
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteFileCategory
+    view: cdf_cdm:CogniteFileCategory(version=v1)
+  - description: PointCloud volume definition
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CognitePointCloudVolume
+    view: cdf_cdm:CognitePointCloudVolume(version=v1)
+  - description: CogniteSchedulable represents the metadata about when an activity
+      (or similar) starts and ends.
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteSchedulable
+    view: cdf_cdm:CogniteSchedulable(version=v1)
+  - description: The CogniteSourceSystem core concept is used to standardize the way
+      source system is stored.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteSourceSystem
+    view: cdf_cdm:CogniteSourceSystem(version=v1)
+  - in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteSourceable
+    view: cdf_cdm:CogniteSourceable(version=v1)
+  - description: Represents a series of data points in time order.
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    name: Time series
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteTimeSeries
+    view: cdf_cdm:CogniteTimeSeries(version=v1)
+  - description: Represents a single unit of measurement
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteUnit
+    view: cdf_cdm:CogniteUnit(version=v1)
+  - description: CogniteVisualizable defines the standard way to reference a related
+      3D resource
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteVisualizable
+    view: cdf_cdm:CogniteVisualizable(version=v1)
+  - implements: cdf_cdm:CogniteFile(version=v1)
+    in_model: true
+    name: Documentation
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation
+    view: NeatINCDocumentation
+  - implements: cdf_cdm:CogniteAsset(version=v1)
+    in_model: true
+    name: Facility
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility
+    view: NeatINCFacility
+  - description: this is a description of the type Pump
+    implements: cdf_cdm:CogniteAsset(version=v1)
+    in_model: true
+    name: Pump
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump
+    view: NeatINCPump

--- a/tests/tests_integration/test_session/test_data_model_prepare_fix/test_prefix_physical_data_model_entities_new_endpoint.yml
+++ b/tests/tests_integration/test_session/test_data_model_prepare_fix/test_prefix_physical_data_model_entities_new_endpoint.yml
@@ -1,0 +1,343 @@
+rules:
+  containers:
+  - container: NeatINCDocumentation
+    name: Documentation
+    used_for: node
+  - container: NeatINCFacility
+    name: Facility
+    used_for: node
+  - container: NeatINCPump
+    name: Pump
+    used_for: node
+  metadata:
+    created: '2024-09-19T00:00:00Z'
+    creator: Neat
+    external_id: NeatHelloWorld
+    name: Neat Hello World
+    role: DMS Architect
+    source_id: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Iteration_2
+    space: neat_playground
+    updated: '2024-09-19T00:00:00Z'
+    version: v1
+  properties:
+  - container: NeatINCDocumentation
+    container_property: doi
+    description: digital object identifier
+    immutable: false
+    max_count: 1
+    min_count: 0
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation/doi
+    value_type: text
+    view: NeatINCDocumentation
+    view_property: doi
+  - container: cdf_cdm:CogniteDescribable
+    container_property: name
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: name
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation/name
+    value_type: text
+    view: NeatINCDocumentation
+    view_property: name
+  - connection: direct
+    container: cdf_cdm:CogniteFile
+    container_property: assets
+    immutable: false
+    max_count: 100
+    min_count: 0
+    name: relatedPumps
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation/relatedPumps
+    value_type: NeatINCPump
+    view: NeatINCDocumentation
+    view_property: relatedPumps
+  - container: NeatINCFacility
+    container_property: UUID
+    description: unique identifier
+    immutable: false
+    max_count: 1
+    min_count: 0
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/UUID
+    value_type: text
+    view: NeatINCFacility
+    view_property: UUID
+  - container: cdf_cdm:CogniteDescribable
+    container_property: description
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: desc
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/desc
+    value_type: text
+    view: NeatINCFacility
+    view_property: desc
+  - connection: reverse(property=livesIn)
+    name: hasPumps
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/hasPumps
+    value_type: NeatINCPump
+    view: NeatINCFacility
+    view_property: hasPumps
+  - container: cdf_cdm:CogniteDescribable
+    container_property: name
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: name
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility/name
+    value_type: text
+    view: NeatINCFacility
+    view_property: name
+  - connection: reverse(property=relatedPumps)
+    name: documentation
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/documentation
+    value_type: NeatINCDocumentation
+    view: NeatINCPump
+    view_property: documentation
+  - connection: direct
+    container: cdf_cdm:CogniteAsset
+    container_property: assetHierarchy_parent
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: livesIn
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/livesIn
+    value_type: NeatINCFacility
+    view: NeatINCPump
+    view_property: livesIn
+  - container: cdf_cdm:CogniteDescribable
+    container_property: name
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: name
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/name
+    value_type: text
+    view: NeatINCPump
+    view_property: name
+  - connection: direct
+    container: NeatINCPump
+    container_property: pressure
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: pressure
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/pressure
+    value_type: cdf_cdm:CogniteTimeSeries(version=v1)
+    view: NeatINCPump
+    view_property: pressure
+  - connection: direct
+    container: NeatINCPump
+    container_property: temperature
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: temperature
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/temperature
+    value_type: cdf_cdm:CogniteTimeSeries(version=v1)
+    view: NeatINCPump
+    view_property: temperature
+  - container: NeatINCPump
+    container_property: weight
+    description: this is a description of the field weight
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: weight
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/weight
+    value_type: float64(unit=mass:kilogm)
+    view: NeatINCPump
+    view_property: weight
+  - container: NeatINCPump
+    container_property: year
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: year
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump/year
+    value_type: int32
+    view: NeatINCPump
+    view_property: year
+  views:
+  - implements: cdf_cdm:Cognite3DTransformation(version=v1),cdf_cdm:CogniteCubeMap(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360Image
+    view: cdf_cdm:Cognite360Image(version=v1)
+  - implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1),cdf_cdm:CogniteAnnotation(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageAnnotation
+    view: cdf_cdm:Cognite360ImageAnnotation(version=v1)
+  - description: Represents a logical collection of Cognite360Image instances
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:Cognite3DRevision(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageCollection
+    view: cdf_cdm:Cognite360ImageCollection(version=v1)
+  - description: Navigational aid for traversing Cognite360ImageModel instances
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:Cognite3DModel(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageModel
+    view: cdf_cdm:Cognite360ImageModel(version=v1)
+  - description: A way to group images across collections. Used for creating visual
+      scan history
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite360ImageStation
+    view: cdf_cdm:Cognite360ImageStation(version=v1)
+  - description: Groups revisions of 3D data of various kinds together (CAD, PointCloud,
+      Image360)
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DModel
+    view: cdf_cdm:Cognite3DModel(version=v1)
+  - description: This is the virtual position representation of an object in the physical
+      world, connecting an asset to one or more 3D resources
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DObject
+    view: cdf_cdm:Cognite3DObject(version=v1)
+  - description: Shared revision information for various 3D data types. Normally not
+      used directly, but through CognitePointCloudRevision, Image360Collection or
+      CogniteCADRevision
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DRevision
+    view: cdf_cdm:Cognite3DRevision(version=v1)
+  - description: The Cognite3DTransformation object defines a comprehensive 3D transformation,
+      enabling precise adjustments to an object's position, orientation, and size
+      in the 3D coordinate system. It allows for the translation of objects along
+      the three spatial axes, rotation around these axes using Euler angles, and scaling
+      along each axis to modify the object's dimensions. The object's transformation
+      is defined in "CDF space", a coordinate system where the positive Z axis is
+      the up direction
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Cognite3DTransformation
+    view: cdf_cdm:Cognite3DTransformation(version=v1)
+  - description: Represents activities. Activities typically happen over a period
+      and have a start and end time.
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1),cdf_cdm:CogniteSchedulable(version=v1)
+    in_model: true
+    name: Activity
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteActivity
+    view: cdf_cdm:CogniteActivity(version=v1)
+  - description: Annotation represents contextualization results or links
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAnnotation
+    view: cdf_cdm:CogniteAnnotation(version=v1)
+  - description: Assets represent systems that support industrial functions or processes.
+      Assets are often called 'functional location'.
+    implements: cdf_cdm:CogniteVisualizable(version=v1),cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    name: Asset
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAsset
+    view: cdf_cdm:CogniteAsset(version=v1)
+  - description: Represents the class of an asset.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    name: Asset class
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAssetClass
+    view: cdf_cdm:CogniteAssetClass(version=v1)
+  - description: Represents the type of an asset.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    name: Asset type
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteAssetType
+    view: cdf_cdm:CogniteAssetType(version=v1)
+  - description: Navigational aid for traversing CogniteCADModel instances
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:Cognite3DModel(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCADModel
+    view: cdf_cdm:CogniteCADModel(version=v1)
+  - description: Represents nodes from the 3D model that have been contextualized
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCADNode
+    view: cdf_cdm:CogniteCADNode(version=v1)
+  - implements: cdf_cdm:Cognite3DRevision(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCADRevision
+    view: cdf_cdm:CogniteCADRevision(version=v1)
+  - description: The cube map holds references to 6 images in used to visually represent
+      the surrounding environment
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteCubeMap
+    view: cdf_cdm:CogniteCubeMap(version=v1)
+  - description: The describable core concept is used as a standard way of holding
+      the bare minimum of information about the instance
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteDescribable
+    view: cdf_cdm:CogniteDescribable(version=v1)
+  - description: Equipment represents physical supplies or devices.
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    name: Equipment
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteEquipment
+    view: cdf_cdm:CogniteEquipment(version=v1)
+  - description: Represents the type of equipment.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    name: Equipment type
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteEquipmentType
+    view: cdf_cdm:CogniteEquipmentType(version=v1)
+  - description: Represents files.
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    name: File
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteFile
+    view: cdf_cdm:CogniteFile(version=v1)
+  - description: Represents the categories of files as determined by contextualization
+      or categorization.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    name: File category
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteFileCategory
+    view: cdf_cdm:CogniteFileCategory(version=v1)
+  - description: PointCloud volume definition
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CognitePointCloudVolume
+    view: cdf_cdm:CognitePointCloudVolume(version=v1)
+  - description: CogniteSchedulable represents the metadata about when an activity
+      (or similar) starts and ends.
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteSchedulable
+    view: cdf_cdm:CogniteSchedulable(version=v1)
+  - description: The CogniteSourceSystem core concept is used to standardize the way
+      source system is stored.
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteSourceSystem
+    view: cdf_cdm:CogniteSourceSystem(version=v1)
+  - in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteSourceable
+    view: cdf_cdm:CogniteSourceable(version=v1)
+  - description: Represents a series of data points in time order.
+    implements: cdf_cdm:CogniteDescribable(version=v1),cdf_cdm:CogniteSourceable(version=v1)
+    in_model: true
+    name: Time series
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteTimeSeries
+    view: cdf_cdm:CogniteTimeSeries(version=v1)
+  - description: Represents a single unit of measurement
+    implements: cdf_cdm:CogniteDescribable(version=v1)
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteUnit
+    view: cdf_cdm:CogniteUnit(version=v1)
+  - description: CogniteVisualizable defines the standard way to reference a related
+      3D resource
+    in_model: true
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/CogniteVisualizable
+    view: cdf_cdm:CogniteVisualizable(version=v1)
+  - implements: cdf_cdm:CogniteFile(version=v1)
+    in_model: true
+    name: Documentation
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Documentation
+    view: NeatINCDocumentation
+  - implements: cdf_cdm:CogniteAsset(version=v1)
+    in_model: true
+    name: Facility
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Facility
+    view: NeatINCFacility
+  - description: this is a description of the type Pump
+    implements: cdf_cdm:CogniteAsset(version=v1)
+    in_model: true
+    name: Pump
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/NeatHelloWorld/v1/Pump
+    view: NeatINCPump

--- a/tests/tests_integration/test_session/test_data_model_prepare_fix/test_standardize_space_and_version_new_endpoint.yml
+++ b/tests/tests_integration/test_session/test_data_model_prepare_fix/test_standardize_space_and_version_new_endpoint.yml
@@ -1,0 +1,168 @@
+rules:
+  containers:
+  - container: Documentation
+    name: Documentation
+    used_for: node
+  - container: Facility
+    name: Facility
+    used_for: node
+  - container: Pump
+    name: Pump
+    used_for: node
+  metadata:
+    created: '2025-02-06T13:51:14.977000'
+    creator: MISSING
+    external_id: TestMixedUpVersions
+    name: TestMixedUpVersions
+    role: DMS Architect
+    source_id: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Iteration_2
+    space: neat_playground
+    updated: '2025-02-06T13:51:14.977000'
+    version: v1
+  properties:
+  - container: Documentation
+    container_property: file
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: file
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Documentation/file
+    value_type: file
+    view: Documentation
+    view_property: file
+  - container: Documentation
+    container_property: name
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: name
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Documentation/name
+    value_type: text
+    view: Documentation
+    view_property: name
+  - connection: edge(direction=inwards,type=Pump.documentation)
+    max_count: .inf
+    name: relatedPumps
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Documentation/relatedPumps
+    value_type: Pump
+    view: Documentation
+    view_property: relatedPumps
+  - container: Facility
+    container_property: desc
+    immutable: false
+    max_count: 1
+    min_count: 1
+    name: desc
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Facility/desc
+    value_type: text
+    view: Facility
+    view_property: desc
+  - connection: reverse(property=livesIn)
+    max_count: .inf
+    name: hasPumps
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Facility/hasPumps
+    value_type: Pump
+    view: Facility
+    view_property: hasPumps
+  - container: Facility
+    container_property: name
+    immutable: false
+    max_count: 1
+    min_count: 1
+    name: name
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Facility/name
+    value_type: text
+    view: Facility
+    view_property: name
+  - connection: edge
+    max_count: .inf
+    name: documentation
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Pump/documentation
+    value_type: Documentation
+    view: Pump
+    view_property: documentation
+  - connection: direct
+    container: Pump
+    container_property: livesIn
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: livesIn
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Pump/livesIn
+    value_type: Facility
+    view: Pump
+    view_property: livesIn
+  - container: Pump
+    container_property: name
+    immutable: false
+    max_count: 1
+    min_count: 1
+    name: name
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Pump/name
+    value_type: text
+    view: Pump
+    view_property: name
+  - container: Pump
+    container_property: pressure
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: pressure
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Pump/pressure
+    value_type: timeseries
+    view: Pump
+    view_property: pressure
+  - container: Pump
+    container_property: temperature
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: temperature
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Pump/temperature
+    value_type: timeseries
+    view: Pump
+    view_property: temperature
+  - container: Pump
+    container_property: weight
+    description: this is a description of the field weight
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: weight
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Pump/weight
+    value_type: float64
+    view: Pump
+    view_property: weight
+  - container: Pump
+    container_property: weightUnit
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: weightUnit
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Pump/weightUnit
+    value_type: text
+    view: Pump
+    view_property: weightUnit
+  - container: Pump
+    container_property: year
+    immutable: false
+    max_count: 1
+    min_count: 0
+    name: year
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Pump/year
+    value_type: int32
+    view: Pump
+    view_property: year
+  views:
+  - in_model: true
+    name: Documentation
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Documentation
+    view: Documentation
+  - in_model: true
+    name: Facility
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Facility
+    view: Facility
+  - in_model: true
+    name: Pump
+    neatId: http://purl.org/cognite/neat/data-model/verified/physical/neat_playground/TestMixedUpVersions/v1/Pump
+    view: Pump


### PR DESCRIPTION
# Description

New endpoint to access existing data model transformation features via `neat.data_model.transform`

To risk reviewers: NO NEW FEATURES! LARGE PR DUE TO TEST DATA!

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Added

- Added new access point for data model transformations `neat.data_model.transform`
