### PR TITLE
🙃 Remove accelerate team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @cognitedata/accelerate @cognitedata/velocity
+* @cognitedata/velocity
 
 


### PR DESCRIPTION
# Description

The team has been renamed from accelerate to velocity. I have done this in two steps to ensure that the repo is not without owners:

1. Add Team velocity as code owner.
2. Remove accelerate team (This PR).

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip
