### PR TITLE
🥺Make refernce hashable

### DIFF
--- a/cognite/neat/_data_model/models/dms/_container.py
+++ b/cognite/neat/_data_model/models/dms/_container.py
@@ -18,6 +18,7 @@ from ._constants import (
 from ._constraints import Constraint
 from ._data_types import DataType
 from ._indexes import Index
+from ._references import ContainerReference
 
 KEY_PATTERN = re.compile(CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER_PATTERN)
 
@@ -131,6 +132,12 @@ class Container(Resource, ABC):
                 f"{humanize_collection(FORBIDDEN_CONTAINER_AND_VIEW_EXTERNAL_IDS)}"
             )
         return val
+
+    def as_reference(self) -> ContainerReference:
+        return ContainerReference(
+            space=self.space,
+            externalId=self.external_id,
+        )
 
 
 class ContainerRequest(Container): ...

--- a/cognite/neat/_data_model/models/dms/_references.py
+++ b/cognite/neat/_data_model/models/dms/_references.py
@@ -6,7 +6,10 @@ from ._base import BaseModelObject
 from ._constants import DM_EXTERNAL_ID_PATTERN, SPACE_FORMAT_PATTERN
 
 
-class ContainerReference(BaseModelObject):
+class ReferenceObject(BaseModelObject, frozen=True): ...
+
+
+class ContainerReference(ReferenceObject):
     type: Literal["container"] = "container"
     space: str = Field(
         description="Id of the space hosting (containing) the container.",


### PR DESCRIPTION
# Description

This is a minor change to ensure that the reference version is hashable and thus can be used as a key in a dict.

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip

