### PR TITLE
Interface for data model transformation plugins

### DIFF
--- a/cognite/neat/plugins/_manager.py
+++ b/cognite/neat/plugins/_manager.py
@@ -5,14 +5,16 @@ from typing import Any, ClassVar, TypeAlias, TypeVar, cast
 
 from ._issues import PluginDuplicateError, PluginError, PluginLoadingError
 from .data_model.importers import DataModelImporterPlugin
+from .data_model.transformers._base import DataModelTransformerPlugin
 
 # Here we configure entry points where external plugins are going to be registered.
 plugins_entry_points = {
     "cognite.neat.plugins.data_model.importers": DataModelImporterPlugin,
+    "cognite.neat.plugins.data_model.transformers": DataModelTransformerPlugin,
 }
 
 #: Type alias for all supported plugin types
-NeatPlugin: TypeAlias = DataModelImporterPlugin
+NeatPlugin: TypeAlias = DataModelImporterPlugin | DataModelTransformerPlugin
 
 # Generic type variable for plugin types
 T_NeatPlugin = TypeVar("T_NeatPlugin", bound=NeatPlugin)
@@ -62,7 +64,7 @@ class PluginManager:
             type_ (type): The type of the plugin.
         """
         try:
-            plugin_class = self._plugins[(name, type_)]
+            plugin_class = self._plugins[(name, cast(type[NeatPlugin], type_))]
             return cast(type[T_NeatPlugin], plugin_class)
         except KeyError:
             raise PluginError(plugin_name=name, plugin_type=type_.__name__) from None

--- a/cognite/neat/plugins/_manager.py
+++ b/cognite/neat/plugins/_manager.py
@@ -7,12 +7,6 @@ from ._issues import PluginDuplicateError, PluginError, PluginLoadingError
 from .data_model.importers import DataModelImporterPlugin
 from .data_model.transformers._base import DataModelTransformerPlugin
 
-# Here we configure entry points where external plugins are going to be registered.
-plugins_entry_points = {
-    "cognite.neat.plugins.data_model.importers": DataModelImporterPlugin,
-    "cognite.neat.plugins.data_model.transformers": DataModelTransformerPlugin,
-}
-
 #: Type alias for all supported plugin types
 NeatPlugin: TypeAlias = DataModelImporterPlugin | DataModelTransformerPlugin
 
@@ -50,6 +44,7 @@ class PluginManager:
 
     _plugins_entry_points: ClassVar[dict[str, type[NeatPlugin]]] = {
         "cognite.neat.plugins.data_model.importers": DataModelImporterPlugin,
+        "cognite.neat.plugins.data_model.transformers": DataModelTransformerPlugin,
     }
 
     def __init__(self, plugins: dict[tuple[str, type[NeatPlugin]], Any]) -> None:

--- a/cognite/neat/plugins/data_model/transformers/__init__.py
+++ b/cognite/neat/plugins/data_model/transformers/__init__.py
@@ -1,0 +1,5 @@
+from ._base import DataModelTransformerPlugin
+
+__all__ = [
+    "DataModelTransformerPlugin",
+]

--- a/cognite/neat/plugins/data_model/transformers/_base.py
+++ b/cognite/neat/plugins/data_model/transformers/_base.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from cognite.neat.core._data_model.transformers._base import VerifiedDataModelTransformer
+
+
+class DataModelTransformerPlugin:
+    """This class is used as an interface for data model transformer plugins.
+    Any plugin that is used for transforming data models should inherit from this class.
+    It is expected to implement the `configure` method which returns a configured transformer.
+    """
+
+    def configure(self, **kwargs: Any) -> VerifiedDataModelTransformer:
+        """Return a configure plugin for data model import.
+
+        Args:
+            **kwargs (Any): Additional keyword arguments for configuration.
+
+        Returns:
+            VerifiedDataModelTransformer: A configured instance of the VerifiedDataModelTransformer.
+
+        !!! note "Returns"
+            The method must return an instance of `VerifiedDataModelTransformer` or its subclasses
+            meaning it must implement the `VerifiedDataModelTransformer` interface.
+        """
+
+        raise NotImplementedError()

--- a/cognite/neat/session/_session/_data_model/_transform.py
+++ b/cognite/neat/session/_session/_data_model/_transform.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any
 
 from cognite.neat.core._data_model.transformers._converters import (
     PrefixEntities,
@@ -7,15 +7,10 @@ from cognite.neat.core._data_model.transformers._converters import (
     ToCompliantEntities,
 )
 from cognite.neat.core._issues._base import IssueList
-from cognite.neat.core._utils.auxiliary import filter_kwargs_by_method
 from cognite.neat.plugins._manager import get_plugin_manager
 from cognite.neat.plugins.data_model.transformers._base import DataModelTransformerPlugin
 from cognite.neat.session._state import SessionState
 from cognite.neat.session.exceptions import session_class_wrapper
-
-InternalTransformerName = Literal[
-    "cdf_compliant_external_ids", "prefix", "standardize_naming", "standardize_space_and_version"
-]
 
 
 @session_class_wrapper
@@ -24,12 +19,11 @@ class TransformAPI:
         self._state = state
 
     def __call__(self, name: str, **kwargs: Any) -> IssueList:
-        """Provides access to internal data model transformers and external data model
-        transformer plugins.
+        """Provides access to external data model transformers provided as python
+        plugins.
 
         Args:
-            name (str): The name of format (e.g. Excel) transformer is handling.
-            io (str | Path | | DataModelIdentifier | None): The input/output interface for the transformer.
+            name (str): The name of transformer.
             **kwargs (Any): Additional keyword arguments for the transformer.
 
         !!! note "kwargs"
@@ -37,32 +31,13 @@ class TransformAPI:
             what keyword arguments are supported.
         """
 
