### PR TITLE
738 fix case sensitivity issue in direction definitions

### DIFF
--- a/cognite/neat/core/_data_model/models/entities/_single_value.py
+++ b/cognite/neat/core/_data_model/models/entities/_single_value.py
@@ -129,6 +129,7 @@ class ConceptualEntity(BaseModel, extra="ignore"):
 
     @model_validator(mode="before")
     def _load(cls, data: Any) -> "dict | ConceptualEntity":
+        print(f"Here {data}")
         defaults = {}
         if isinstance(data, dict) and _PARSE in data:
             defaults = data.get("defaults", {})
@@ -578,6 +579,13 @@ class EdgeEntity(PhysicalEntity[None]):
     edge_type: DMSNodeEntity | None = Field(None, alias="type")
     properties: ViewEntity | None = None
     direction: Literal["outwards", "inwards"] = "outwards"
+
+    @field_validator("direction", mode="before")
+    @classmethod
+    def _normalize_direction(cls, value: Any) -> str:
+        if isinstance(value, str):
+            return value.lower()
+        return value
 
     def dump(self, **defaults: Any) -> str:
         # Add default direction

--- a/cognite/neat/core/_data_model/models/entities/_single_value.py
+++ b/cognite/neat/core/_data_model/models/entities/_single_value.py
@@ -129,7 +129,6 @@ class ConceptualEntity(BaseModel, extra="ignore"):
 
     @model_validator(mode="before")
     def _load(cls, data: Any) -> "dict | ConceptualEntity":
-        print(f"Here {data}")
         defaults = {}
         if isinstance(data, dict) and _PARSE in data:
             defaults = data.get("defaults", {})

--- a/tests/tests_unit/test_rules/test_models/test_entities.py
+++ b/tests/tests_unit/test_rules/test_models/test_entities.py
@@ -268,6 +268,14 @@ class TestEntities:
         actual = cls_.load(raw, return_on_failure=True)
         assert actual == raw
 
+    def test_direction_case_insensitive(self) -> None:
+        defaults = {"space": DEFAULT_SPACE, "version": DEFAULT_VERSION}
+        e1 = EdgeEntity.load("edge(direction=INWardS,properties=StartEndTime)", **defaults)
+        e2 = EdgeEntity.load("edge(direction=OutWArds,properties=StartEndTime)", **defaults)
+
+        assert e1.direction == "inwards"
+        assert e2.direction == "outwards"
+
 
 class TestEntityPattern:
     @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Up until now we were case-sensitive when providing input for edge directionality , which had to be specified in lower case as either `inwards` or `outwards`. With this PR we are fixing this issue, i.e. being case-insensitive.

## Bump

- [X] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Improved

- No more case-sensitive input needed for edge definition of directionality
