### PR TITLE
🐛AutoIncrement is a breaking change.

### DIFF
--- a/cognite/neat/_data_model/deployer/_differ_container.py
+++ b/cognite/neat/_data_model/deployer/_differ_container.py
@@ -106,7 +106,7 @@ class ContainerPropertyDiffer(ObjectDiffer[ContainerPropertyDefinition]):
         if current.auto_increment != new.auto_increment:
             changes.append(
                 ChangedField(
-                    item_severity=SeverityType.WARNING,
+                    item_severity=SeverityType.BREAKING,
                     field_path=self._get_path(f"{identifier}.autoIncrement"),
                     current_value=current.auto_increment,
                     new_value=new.auto_increment,

--- a/tests/tests_unit/test_data_model/test_deployer/test_diff_container.py
+++ b/tests/tests_unit/test_data_model/test_deployer/test_diff_container.py
@@ -255,7 +255,7 @@ class TestContainerDiffer:
                     ),
                     ChangedField(
                         field_path=f"{CONTAINER_PROPERTY_ID}.autoIncrement",
-                        item_severity=SeverityType.WARNING,
+                        item_severity=SeverityType.BREAKING,
                         current_value=False,
                         new_value=True,
                     ),


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Neat now correctly classifies changing `autoIncrement` in a container property as a breaking change (before it was a warning).
