### PR TITLE
Fix ViewRequest to accept views without properties key

### DIFF
--- a/cognite/neat/_data_model/models/dms/_views.py
+++ b/cognite/neat/_data_model/models/dms/_views.py
@@ -123,7 +123,8 @@ class View(Resource, APIResource[ViewReference], ABC):
 
 class ViewRequest(View):
     properties: dict[str, ViewRequestProperty] = Field(
-        description="View with included properties and expected edges, indexed by a unique space-local identifier."
+        default_factory=dict,
+        description="View with included properties and expected edges, indexed by a unique space-local identifier.",
     )
 
     @field_validator("properties", mode="after")

--- a/tests/tests_unit/test_data_model/test_models/test_dms/test_views.py
+++ b/tests/tests_unit/test_data_model/test_models/test_dms/test_views.py
@@ -286,6 +286,17 @@ class TestViewRequests:
             ViewRequest.model_validate(data)
         assert {humanize_validation_error(error) for error in excinfo.value.errors()} == expected_errors
 
+    def test_view_without_properties_key_is_valid(self) -> None:
+        view = ViewRequest.model_validate(
+            {
+                "space": "my_space",
+                "externalId": "MyView",
+                "version": "1",
+                "implements": [{"space": "my_space", "externalId": "ParentView", "version": "1"}],
+            }
+        )
+        assert view.properties == {}
+
 
 class TestViewResponse:
     @settings(max_examples=1)


### PR DESCRIPTION
# Description

`ViewRequest.properties` was a required field with no default, causing validation to fail
when importing toolkit-built data model YAML where views that only inherit via `implements`
have no `properties` key. Aligns `ViewRequest` with accepting unspecified properties as in CDF API / toolkit semantics by defaulting `properties` to an empty dict.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix import of data model YAML views that only use `implements` and omit the `properties` key