### PR TITLE
Removing debugging part of test

### DIFF
--- a/tests/tests_integration/test_client_available.py
+++ b/tests/tests_integration/test_client_available.py
@@ -4,9 +4,4 @@ from cognite.client import CogniteClient
 def test_cognite_client_available(cognite_client: CogniteClient) -> None:
     assert cognite_client is not None
     token = cognite_client.iam.token.inspect()
-    cognite_client.post(
-        "/api/v1/projects/list",
-        json={"limit": 1},
-        headers={"Content-Type": "application/json", "Accept": "application/json"},
-    )
     assert token is not None


### PR DESCRIPTION
# Description

Removing part of test that was used locally for debugging, which unft. got pushed and merged to main. This test is blocking all other PRs, who got synced with main. Therefore, the test is reverted to the original form, without the debug part.

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip

## Changelog
### Removed

- Reverted to the original test
