### PR TITLE
Allow cognite-sdk v7

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -78,6 +78,12 @@ jobs:
       - name: Run unit tests
         run: export PYTHONPATH=$PYTHONPATH:$(pwd); uv run pytest tests/tests_unit
 
+      - name: Install Cognit-sdk v7
+        run: uv pip install cognite-sdk==7.92.0
+
+      - name: Run test on cognite-sdk v7
+        run: export PYTHONPATH=$PYTHONPATH:$(pwd); uv run pytest tests/tests_unit
+
   build-docs:
     runs-on: ubuntu-latest
 
@@ -136,11 +142,24 @@ jobs:
             coverageFile: coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
             thresholdAll: 0.9
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: cognitedata/neat
+
+      - name: Install cognite-sdk v7
+        run: uv pip install cognite-sdk==7.92.0
+
+      - name: Create test coverage report with cognite-sdk v7
+        env:
+          CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
+          CDF_PROJECT: ${{ vars.CDF_PROJECT }}
+          IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
+          IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
+          IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
+        run: export PYTHONPATH=$PYTHONPATH:$(pwd); uv run pytest --cov=cognite/ --cov-config=pyproject.toml --cov-report=xml:coverage-sdk7.xml tests/
 
   validate-description:
     name: Validate PR description

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ which require you to be a technical wizard or modeling expert, NEAT provides you
 We offer various interfaces on how you can develop your data model, where majority of our users prefer
 a combination of Jupyter Notebooks, leveraging NEAT features through so called [NeatSession](https://cognite-neat.readthedocs-hosted.com/en/latest/reference/NeatSession/session.html),  with [a Spreadsheet data model template](https://cognite-neat.readthedocs-hosted.com/en/latest/excel_data_modeling/data_model.html).
 
-
 Only Data modeling? There was more before!?
 True, NEAT v0.x (legacy) offered a complete knowledge graph
 tooling. Do not worry though, all the legacy features are still available and will be gradually

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "cognite-sdk>=8.2.0, <9.0.0",
+    "cognite-sdk>=7.92.0, <9.0.0",
     "httpx>=0.28.1",
     "pydantic>=2.0.0, <3.0.0",
     "PyYAML>=6.0.1, <7.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.2,<2.0.0" },
-    { name = "cognite-sdk", specifier = ">=8.2.0,<9.0.0" },
+    { name = "cognite-sdk", specifier = ">=7.92.0,<9.0.0" },
     { name = "elementpath", marker = "extra == 'legacy'", specifier = ">=4.0.0,<5.0.0" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.1.3,<2.0.0" },
     { name = "google-api-python-client", marker = "extra == 'google'", specifier = ">=2.70.0,<3.0.0" },


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Changed

- Allow Neat to run with `cognite-sdk` `v7` (and still `v8`). This is to ensure it works well with jupyter notebooks in Fusion.
