### PR TITLE
[THIS-732] 🏗 Add model pydantic

### DIFF
--- a/cognite/neat/_data_model/models/dms/_data_model.py
+++ b/cognite/neat/_data_model/models/dms/_data_model.py
@@ -1,0 +1,71 @@
+from abc import ABC
+
+from pydantic import Field
+
+from ._base import Resource, WriteableResource
+from ._constants import (
+    DM_EXTERNAL_ID_PATTERN,
+    DM_VERSION_PATTERN,
+    SPACE_FORMAT_PATTERN,
+)
+from ._references import ViewReference
+
+
+class DataModel(Resource, ABC):
+    """Cognite Data Model resource.
+
+    Data models group and structure views into reusable collections.
+    A data model contains a set of views where the node types can
+    refer to each other with direct relations and edges.
+    """
+
+    space: str = Field(
+        description="The workspace for the data model, a unique identifier for the space.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
+    external_id: str = Field(
+        description="External-id of the data model.",
+        min_length=1,
+        max_length=255,
+        pattern=DM_EXTERNAL_ID_PATTERN,
+    )
+    version: str = Field(
+        description="Version of the data model.",
+        max_length=43,
+        pattern=DM_VERSION_PATTERN,
+    )
+    name: str | None = Field(
+        default=None,
+        description="Human readable name for the data model.",
+        max_length=255,
+    )
+    description: str | None = Field(
+        default=None,
+        description="Description of the data model.",
+        max_length=1024,
+    )
+    # The API supports View here, but in Neat we will only use ViewReference
+    views: list[ViewReference] | None = Field(
+        description="List of views included in this data model.",
+        default=None,
+    )
+
+
+class DataModelRequest(DataModel): ...
+
+
+class DataModelResponse(DataModel, WriteableResource[DataModelRequest]):
+    created_time: int = Field(
+        description="When the data model was created. The number of milliseconds since 00:00:00 Thursday, "
+        "1 January 1970, Coordinated Universal Time (UTC), minus leap seconds."
+    )
+    last_updated_time: int = Field(
+        description="When the data model was last updated. The number of milliseconds since 00:00:00 Thursday, "
+        "1 January 1970, Coordinated Universal Time (UTC), minus leap seconds."
+    )
+    is_global: bool = Field(description="Is this a global data model.")
+
+    def as_request(self) -> DataModelRequest:
+        return DataModelRequest.model_validate(self.model_dump(by_alias=True))


### PR DESCRIPTION
# Description

Stacked on #1284, #1296

**Context**: We are changing the internal structure of the neat data models. We are dropping the physical data model format in Neat, and instead will have a one-to-one DMS format identical to the API. In principle, we could use the data classes that are in the `cognite-sdk`, but we decided to reimplement them in `pydantic`. This is to 1. Get better validation. 2. Better performance on serialization (pydantic does serialization in rust), 3. Make them easy to extend and connect to the Neat Conceptual model.

This PR implements the Pydantic class for data models. 

Note this PR has very few tests. This is because this an implementation of the API in pydantic. Having a lot of tests of the serialization/deserialization is essentially testing that `pydantic` functionality. 

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip

