### PR TITLE
Refactoring Data Model: Adding neat specific URI and NameSpace classes

### DIFF
--- a/cognite/neat/data_model/models/entities/__init__.py
+++ b/cognite/neat/data_model/models/entities/__init__.py
@@ -1,0 +1,9 @@
+from ._constants import Undefined, Unknown
+from ._identifiers import URI, NameSpace
+
+__all__ = [
+    "URI",
+    "NameSpace",
+    "Undefined",
+    "Unknown",
+]

--- a/cognite/neat/data_model/models/entities/_constants.py
+++ b/cognite/neat/data_model/models/entities/_constants.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class _UndefinedType(BaseModel): ...
+
+
+class _UnknownType(BaseModel):
+    def __str__(self) -> str:
+        return "#N/A"
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+
+# This is a trick to make Undefined and Unknown singletons
+Undefined = _UndefinedType()
+Unknown = _UnknownType()
+_PARSE = object()

--- a/cognite/neat/data_model/models/entities/_identifiers.py
+++ b/cognite/neat/data_model/models/entities/_identifiers.py
@@ -1,0 +1,61 @@
+from pydantic import HttpUrl, RootModel, ValidationError
+
+from cognite.neat.core._utils.auxiliary import local_import
+
+
+class URI(RootModel[str]):
+    def __init__(self, value: str):
+        try:
+            # Use Pydantic's AnyUrl to validate the URI
+            _ = HttpUrl(value)
+        except ValidationError as e:
+            raise ValueError(f"Invalid URI: {value}") from e
+        super().__init__(value)
+
+    def __str__(self) -> str:
+        return self.root
+
+    def __repr__(self) -> str:
+        return f"URI({self.root!r})"
+
+    def as_rdflib_uriref(self):  # type: ignore[no-untyped-def]
+        # rdflib is an optional dependency, so import here
+        local_import("rdflib", "rdflib")
+        from rdflib import URIRef
+
+        return URIRef(self.root)
+
+
+class NameSpace(RootModel[str]):
+    def __init__(self, value: str):
+        try:
+            # Use Pydantic's AnyUrl to validate the URI
+            _ = HttpUrl(value)
+        except ValidationError as e:
+            raise ValueError(f"Invalid Namespace: {value}") from e
+        super().__init__(value)
+
+    def __str__(self) -> str:
+        return self.root
+
+    def __repr__(self) -> str:
+        return f"NameSpace({self.root!r})"
+
+    def term(self, name: str) -> URI:
+        # need to handle slices explicitly because of __getitem__ override
+        return URI(self.root + (name if isinstance(name, str) else ""))
+
+    def __getitem__(self, key: str) -> URI:  # type: ignore[override]
+        return self.term(key)
+
+    def __getattr__(self, name: str) -> URI:
+        if name.startswith("__"):  # ignore any special Python names!
+            raise AttributeError
+        return self.term(name)
+
+    def as_rdflib_namespace(self):  # type: ignore[no-untyped-def]
+        # rdflib is an optional dependency, so import here
+        local_import("rdflib", "rdflib")
+        from rdflib import Namespace
+
+        return Namespace(self.root)

