### PR TITLE
Fix bug in toolkit yaml version parsing

### DIFF
--- a/cognite/neat/_utils/text.py
+++ b/cognite/neat/_utils/text.py
@@ -74,7 +74,7 @@ def split_on_capitals(text: str) -> list[str]:
 def quote_int_value_by_key_in_yaml(content: str, key: str) -> str:
     """Quote a value in a yaml string"""
     # This pattern will match the key if it is not already quoted
-    pattern = rf"^(\s*-?\s*{key}:\s*)([\d_]+)(.*)$"
-    replacement = r'\1"\2"\3'
+    pattern = rf"^(\s*-?\s*)?{re.escape(key)}:\s*([\d_]+)(\s*#.*)?$"
+    replacement = rf'\1{key}: "\2"\3'
 
     return re.sub(pattern, replacement, content, flags=re.MULTILINE)

--- a/cognite/neat/_utils/text.py
+++ b/cognite/neat/_utils/text.py
@@ -74,7 +74,7 @@ def split_on_capitals(text: str) -> list[str]:
 def quote_int_value_by_key_in_yaml(content: str, key: str) -> str:
     """Quote a value in a yaml string"""
     # This pattern will match the key if it is not already quoted
-    pattern = rf"^(\s*-?\s*)?{re.escape(key)}:\s*([\d_]+)(\s*#.*)?$"
+    pattern = rf"^(\s*-?\s*)?{key}:\s*([\d_]+)(\s*#.*)?$"
     replacement = rf'\1{key}: "\2"\3'
 
     return re.sub(pattern, replacement, content, flags=re.MULTILINE)

--- a/cognite/neat/_utils/text.py
+++ b/cognite/neat/_utils/text.py
@@ -74,7 +74,7 @@ def split_on_capitals(text: str) -> list[str]:
 def quote_int_value_by_key_in_yaml(content: str, key: str) -> str:
     """Quote a value in a yaml string"""
     # This pattern will match the key if it is not already quoted
-    pattern = rf"^(\s*-?\s*)?{key}:\s*([\d_]+)(\s*#.*)?$"
-    replacement = rf'\1{key}: "\2"\3'
+    pattern = rf"^(\s*-?\s*{key}:\s*)([\d_]+)(\s*(?:#.*)?)$"
+    replacement = r'\1"\2"\3'
 
     return re.sub(pattern, replacement, content, flags=re.MULTILINE)

--- a/tests/tests_unit/test_utils/test_text.py
+++ b/tests/tests_unit/test_utils/test_text.py
@@ -113,6 +113,72 @@ properties:
         id="Handle comment with quotes after version",
     )
 
+    yield pytest.param(
+        """space: my_space
+externalID: myModel
+version: 1.0
+""",
+        """space: my_space
+externalID: myModel
+version: 1.0
+""",
+        id="version float stays unchanged",
+    )
+    yield pytest.param(
+        """space: my_space
+externalID: myModel
+version: 1.0.0
+""",
+        """space: my_space
+externalID: myModel
+version: 1.0.0
+""",
+        id="version dotted triple unchanged",
+    )
+    yield pytest.param(
+        """version: 1.0 # release note""",
+        """version: 1.0 # release note""",
+        id="version float with comment unchanged",
+    )
+    yield pytest.param(
+        """space: my_space
+externalID: myModel
+version: v1
+""",
+        """space: my_space
+externalID: myModel
+version: v1
+""",
+        id="version alphanumeric unchanged",
+    )
+    yield pytest.param(
+        """space: my_space
+externalID: myModel
+version: 1.0.0-beta
+""",
+        """space: my_space
+externalID: myModel
+version: 1.0.0-beta
+""",
+        id="version semver prerelease unchanged",
+    )
+    yield pytest.param(
+        "version: 1e2",
+        "version: 1e2",
+        id="version scientific notation unchanged",
+    )
+    yield pytest.param(
+        """space: s
+externalId: M
+version:
+""",
+        """space: s
+externalId: M
+version:
+""",
+        id="version empty same line null unchanged",
+    )
+
 
 class TestQuoteKeyInYAML:
     @pytest.mark.parametrize("raw, expected", list(quote_key_in_yaml_test_cases()))


### PR DESCRIPTION
# Description

Tighten `quote_int_value_by_key_in_yaml` so it no longer uses `([\d_]+)(.*)$`, which only quoted the leading digit run and broke lines like `version: 1.0` by formating them like `version: "1".0`. This PR builds upon #1594 which was again based on the the existing handling in Toolkit, and retains the same-line `#` comment handling which was added while avoiding to malformat floats. Extra unit tests added to ensure we don't introduce changes to floats, semver-like text, scientific notation, and empty `version:` lines.

Currently, the user would see the following error if the version contains periods:

<img width="2228" height="762" alt="image" src="https://github.com/user-attachments/assets/b398bd59-34e9-4589-ae3e-8606af20af99" />

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fixes a crashing issue when reading Toolkit-format data models with version strings containing periods (e.g. `1.0.0`).