### PR TITLE
Cognite sdk v8

### DIFF
--- a/cognite/neat/_client/config.py
+++ b/cognite/neat/_client/config.py
@@ -14,7 +14,6 @@ class NeatClientConfig(ClientConfig):
             credentials=config.credentials,
             api_subversion=config.api_subversion,
             base_url=config.base_url,
-            max_workers=config.max_workers,
             headers=config.headers,
             timeout=config.timeout,
             file_transfer_timeout=config.file_transfer_timeout,

--- a/cognite/neat/_client/init/main.py
+++ b/cognite/neat/_client/init/main.py
@@ -55,7 +55,6 @@ def create_client_config_from_env_vars(env_vars: ClientEnvironmentVariables) -> 
         client_name=CLIENT_NAME,
         project=env_vars.CDF_PROJECT,
         credentials=get_credentials(env_vars),
-        max_workers=env_vars.CDF_MAX_WORKERS,
         timeout=env_vars.CDF_CLIENT_TIMEOUT,
         base_url=env_vars.cdf_url,
     )

--- a/cognite/neat/_v0/core/_client/_api/statistics.py
+++ b/cognite/neat/_v0/core/_client/_api/statistics.py
@@ -1,8 +1,8 @@
 import itertools
 from typing import overload
 
+from cognite.client import CogniteClient
 from cognite.client._api_client import APIClient
-from cognite.client._cognite_client import CogniteClient
 from cognite.client.config import ClientConfig
 from cognite.client.data_classes.data_modeling.ids import _load_space_identifier
 from cognite.client.utils.useful_types import SequenceNotStr

--- a/cognite/neat/_v0/core/_client/data_classes/statistics.py
+++ b/cognite/neat/_v0/core/_client/data_classes/statistics.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from cognite.client import CogniteClient
-from cognite.client.data_classes._base import CogniteObject, CogniteResource, CogniteResourceList
+from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 from typing_extensions import Self
 
 
@@ -43,7 +43,7 @@ class SpaceInstanceCountsList(CogniteResourceList):
 
 
 @dataclass
-class CountLimitPair(CogniteObject):
+class CountLimitPair(CogniteResource):
     count: int
     limit: int
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "cognite-sdk>=7.83.0, <8.0.0",
+    "cognite-sdk>=8.2.0, <9.0.0",
     "httpx>=0.28.1",
     "pydantic>=2.0.0, <3.0.0",
     "PyYAML>=6.0.1, <7.0.0",
@@ -108,7 +108,10 @@ dev = [
     "types-setuptools>=68, <69",
     "types-tqdm>=4, <5",
     "networkx-stubs>=0, <1",
-    "cognite-toolkit >= 0.7,< 0.8",
+    # Must taken out to avoid a catch 22. Toolkit cannot go to v8
+    # unless neat does it, thus neat cannot have Toolkit as a dev dependency until both
+    # are updated to v8.
+#    "cognite-toolkit >= 0.7,< 0.8",
     "tqdm>=4.67.1, <5",
     "deepdiff>=8.2.0, <9.0.0",
     "respx>=0.22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,8 @@ dev = [
     "pytest-json-report>=1.5.0",
     "matplotlib>=3.10.8",
     "ipycytoscape>=1.3.3",
+    "python-dotenv >=1.0.0",
+    "typer >=0.12.0, <1.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/tests_unit/conftest.py
+++ b/tests/tests_unit/conftest.py
@@ -23,7 +23,6 @@ def neat_config() -> NeatClientConfig:
             client_name="test-client",
             project="test-project",
             base_url=BASE_URL,
-            max_workers=1,
             timeout=10,
             credentials=Token("abc"),
         )

--- a/tests/tests_unit/test_toolkit_adapter.py
+++ b/tests/tests_unit/test_toolkit_adapter.py
@@ -2,14 +2,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (  # type: ignore[import-untyped]
-    BuiltModule,
-    ResourceType,
-)
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource  # type: ignore[import-untyped]
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import ModuleId  # type: ignore[import-untyped]
-from cognite_toolkit._cdf_tk.resource_ios import DataModelIO  # type: ignore[import-untyped]
-from cognite_toolkit._cdf_tk.rules._neat import NeatRuleSet  # type: ignore[import-untyped]
 
 from cognite.neat import _toolkit_adapter
 from cognite.neat._client import NeatClient
