### PR TITLE
Export excel with missing sheet

### DIFF
--- a/cognite/neat/_data_model/exporters/_table_exporter/workbook.py
+++ b/cognite/neat/_data_model/exporters/_table_exporter/workbook.py
@@ -103,6 +103,10 @@ class WorkbookCreator:
         containers = cast(str, TableDMS.model_fields["containers"].validation_alias)
         dropdown_source = "_dropdown_source"
 
+        @classmethod
+        def dropdown_sheets(cls) -> set[str]:
+            return {cls.properties, cls.views, cls.containers}
+
     # The following classes are used to refer to sheets and columns that are used
     # in dropdown creation.
     class PropertyColumns:
@@ -153,6 +157,8 @@ class WorkbookCreator:
         index_by_sheet_name_column: dict[tuple[str, str], int] = {}
         for sheet_name, table in tables.items():
             if not table and sheet_name not in TableDMS.required_sheets():
+                if sheet_name in self.Sheets.dropdown_sheets():
+                    self._add_dropdowns = False
                 continue
             worksheet = workbook.create_sheet(title=sheet_name)
             if sheet_name == self.Sheets.metadata:

--- a/cognite/neat/_data_model/exporters/_table_exporter/workbook.py
+++ b/cognite/neat/_data_model/exporters/_table_exporter/workbook.py
@@ -157,7 +157,7 @@ class WorkbookCreator:
         index_by_sheet_name_column: dict[tuple[str, str], int] = {}
         for sheet_name, table in tables.items():
             if not table and sheet_name not in TableDMS.required_sheets():
-                if sheet_name in self.Sheets.dropdown_sheets():
+                if sheet_name in self.Sheets.dropdown_sheets() and self._add_dropdowns:
                     self._add_dropdowns = False
                 continue
             worksheet = workbook.create_sheet(title=sheet_name)

--- a/tests/tests_unit/test_data_model/test_exporters/test_dms_table_exporter.py
+++ b/tests/tests_unit/test_data_model/test_exporters/test_dms_table_exporter.py
@@ -1,9 +1,10 @@
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from cognite.neat._data_model._constants import DEFAULT_MAX_LIST_SIZE, DEFAULT_MAX_LIST_SIZE_DIRECT_RELATIONS
 from cognite.neat._data_model.exporters import DMSTableExporter
+from cognite.neat._data_model.exporters._table_exporter.workbook import WorkbookCreator
 from cognite.neat._data_model.exporters._table_exporter.writer import DMSTableWriter
 from cognite.neat._data_model.importers._table_importer.data_classes import (
     EntityTableFilter,
@@ -22,6 +23,7 @@ from cognite.neat._data_model.models.dms import (
     ViewReference,
 )
 from cognite.neat._data_model.models.entities import ParsedEntity
+from cognite.neat._utils.useful_types import DataModelTableType
 
 
 class TestDMSTableExporter:
@@ -158,3 +160,28 @@ class TestDMSTableWriter:
     def test_write_view_filter(self, filter: Filter | None, expected: TableViewFilter) -> None:
         writer = DMSTableWriter(self.DEFAULT_SPACE, self.DEFAULT_VERSION, skip_properties_in_other_spaces=True)
         assert writer.write_view_filter(filter) == expected
+
+
+def test_add_dropdowns_disabled_on_empty_dropdown_sheet() -> None:
+    """Test that _add_dropdowns is set to False when an empty dropdown sheet is detected."""
+
+    # Create minimal test data with empty Containers (which is a dropdown sheet)
+    tables = {
+        WorkbookCreator.Sheets.metadata: [{"Key": "space", "Value": "test"}],
+        WorkbookCreator.Sheets.properties: [{"View": "TestView", "View Property": "prop"}],
+        WorkbookCreator.Sheets.views: [{"View": "TestView"}],
+        WorkbookCreator.Sheets.containers: [],  # Empty dropdown sheet
+    }
+
+    workbook_creator = WorkbookCreator()
+    workbook = workbook_creator.create_workbook(cast(DataModelTableType, tables))
+
+    # Assert that _add_dropdowns was set to False due to empty Containers sheet
+    assert workbook_creator._add_dropdowns is False, (
+        "_add_dropdowns should be False when an empty dropdown sheet is detected"
+    )
+
+    # Assert that dropdown_source sheet was NOT created
+    assert WorkbookCreator.Sheets.dropdown_source not in workbook.sheetnames, (
+        "dropdown_source sheet should not be created when _add_dropdowns is False"
+    )


### PR DESCRIPTION
# Description

There could be data model in CDF which consist of views with have no properties (purely concepts). As our limit rules are only raising Insights and not Consistency Errors, one can attempt to export such models, which as they are not complete, will fail export. 

This PR brings a simple solution for a problem of concept (i.e. views) only data models by skipping creation of drop down menus in Excel sheet.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- Export of views only data model to Excel