--- a/tests/tests_unit/test_rules/test_models/test_identifiers.py
+++ b/tests/tests_unit/test_rules/test_models/test_identifiers.py
@@ -1,0 +1,179 @@
+import pytest
+from rdflib import Namespace, URIRef
+
+from cognite.neat.data_model.models.entities import URI, NameSpace
+
+
+class TestNameSpace:
+    def test_valid_namespace_creation(self):
+        """Test creating a NameSpace with valid URIs."""
+        valid_namespaces = [
+            "http://example.com/",
+            "https://example.org/vocab#",
+            "http://www.w3.org/2000/01/rdf-schema#",
+            "https://schema.org/",
+        ]
+
+        for namespace_str in valid_namespaces:
+            ns = NameSpace(namespace_str)
+            assert str(ns) == namespace_str
+            assert ns.root == namespace_str
+
+    def test_invalid_namespace_creation(self):
+        """Test that invalid URIs raise ValueError."""
+        invalid_namespaces = [
+            "not-a-uri",
+            "",
+            "://invalid",
+            "http://",
+            "just-text",
+            "ftp://files.example.com/",
+        ]
+
+        for invalid_ns in invalid_namespaces:
+            with pytest.raises(ValueError, match="Invalid Namespace"):
+                NameSpace(invalid_ns)
+
+    def test_namespace_repr(self):
+        """Test string representation of NameSpace."""
+        ns = NameSpace("http://example.com/")
+        assert repr(ns) == "NameSpace('http://example.com/')"
+
+    def test_term_method(self):
+        """Test creating terms using the term method."""
+        ns = NameSpace("http://example.com/vocab#")
+
+        term = ns.term("Person")
+        assert isinstance(term, URI)
+        assert str(term) == "http://example.com/vocab#Person"
+
+        term = ns.term("hasName")
+        assert str(term) == "http://example.com/vocab#hasName"
+
+    def test_getitem_method(self):
+        """Test creating terms using bracket notation."""
+        ns = NameSpace("http://example.com/vocab#")
+
+        term = ns["Person"]
+        assert isinstance(term, URI)
+        assert str(term) == "http://example.com/vocab#Person"
+
+        term = ns["hasAge"]
+        assert str(term) == "http://example.com/vocab#hasAge"
+
+    def test_getattr_method(self):
+        """Test creating terms using attribute access."""
+        ns = NameSpace("http://example.com/vocab#")
+
+        term = ns.Person
+        assert isinstance(term, URI)
+        assert str(term) == "http://example.com/vocab#Person"
+
+        term = ns.hasName
+        assert str(term) == "http://example.com/vocab#hasName"
+
+    def test_getattr_special_names(self):
+        """Test that special Python names raise AttributeError."""
+        ns = NameSpace("http://example.com/vocab#")
+
+        with pytest.raises(AttributeError):
+            _ = ns.__special__
+
+    def test_as_rdflib_namespace(self):
+        """Test conversion to rdflib Namespace."""
+        pytest.importorskip("rdflib")
+
+        ns = NameSpace("http://example.com/vocab#")
+        rdflib_ns = ns.as_rdflib_namespace()
+
+        assert isinstance(rdflib_ns, Namespace)
+        assert str(rdflib_ns) == "http://example.com/vocab#"
+
+    @pytest.mark.parametrize(
+        "term_name",
+        [
+            "Person",
+            "hasName",
+            "Organization",
+            "member_of",
+            "CamelCase",
+            "snake_case",
+            "kebab-case",
+        ],
+    )
+    def test_various_term_names(self, term_name: str):
+        """Test creating terms with various naming conventions."""
+        ns = NameSpace("http://example.com/vocab#")
+
+        # Test all three ways of creating terms
+        term1 = ns.term(term_name)
+        term2 = ns[term_name]
+        term3 = getattr(ns, term_name)
+
+        expected = f"http://example.com/vocab#{term_name}"
+        assert str(term1) == expected
+        assert str(term2) == expected
+        assert str(term3) == expected
+
+
+class TestURI:
+    def test_valid_uri_creation(self):
+        """Test creating URI with valid URIs."""
+        valid_uris = [
+            "http://example.com",
+            "https://example.org/path",
+            "http://www.w3.org/2000/01/rdf-schema#Class",
+            "https://schema.org/Person",
+        ]
+
+        for uri_str in valid_uris:
+            uri = URI(uri_str)
+            assert str(uri) == uri_str
+            assert uri.root == uri_str
+
+    def test_invalid_uri_creation(self):
+        """Test that invalid URIs raise ValueError."""
+        invalid_uris = [
+            "not-a-uri",
+            "",
+            "://invalid",
+            "http://",
+            "just-text",
+            "file:///path/to/file",
+            "mailto:user@example.com",
+            "ftp://files.example.com/file.txt",
+        ]
+
+        for invalid_uri in invalid_uris:
+            with pytest.raises(ValueError, match="Invalid URI"):
+                URI(invalid_uri)
+
+    def test_uri_repr(self):
+        """Test string representation of URI."""
+        uri = URI("http://example.com/Person")
+        assert repr(uri) == "URI('http://example.com/Person')"
+
+    def test_as_rdflib_uriref(self):
+        """Test conversion to rdflib URIRef."""
+        pytest.importorskip("rdflib")
+
+        uri = URI("http://example.com/Person")
+        uriref = uri.as_rdflib_uriref()
+
+        assert isinstance(uriref, URIRef)
+        assert str(uriref) == "http://example.com/Person"
+
+    @pytest.mark.parametrize(
+        "uri_str",
+        [
+            "http://example.com",
+            "https://www.w3.org/2000/01/rdf-schema#Class",
+            "https://schema.org/Person",
+            "http://xmlns.com/foaf/0.1/name",
+        ],
+    )
+    def test_various_uri_formats(self, uri_str: str):
+        """Test creating URIs with various formats."""
+        uri = URI(uri_str)
+        assert str(uri) == uri_str
+        assert uri.root == uri_str


### PR DESCRIPTION
# Description

This is first of a number of PR that are focused on refactoring neat data model features to be exposed as Toolkit plugin. In this specific PR previously neat own `Uri` and `NameSpace` class is defined, such that `rdflib` package can be made into an optional dependency.  Notice that `_constants.py` is copied from `cognite/neat/core/_data_model/models/entities`.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Added

- Added neat native `URI` and `NameSpace` classes that behave same as those provided by `rdflib` package