@@ -59,7 +51,10 @@ def test_run_toolkit_validation_with_empty_modules(tmp_path: Path, monkeypatch: 
     """Tests that NeatRuleSet.validate() returns empty results when no modules are provided."""
     # The NeatRuleSet.validate() method iterates over BuiltModule resources looking for DataModel resources.
     # Without modules (and without a client), it should simply return no insights.
-
+    try:
+        from cognite_toolkit._cdf_tk.rules._neat import NeatRuleSet  # type: ignore[import-untyped, import-not-found]
+    except ModuleNotFoundError:
+        pytest.skip("Requires Toolkit to run")
     rule = NeatRuleSet(modules=[])
 
     result = list(rule.validate())
@@ -73,6 +68,21 @@ def test_run_toolkit_validation_with_data_model(
     valid_dms_toolkit_yaml_format: str,
 ) -> None:
     """Tests that NeatRuleSet.validate() validates a data model file and returns insights."""
+    try:
+        from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (  # type: ignore[import-untyped, import-not-found]
+            BuiltModule,
+            ResourceType,
+        )
+        from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import (  # type: ignore[import-not-found]
+            BuiltResource,  # type: ignore[import-untyped]
+        )
+        from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import (  # type: ignore[import-not-found]
+            ModuleId,  # type: ignore[import-untyped, import-not-found]
+        )
+        from cognite_toolkit._cdf_tk.resource_ios import DataModelIO  # type: ignore[import-untyped, import-not-found]
+        from cognite_toolkit._cdf_tk.rules._neat import NeatRuleSet  # type: ignore[import-untyped, import-not-found]
+    except ModuleNotFoundError:
+        pytest.skip("Requires Toolkit to run")
 
     # Create the data model directory structure
     data_model_dir = tmp_path / "data_modeling"

--- a/tests/tests_unit/test_utils/test_http_client.py
+++ b/tests/tests_unit/test_utils/test_http_client.py
@@ -41,7 +41,6 @@ def client_config() -> ClientConfig:
         client_name="test-client",
         project="test-project",
         base_url=BASE_URL,
-        max_workers=1,
         timeout=10,
         credentials=Token("abc"),
     )