-        # Clean the input name once before matching.
-        clean_name: InternalTransformerName | str = name.strip().lower()
-
-        # The match statement cleanly handles each case.
-        match clean_name:
-            case "cdf_compliant_external_ids":
-                return self.cdf_compliant_external_ids()
-
-            case "prefix":
-                return self.prefix(**filter_kwargs_by_method(kwargs, self.prefix))
-
-            case "standardize_naming":
-                return self.standardize_naming()
-
-            case "standardize_space_and_version":
-                return self.standardize_space_and_version()
-
-            case _:  # The wildcard '_' acts as the default 'else' case.
-                return self._plugin(name, **kwargs)
+        return self._plugin(name, **kwargs)
 
     def _plugin(self, name: str, **kwargs: Any) -> IssueList:
-        """Provides access to the external plugins for data model importing.
+        """Provides access to the external plugins for data model transformations.
 
         Args:
-            name (str): The name of format (e.g. Excel) plugin is handling.
-            io (str | Path | None): The input/output interface for the plugin.
+            name (str): The name of transformer.
             **kwargs (Any): Additional keyword arguments for the plugin.
 
         !!! note "kwargs"

--- a/cognite/neat/session/_session/_data_model/_transform.py
+++ b/cognite/neat/session/_session/_data_model/_transform.py
@@ -1,3 +1,5 @@
+from typing import Any, Literal
+
 from cognite.neat.core._data_model.transformers._converters import (
     PrefixEntities,
     StandardizeNaming,
@@ -5,14 +7,83 @@ from cognite.neat.core._data_model.transformers._converters import (
     ToCompliantEntities,
 )
 from cognite.neat.core._issues._base import IssueList
+from cognite.neat.core._utils.auxiliary import filter_kwargs_by_method
+from cognite.neat.plugins._manager import get_plugin_manager
+from cognite.neat.plugins.data_model.transformers._base import DataModelTransformerPlugin
 from cognite.neat.session._state import SessionState
 from cognite.neat.session.exceptions import session_class_wrapper
+
+InternalTransformerName = Literal[
+    "cdf_compliant_external_ids", "prefix", "standardize_naming", "standardize_space_and_version"
+]
 
 
 @session_class_wrapper
 class TransformAPI:
     def __init__(self, state: SessionState) -> None:
         self._state = state
+
+    def __call__(self, name: str, **kwargs: Any) -> IssueList:
+        """Provides access to internal data model transformers and external data model
+        transformer plugins.
+
+        Args:
+            name (str): The name of format (e.g. Excel) transformer is handling.
+            io (str | Path | | DataModelIdentifier | None): The input/output interface for the transformer.
+            **kwargs (Any): Additional keyword arguments for the transformer.
+
+        !!! note "kwargs"
+            Users must consult the documentation of the transformer to understand
+            what keyword arguments are supported.
+        """
+
+        # Clean the input name once before matching.
+        clean_name: InternalTransformerName | str = name.strip().lower()
+
+        # The match statement cleanly handles each case.
+        match clean_name:
+            case "cdf_compliant_external_ids":
+                return self.cdf_compliant_external_ids()
+
+            case "prefix":
+                return self.prefix(**filter_kwargs_by_method(kwargs, self.prefix))
+
+            case "standardize_naming":
+                return self.standardize_naming()
+
+            case "standardize_space_and_version":
+                return self.standardize_space_and_version()
+
+            case _:  # The wildcard '_' acts as the default 'else' case.
+                return self._plugin(name, **kwargs)
+
+    def _plugin(self, name: str, **kwargs: Any) -> IssueList:
+        """Provides access to the external plugins for data model importing.
+
+        Args:
+            name (str): The name of format (e.g. Excel) plugin is handling.
+            io (str | Path | None): The input/output interface for the plugin.
+            **kwargs (Any): Additional keyword arguments for the plugin.
+
+        !!! note "kwargs"
+            Users must consult the documentation of the plugin to understand
+            what keyword arguments are supported.
+        """
+
+        self._state._raise_exception_if_condition_not_met(
+            "Data Model Read",
+            empty_data_model_store_required=False,
+        )
+
+        plugin_manager = get_plugin_manager()
+        plugin = plugin_manager.get(name, DataModelTransformerPlugin)
+
+        print(
+            f"You are using an external plugin {plugin.__name__}, which is not developed by the NEAT team."
+            "\nUse it at your own risk."
+        )
+
+        return self._state.data_model_transform(plugin().configure(**kwargs))
 
     def cdf_compliant_external_ids(self) -> IssueList:
         """Convert conceptual data model component external ids to CDF compliant ids."""
@@ -23,7 +94,6 @@ class TransformAPI:
 
         Args:
             prefix: The prefix to add to the views in the data model.
-
         """
 
         return self._state.data_model_transform(PrefixEntities(prefix))  # type: ignore[arg-type]


### PR DESCRIPTION
# Description

Added interface for data model transformation plugins. The data model transformation plugins in current implementation of interface only support validated data models.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Added

- Plugin interface for data model transformers.