--- a/tests/v0/data/_instances/classic_windfarm.py
+++ b/tests/v0/data/_instances/classic_windfarm.py
@@ -64,6 +64,7 @@ DATASETS = [ds_source, ds_analysis, ds_maintenance]
 
 
 root = Asset(
+    root_id=4,
     external_id="Utsira",
     name="Utsira",
     description="Utsira wind farm",
@@ -77,6 +78,7 @@ root = Asset(
 )
 
 wind_turbine = Asset(
+    root_id=4,
     external_id="WT-01",
     name="WT-01",
     description="Wind turbine 01",
@@ -92,6 +94,7 @@ wind_turbine = Asset(
 )
 
 wind_turbine2 = Asset(
+    root_id=4,
     external_id="WT-02",
     name="WT-02",
     description="Wind turbine 02",
@@ -107,6 +110,7 @@ wind_turbine2 = Asset(
 )
 
 measurment_root = Asset(
+    root_id=4,
     external_id="Measurement",
     name="Measurement",
     description="Measurement",
@@ -120,6 +124,7 @@ measurment_root = Asset(
 )
 
 metmast = Asset(
+    root_id=4,
     external_id="MetMast",
     name="MetMast",
     description="Meteorological mast",
@@ -144,6 +149,8 @@ turbine_to_metmast = Relationship(
     target_type="Asset",
     data_set_id=ds_source.id,
     labels=[Label("metMast")],
+    created_time=0,
+    last_updated_time=1,
 )
 
 turbine_to_metmast2 = Relationship(
@@ -154,6 +161,8 @@ turbine_to_metmast2 = Relationship(
     target_type="Asset",
     data_set_id=ds_source.id,
     labels=[Label("metMast")],
+    created_time=0,
+    last_updated_time=1,
 )
 
 RELATIONSHIPS = [turbine_to_metmast, turbine_to_metmast2]
@@ -220,24 +229,28 @@ LABELS = [
         name="Power generating unit",
         description="Power generating unit",
         data_set_id=ds_source.id,
+        created_time=0,
     ),
     LabelDefinition(
         external_id="WindTurbine",
         name="Wind turbine",
         description="Wind turbine",
         data_set_id=ds_source.id,
+        created_time=0,
     ),
     LabelDefinition(
         external_id="metMast",
         name="Meteorological mast",
         description="Meteorological mast",
         data_set_id=ds_source.id,
+        created_time=0,
     ),
     LabelDefinition(
         external_id="Measurement",
         name="Measurement",
         description="Measurement",
         data_set_id=ds_source.id,
+        created_time=0,
     ),
 ]
 
@@ -336,6 +349,8 @@ data_sheet = FileMetadata(
     id=2,
     created_time=1,
     last_updated_time=2,
+    uploaded_time=3,
+    uploaded=True,
 )
 
 FILES = [data_sheet]

--- a/uv.lock
+++ b/uv.lock
@@ -140,6 +140,19 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -470,7 +483,6 @@ oxi = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "cognite-toolkit" },
     { name = "deepdiff" },
     { name = "httpx" },
     { name = "hypothesis" },
@@ -504,7 +516,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.2,<2.0.0" },
-    { name = "cognite-sdk", specifier = ">=7.83.0,<8.0.0" },
+    { name = "cognite-sdk", specifier = ">=8.2.0,<9.0.0" },
     { name = "elementpath", marker = "extra == 'legacy'", specifier = ">=4.0.0,<5.0.0" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.1.3,<2.0.0" },
     { name = "google-api-python-client", marker = "extra == 'google'", specifier = ">=2.70.0,<3.0.0" },
@@ -545,7 +557,6 @@ provides-extras = ["legacy", "lxml", "oxi", "google", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "cognite-toolkit", specifier = ">=0.7,<0.8" },
     { name = "deepdiff", specifier = ">=8.2.0,<9.0.0" },
     { name = "httpx" },
     { name = "hypothesis", specifier = ">=6.135.0,<7.0.0" },
@@ -578,48 +589,19 @@ dev = [
 
 [[package]]
 name = "cognite-sdk"
-version = "7.91.1"
+version = "8.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "authlib" },
+    { name = "httpx" },
     { name = "msal" },
     { name = "packaging" },
     { name = "protobuf" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/21/e861df1d8d8e62f8ab673ee48705c0fc6cd886b7642f2b2c24dac578ddcf/cognite_sdk-7.91.1.tar.gz", hash = "sha256:5c945ae04ec7b71d0955611a2b1763ac2898dac180d263c41d7201a7ea78a924", size = 539341, upload-time = "2026-01-13T14:48:44.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/71/c2a2263bff369ec00af3c5b1bbb1f36c4ca94acc8eb02b0a077be290be6c/cognite_sdk-8.2.0.tar.gz", hash = "sha256:072a515490993218e0025441011387c12fa325415b60b24a5985aa92372177c0", size = 698805, upload-time = "2026-04-27T09:39:23.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/2f/d8ef95bcdb5c9bf0a784e7425d0a821c37b91108869709f6894e0b95db62/cognite_sdk-7.91.1-py3-none-any.whl", hash = "sha256:858bcc8214eab5ab217ef2d7e25871bcf6b02e2b1b2171eb944f7809470ee5a3", size = 686239, upload-time = "2026-01-13T14:48:42.393Z" },
-]
-
-[[package]]
-name = "cognite-toolkit"
-version = "0.7.246"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cognite-sdk" },
-    { name = "filelock" },
-    { name = "httpx" },
-    { name = "mixpanel" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pip" },
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "questionary" },
-    { name = "rich" },
-    { name = "sentry-sdk" },
-    { name = "toml" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/03/3764bc4788774ddd8d369f1a16f95d72098284c310ef7bb41316d3c4c7ad/cognite_toolkit-0.7.246.tar.gz", hash = "sha256:9cb541520ce8629ab3bc8b404728e3765ba5a36dc8d03cbfd38f1d2dfdf438a6", size = 654963, upload-time = "2026-04-15T09:14:23.149Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/ad/334c8a97fa2ef8d386998fc5c9f6cc0fc7894374f5bd71e5556ade177585/cognite_toolkit-0.7.246-py3-none-any.whl", hash = "sha256:11783d7294986b80d80013fe4ff19e609b04247035261d21ea30b207cc681a86", size = 960946, upload-time = "2026-04-15T09:14:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ab/4a0471202311555290f98c64e9185f455616a5c38bc6db4325c67e909974/cognite_sdk-8.2.0-py3-none-any.whl", hash = "sha256:e2a8ad3319d1fca47fc5cefe7ce6162bb2e0a2cb27a162bd8ee0107b13329763", size = 929824, upload-time = "2026-04-27T09:39:20.964Z" },
 ]
 
 [[package]]
@@ -1669,6 +1651,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
 ]
 
 [[package]]
@@ -3479,15 +3473,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pip"
-version = "26.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4015,15 +4000,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dotenv"
-version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
-]
-
-[[package]]
 name = "python-json-logger"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4228,18 +4204,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/0e/3f0d0d335c6b3abb9b7b723776d0b21fa7f3a6c819a0db6097059aada160/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53b40f8ae006f2734ee7608d59ed661419f087521edbfc2149c3932e9c14808c", size = 567747, upload-time = "2025-09-08T23:09:52.698Z" },
     { url = "https://files.pythonhosted.org/packages/a1/cf/f2b3784d536250ffd4be70e049f3b60981235d70c6e8ce7e3ef21e1adb25/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f605d884e7c8be8fe1aa94e0a783bf3f591b84c24e4bc4f3e7564c82ac25e271", size = 747371, upload-time = "2025-09-08T23:09:54.563Z" },
     { url = "https://files.pythonhosted.org/packages/01/1b/5dbe84eefc86f48473947e2f41711aded97eecef1231f4558f1f02713c12/pyzmq-27.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c9f7f6e13dff2e44a6afeaf2cf54cee5929ad64afaf4d40b50f93c58fc687355", size = 544862, upload-time = "2025-09-08T23:09:56.509Z" },
-]
-
-[[package]]
-name = "questionary"
-version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "prompt-toolkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -4615,34 +4579,12 @@ wheels = [
 ]
 
 [[package]]
-name = "sentry-sdk"
-version = "2.50.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/15/8a/3c4f53d32c21012e9870913544e56bfa9e931aede080779a0f177513f534/sentry_sdk-2.50.0.tar.gz", hash = "sha256:873437a989ee1b8b25579847bae8384515bf18cfed231b06c591b735c1781fe3", size = 401233, upload-time = "2026-01-20T12:53:16.244Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/5b/cbc2bb9569f03c8e15d928357e7e6179e5cfab45544a3bbac8aec4caf9be/sentry_sdk-2.50.0-py2.py3-none-any.whl", hash = "sha256:0ef0ed7168657ceb5a0be081f4102d92042a125462d1d1a29277992e344e749e", size = 424961, upload-time = "2026-01-20T12:53:14.826Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -4744,15 +4686,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
-]
-
-[[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -4867,21 +4800,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.21.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371, upload-time = "2026-01-06T11:21:10.989Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381, upload-time = "2026-01-06T11:21:09.824Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,15 @@ constraints = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -503,9 +512,11 @@ dev = [
     { name = "pytest-notebook" },
     { name = "pytest-regressions" },
     { name = "pytest-xdist" },
+    { name = "python-dotenv" },
     { name = "respx" },
     { name = "tqdm" },
     { name = "twine" },
+    { name = "typer" },
     { name = "types-openpyxl" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -577,9 +588,11 @@ dev = [
     { name = "pytest-notebook" },
     { name = "pytest-regressions" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "tqdm", specifier = ">=4.67.1,<5" },
     { name = "twine", specifier = ">=6.0.0,<7.0.0" },
+    { name = "typer", specifier = ">=0.12.0,<1.0.0" },
     { name = "types-openpyxl", specifier = ">=3,<4" },
     { name = "types-pyyaml", specifier = ">=6,<7" },
     { name = "types-requests", specifier = ">=2,<3" },
@@ -4000,6 +4013,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "python-json-logger"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4588,6 +4610,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4800,6 +4831,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Changed

- Neat now requires `cognite-sdk>v8`. Note Neat only uses the cognite-sdk for authentication. 
