### PR TITLE
Add Toolkit template variable substitution for toolkit YAML reads

### DIFF
--- a/cognite/neat/_data_model/importers/_api_importer.py
+++ b/cognite/neat/_data_model/importers/_api_importer.py
@@ -9,6 +9,10 @@ from cognite.neat._client import NeatClient
 from cognite.neat._data_model._analysis import ValidationResources
 from cognite.neat._data_model._snapshot import SchemaSnapshot
 from cognite.neat._data_model.importers._base import DMSImporter
+from cognite.neat._data_model.importers._toolkit_variables import (
+    ToolkitProjectContext,
+    prepare_toolkit_yaml_content,
+)
 from cognite.neat._data_model.models.dms import (
     DataModelReference,
     RequestSchema,
@@ -118,18 +122,47 @@ class DMSAPIImporter(DMSImporter):
         )
 
     @classmethod
-    def from_yaml(cls, yaml_file: Path, data_model_file: Path | None = None) -> "DMSAPIImporter":
+    def from_yaml(
+        cls,
+        yaml_file: Path,
+        data_model_file: Path | str | None = None,
+        *,
+        toolkit_env: str | None = None,
+        toolkit_config: Path | str | None = None,
+        toolkit_version: str | None = None,
+        substitute_toolkit_variables: bool = True,
+    ) -> "DMSAPIImporter":
         """Create a DMSTableImporter from a YAML file."""
+        if toolkit_config is not None:
+            toolkit_config = Path(toolkit_config)
         source = cls._display_name(yaml_file)
         if yaml_file.suffix.lower() in {".yaml", ".yml", ".json"}:
             yaml_content = yaml_file.read_text(encoding=cls.ENCODING)
+            yaml_content = prepare_toolkit_yaml_content(
+                yaml_content,
+                source=yaml_file,
+                data_model_dir=yaml_file.parent,
+                toolkit_env=toolkit_env,
+                toolkit_config=toolkit_config,
+                toolkit_version=toolkit_version,
+                enabled=substitute_toolkit_variables,
+            )
             # DataModels and Views have `version` that is often given as an integer by the user.
             # This ensures that the version is always read as a string, even if the user forgets to
             # quote it in the YAML file.
             fixed_content = quote_int_value_by_key_in_yaml(yaml_content, "version")
             return cls(yaml.safe_load(fixed_content))
         elif yaml_file.is_dir():
-            return cls(cls._read_yaml_files(yaml_file, data_model_file))
+            return cls(
+                cls._read_yaml_files(
+                    yaml_file,
+                    data_model_file,
+                    toolkit_env=toolkit_env,
+                    toolkit_config=toolkit_config,
+                    toolkit_version=toolkit_version,
+                    substitute_toolkit_variables=substitute_toolkit_variables,
+                )
+            )
         raise FileReadException(source.as_posix(), f"Unsupported file type: {source.suffix}")
 
     @classmethod
@@ -147,16 +180,39 @@ class DMSAPIImporter(DMSImporter):
         return source
 
     @classmethod
-    def _read_yaml_files(cls, directory: Path, data_model_file: Path | None = None) -> dict[str, Any]:
+    def _read_yaml_files(
+        cls,
+        directory: Path,
+        data_model_file: Path | str | None = None,
+        *,
+        toolkit_env: str | None = None,
+        toolkit_config: Path | str | None = None,
+        toolkit_version: str | None = None,
+        substitute_toolkit_variables: bool = True,
+    ) -> dict[str, Any]:
         """Read all YAML files in a directory and combine them into a single dictionary."""
         schema_data: dict[str, Any] = {}
         data_model: dict[str, Any] | None = None
+        data_model_file_name = Path(data_model_file).name if data_model_file is not None else None
+        variables = None
+        if substitute_toolkit_variables:
+            variables = ToolkitProjectContext.load(
+                directory,
+                toolkit_env=toolkit_env,
+                toolkit_config=toolkit_config,
+            ).variables_for(directory, toolkit_version)
         for yaml_file in directory.rglob("**/*"):
             if yaml_file.suffix.lower() not in {".yaml", ".yml", ".json"}:
                 continue
             stem = yaml_file.stem.casefold()
 
             yaml_content = yaml_file.read_text(encoding=cls.ENCODING)
+            yaml_content = prepare_toolkit_yaml_content(
+                yaml_content,
+                source=yaml_file,
+                variables=variables,
+                enabled=substitute_toolkit_variables,
+            )
             if stem.endswith("datamodel") or stem.endswith("view"):
                 # DataModels and Views have `version` that is often given as an integer by the user.
                 # This ensures that the version is always read as a string, even if the user forgets to
@@ -166,7 +222,7 @@ class DMSAPIImporter(DMSImporter):
             list_data = data if isinstance(data, list) else [data]
 
             if stem.endswith("datamodel"):
-                if data_model_file and yaml_file.name != data_model_file.name:
+                if data_model_file_name and yaml_file.name != data_model_file_name:
                     continue  # skip this file as it doesn't match the specified data model file
                 if data_model is not None and not data_model_file:
                     raise FileReadException(

--- a/cognite/neat/_data_model/importers/_api_importer.py
+++ b/cognite/neat/_data_model/importers/_api_importer.py
@@ -210,7 +210,13 @@ class DMSAPIImporter(DMSImporter):
         *,
         options: ToolkitReadOptions | None = None,
     ) -> dict[str, Any]:
-        """Read all YAML files in a directory and combine them into a single dictionary."""
+        """Read Toolkit DMS YAML files in a directory and combine them into a single schema.
+
+        Template variables are resolved per file from that file's module path, so a read of
+        ``modules/`` still sees nested keys such as ``variables.modules.valve_track.*``.
+        When ``data_model_file`` selects one model, sibling DataModel/view/node files are
+        not parsed.
+        """
         options = options or ToolkitReadOptions()
         schema_data: dict[str, Any] = {}
         data_model: dict[str, Any] | None = None
@@ -219,26 +225,42 @@ class DMSAPIImporter(DMSImporter):
         config_dir = directory
         if dm_path is not None and _is_filesystem_path(dm_path) and dm_path.is_file():
             config_dir = dm_path.parent
-        variables = None
-        if options.substitute:
-            variables = ToolkitProjectContext.load(config_dir, options).variables_for(config_dir, options.version)
-        for yaml_file in directory.rglob("**/*"):
-            if not cls._is_toolkit_schema_yaml(yaml_file):
-                continue
+        context = ToolkitProjectContext.load(config_dir, options) if options.substitute else None
+
+        schema_files = [yaml_file for yaml_file in directory.rglob("**/*") if cls._is_toolkit_schema_yaml(yaml_file)]
+        selected_dm_files = [
+            yaml_file
+            for yaml_file in schema_files
+            if yaml_file.stem.casefold().endswith("datamodel")
+            and (not data_model_file_name or yaml_file.name == data_model_file_name)
+        ]
+        resource_root: Path | None = None
+        if data_model_file_name and len(selected_dm_files) == 1 and _is_filesystem_path(selected_dm_files[0]):
+            resource_root = selected_dm_files[0].parent
+
+        for yaml_file in schema_files:
             stem = yaml_file.stem.casefold()
+            if stem.endswith("datamodel") and data_model_file_name and yaml_file.name != data_model_file_name:
+                continue
+            if (
+                resource_root is not None
+                and stem.endswith(("view", "node"))
+                and not cls._is_path_under(yaml_file, resource_root)
+            ):
+                continue
             quote_version = stem.endswith("datamodel") or stem.endswith("view")
+            file_dir = yaml_file.parent
+            file_variables = context.variables_for(file_dir, options.version) if context is not None else None
             data = cls._load_toolkit_yaml_file(
                 yaml_file,
                 options,
-                variables=variables,
+                variables=file_variables,
                 quote_version=quote_version,
-                data_model_dir=config_dir,
+                data_model_dir=file_dir,
             )
             list_data = data if isinstance(data, list) else [data]
 
             if stem.endswith("datamodel"):
-                if data_model_file_name and yaml_file.name != data_model_file_name:
-                    continue  # skip this file as it doesn't match the specified data model file
                 if data_model is not None and not data_model_file:
                     raise FileReadException(
                         cls._display_name(directory).as_posix(),
@@ -264,6 +286,14 @@ class DMSAPIImporter(DMSImporter):
             )
         schema_data["dataModel"] = data_model
         return schema_data
+
+    @staticmethod
+    def _is_path_under(path: Path, root: Path) -> bool:
+        try:
+            path.resolve().relative_to(root.resolve())
+        except (ValueError, OSError):
+            return False
+        return True
 
 
 class DMSAPICreator(DMSImporter):

--- a/cognite/neat/_data_model/importers/_api_importer.py
+++ b/cognite/neat/_data_model/importers/_api_importer.py
@@ -188,11 +188,19 @@ class DMSAPIImporter(DMSImporter):
 
     @classmethod
     def _is_toolkit_schema_yaml(cls, yaml_file: Path) -> bool:
-        """True for DMS resource files; skip Toolkit config, build_info, and other YAML."""
+        """True for DMS resource files; skip Toolkit config, Yamale schemas, and other YAML.
+
+        Resource files follow Toolkit naming (``*.Container.yaml``, ``*.View.yaml``, …).
+        Names such as ``data_model_container.yaml`` are validation schemas, not DMS resources.
+        """
         if yaml_file.suffix.lower() not in {".yaml", ".yml", ".json"}:
             return False
-        stem = yaml_file.stem.casefold()
-        return any(stem.endswith(kind) for kind in ("datamodel", "view", "container", "space", "node"))
+        name = yaml_file.name.casefold()
+        return any(
+            name.endswith(suffix)
+            for kind in ("datamodel", "view", "container", "space", "node")
+            for suffix in (f".{kind}.yaml", f".{kind}.yml", f".{kind}.json")
+        )
 
     @classmethod
     def _read_yaml_files(

--- a/cognite/neat/_data_model/importers/_api_importer.py
+++ b/cognite/neat/_data_model/importers/_api_importer.py
@@ -11,6 +11,7 @@ from cognite.neat._data_model._snapshot import SchemaSnapshot
 from cognite.neat._data_model.importers._base import DMSImporter
 from cognite.neat._data_model.importers._toolkit_variables import (
     ToolkitProjectContext,
+    ToolkitReadOptions,
     prepare_toolkit_yaml_content,
 )
 from cognite.neat._data_model.models.dms import (
@@ -131,38 +132,20 @@ class DMSAPIImporter(DMSImporter):
         toolkit_config: Path | str | None = None,
         toolkit_version: str | None = None,
         substitute_toolkit_variables: bool = True,
+        options: ToolkitReadOptions | None = None,
     ) -> "DMSAPIImporter":
         """Create a DMSTableImporter from a YAML file."""
-        if toolkit_config is not None:
-            toolkit_config = Path(toolkit_config)
+        options = options or ToolkitReadOptions.from_args(
+            toolkit_env,
+            toolkit_config,
+            toolkit_version,
+            substitute_toolkit_variables=substitute_toolkit_variables,
+        )
         source = cls._display_name(yaml_file)
         if yaml_file.suffix.lower() in {".yaml", ".yml", ".json"}:
-            yaml_content = yaml_file.read_text(encoding=cls.ENCODING)
-            yaml_content = prepare_toolkit_yaml_content(
-                yaml_content,
-                source=yaml_file,
-                data_model_dir=yaml_file.parent,
-                toolkit_env=toolkit_env,
-                toolkit_config=toolkit_config,
-                toolkit_version=toolkit_version,
-                enabled=substitute_toolkit_variables,
-            )
-            # DataModels and Views have `version` that is often given as an integer by the user.
-            # This ensures that the version is always read as a string, even if the user forgets to
-            # quote it in the YAML file.
-            fixed_content = quote_int_value_by_key_in_yaml(yaml_content, "version")
-            return cls(yaml.safe_load(fixed_content))
+            return cls(cls._load_toolkit_yaml_file(yaml_file, options))
         elif yaml_file.is_dir():
-            return cls(
-                cls._read_yaml_files(
-                    yaml_file,
-                    data_model_file,
-                    toolkit_env=toolkit_env,
-                    toolkit_config=toolkit_config,
-                    toolkit_version=toolkit_version,
-                    substitute_toolkit_variables=substitute_toolkit_variables,
-                )
-            )
+            return cls(cls._read_yaml_files(yaml_file, data_model_file, options=options))
         raise FileReadException(source.as_posix(), f"Unsupported file type: {source.suffix}")
 
     @classmethod
@@ -180,45 +163,56 @@ class DMSAPIImporter(DMSImporter):
         return source
 
     @classmethod
+    def _load_toolkit_yaml_file(
+        cls,
+        yaml_file: Path,
+        options: ToolkitReadOptions,
+        *,
+        variables: dict[str, str] | None = None,
+        quote_version: bool = True,
+        data_model_dir: Path | None = None,
+    ) -> Any:
+        yaml_content = yaml_file.read_text(encoding=cls.ENCODING)
+        yaml_content = prepare_toolkit_yaml_content(
+            yaml_content,
+            source=yaml_file,
+            data_model_dir=data_model_dir or yaml_file.parent,
+            variables=variables,
+            options=options,
+        )
+        if quote_version:
+            # DataModels and Views often give `version` as an unquoted integer.
+            yaml_content = quote_int_value_by_key_in_yaml(yaml_content, "version")
+        return yaml.safe_load(yaml_content)
+
+    @classmethod
     def _read_yaml_files(
         cls,
         directory: Path,
         data_model_file: Path | str | None = None,
         *,
-        toolkit_env: str | None = None,
-        toolkit_config: Path | str | None = None,
-        toolkit_version: str | None = None,
-        substitute_toolkit_variables: bool = True,
+        options: ToolkitReadOptions | None = None,
     ) -> dict[str, Any]:
         """Read all YAML files in a directory and combine them into a single dictionary."""
+        options = options or ToolkitReadOptions()
         schema_data: dict[str, Any] = {}
         data_model: dict[str, Any] | None = None
         data_model_file_name = Path(data_model_file).name if data_model_file is not None else None
         variables = None
-        if substitute_toolkit_variables:
-            variables = ToolkitProjectContext.load(
-                directory,
-                toolkit_env=toolkit_env,
-                toolkit_config=toolkit_config,
-            ).variables_for(directory, toolkit_version)
+        if options.substitute:
+            variables = ToolkitProjectContext.load(directory, options).variables_for(directory, options.version)
         for yaml_file in directory.rglob("**/*"):
             if yaml_file.suffix.lower() not in {".yaml", ".yml", ".json"}:
                 continue
             stem = yaml_file.stem.casefold()
-
-            yaml_content = yaml_file.read_text(encoding=cls.ENCODING)
-            yaml_content = prepare_toolkit_yaml_content(
-                yaml_content,
-                source=yaml_file,
+            quote_version = stem.endswith("datamodel") or stem.endswith("view")
+            data = cls._load_toolkit_yaml_file(
+                yaml_file,
+                options,
                 variables=variables,
-                enabled=substitute_toolkit_variables,
+                quote_version=quote_version,
+                data_model_dir=directory,
             )
-            if stem.endswith("datamodel") or stem.endswith("view"):
-                # DataModels and Views have `version` that is often given as an integer by the user.
-                # This ensures that the version is always read as a string, even if the user forgets to
-                # quote it in the YAML file.
-                yaml_content = quote_int_value_by_key_in_yaml(yaml_content, "version")
-            data = yaml.safe_load(yaml_content)
             list_data = data if isinstance(data, list) else [data]
 
             if stem.endswith("datamodel"):

--- a/cognite/neat/_data_model/importers/_api_importer.py
+++ b/cognite/neat/_data_model/importers/_api_importer.py
@@ -12,6 +12,7 @@ from cognite.neat._data_model.importers._base import DMSImporter
 from cognite.neat._data_model.importers._toolkit_variables import (
     ToolkitProjectContext,
     ToolkitReadOptions,
+    _is_filesystem_path,
     prepare_toolkit_yaml_content,
 )
 from cognite.neat._data_model.models.dms import (
@@ -186,6 +187,14 @@ class DMSAPIImporter(DMSImporter):
         return yaml.safe_load(yaml_content)
 
     @classmethod
+    def _is_toolkit_schema_yaml(cls, yaml_file: Path) -> bool:
+        """True for DMS resource files; skip Toolkit config, build_info, and other YAML."""
+        if yaml_file.suffix.lower() not in {".yaml", ".yml", ".json"}:
+            return False
+        stem = yaml_file.stem.casefold()
+        return any(stem.endswith(kind) for kind in ("datamodel", "view", "container", "space", "node"))
+
+    @classmethod
     def _read_yaml_files(
         cls,
         directory: Path,
@@ -197,12 +206,16 @@ class DMSAPIImporter(DMSImporter):
         options = options or ToolkitReadOptions()
         schema_data: dict[str, Any] = {}
         data_model: dict[str, Any] | None = None
-        data_model_file_name = Path(data_model_file).name if data_model_file is not None else None
+        dm_path = Path(data_model_file) if data_model_file is not None else None
+        data_model_file_name = dm_path.name if dm_path is not None else None
+        config_dir = directory
+        if dm_path is not None and _is_filesystem_path(dm_path) and dm_path.is_file():
+            config_dir = dm_path.parent
         variables = None
         if options.substitute:
-            variables = ToolkitProjectContext.load(directory, options).variables_for(directory, options.version)
+            variables = ToolkitProjectContext.load(config_dir, options).variables_for(config_dir, options.version)
         for yaml_file in directory.rglob("**/*"):
-            if yaml_file.suffix.lower() not in {".yaml", ".yml", ".json"}:
+            if not cls._is_toolkit_schema_yaml(yaml_file):
                 continue
             stem = yaml_file.stem.casefold()
             quote_version = stem.endswith("datamodel") or stem.endswith("view")
@@ -211,7 +224,7 @@ class DMSAPIImporter(DMSImporter):
                 options,
                 variables=variables,
                 quote_version=quote_version,
-                data_model_dir=directory,
+                data_model_dir=config_dir,
             )
             list_data = data if isinstance(data, list) else [data]
 

--- a/cognite/neat/_data_model/importers/_toolkit_variables.py
+++ b/cognite/neat/_data_model/importers/_toolkit_variables.py
@@ -13,8 +13,10 @@ Strategy (pipeline)
    Toolkit projects for the path being read.
 
 2. **Resolve config chain** — Merge configs in Toolkit order:
-   ``default.config.yaml`` (base) then an environment overlay
-   (``config.<env>.yaml``, explicit ``toolkit_config``, or ``cdf.toml`` hints).
+   ``default.config.yaml`` (project and/or module-local), then an environment overlay.
+   Overlay selection: explicit ``toolkit_config``, then ``config.<toolkit_env>.yaml``,
+   then ``cdf.toml`` ``default_config_yaml`` / ``default_env`` (e.g. sandbox),
+   then ``config.dev.yaml`` / ``config.sandbox.yaml``.
    Prefer the organization directory from ``cdf.toml`` when present
    (e.g. ``beyond-the-plant/config.dev.yaml``).
 
@@ -116,13 +118,20 @@ class ToolkitProjectContext:
         config_paths = resolve_toolkit_config_paths(project_root, hints=hints, options=options)
         if not config_paths and options.config is not None:
             config_paths = [options.config]
+        module_default = find_module_default_config(data_model_dir, project_root)
+        if module_default is not None:
+            already = {path.resolve() for path in config_paths}
+            if module_default.resolve() not in already:
+                project_default = (project_root / "default.config.yaml").resolve()
+                insert_at = 1 if config_paths and config_paths[0].resolve() == project_default else 0
+                config_paths = [*config_paths[:insert_at], module_default, *config_paths[insert_at:]]
 
         # Deep-merge in chain order so env overlays win over default.config.yaml.
         merged_variables: dict[str, Any] = {}
         for config_path in config_paths:
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-            variable_source = raw.get("variables") or {}
-            if isinstance(variable_source, dict):
+            variable_source = variables_mapping_from_config(raw)
+            if variable_source:
                 merged_variables = deep_merge_dict(merged_variables, variable_source)
 
         return cls(
@@ -178,17 +187,85 @@ def _path_under_toolkit_modules(start: Path, project_root: Path, hints: dict[str
     return bool(org_dir and len(parts) > 1 and parts[0] == org_dir and parts[1] == "modules")
 
 
-def find_toolkit_project_root(start: Path) -> Path | None:
-    """Find the nearest Toolkit project root by walking up from *start*."""
+def _is_filesystem_path(path: object) -> bool:
+    """True for real pathlib objects (not unittest mocks with spec=Path)."""
+    return type(path).__module__.startswith("pathlib")
+
+
+def _as_directory(start: Path) -> Path | None:
+    if not _is_filesystem_path(start):
+        return None
     current = Path(start)
-    if current.is_file():
-        current = current.parent
+    return current.parent if current.is_file() else current
+
+
+def _toolkit_root_markers(candidate: Path) -> tuple[bool, bool, bool]:
+    return (
+        (candidate / "modules").is_dir(),
+        (candidate / "cdf.toml").exists(),
+        (candidate / "default.config.yaml").exists(),
+    )
+
+
+def _is_toolkit_project_root_dir(candidate: Path) -> bool:
+    has_modules, has_cdf, has_default = _toolkit_root_markers(candidate)
+    return has_modules and (has_cdf or has_default)
+
+
+def find_toolkit_project_root(start: Path) -> Path | None:
+    """Find the nearest Toolkit project root by walking up from *start*.
+
+    Prefer a ``cdf.toml`` that owns this path (under ``modules/``), then a
+    ``default.config.yaml`` sitting next to ``modules/``. A *module-local*
+    ``modules/<name>/default.config.yaml`` is only a fallback — it must not
+    hide the real project root where ``config.sandbox.yaml`` / ``cdf.toml`` live.
+
+    The start path itself counts as the root when it contains ``modules/`` plus
+    ``cdf.toml`` or ``default.config.yaml``. If *start* is a parent folder of a
+    single Toolkit project (one child with those markers), that child is used.
+    """
+    current = _as_directory(start)
+    if current is None:
+        return None
+    fallback: Path | None = None
     for candidate in [current, *current.parents]:
-        if (candidate / "default.config.yaml").exists():
+        has_modules, has_cdf, has_default = _toolkit_root_markers(candidate)
+        if has_cdf and (
+            (candidate.resolve() == current.resolve() and has_modules)
+            or _path_under_toolkit_modules(current, candidate)
+        ):
             return candidate
-        # cdf.toml only counts when start is under that project's modules tree.
-        if (candidate / "cdf.toml").exists() and _path_under_toolkit_modules(current, candidate):
+        if has_default and has_modules:
             return candidate
+        if fallback is None and has_default:
+            fallback = candidate
+
+    try:
+        child_roots = [child for child in current.iterdir() if child.is_dir() and _is_toolkit_project_root_dir(child)]
+    except OSError:
+        child_roots = []
+    if len(child_roots) == 1:
+        return child_roots[0]
+    return fallback
+
+
+def find_module_default_config(start: Path, project_root: Path) -> Path | None:
+    """Return a module-local ``default.config.yaml`` between *start* and *project_root*."""
+    current = _as_directory(start)
+    if current is None:
+        return None
+    project_root = project_root.resolve()
+    for ancestor in [current, *current.parents]:
+        resolved = ancestor.resolve()
+        if resolved == project_root:
+            break
+        candidate = ancestor / "default.config.yaml"
+        if candidate.exists():
+            return candidate
+        try:
+            resolved.relative_to(project_root)
+        except ValueError:
+            break
     return None
 
 
@@ -235,9 +312,9 @@ def resolve_toolkit_config_paths(
     """Resolve the ordered Toolkit config chain: base + environment overlay.
 
     Selection order for the overlay when not passed explicitly:
-    1. ``config.<toolkit_env>.yaml``
-    2. ``config.dev.yaml`` if present (default env heuristic)
-    3. ``default_env`` / ``default_config_yaml`` from ``cdf.toml``
+    1. ``config.<toolkit_env>.yaml`` when ``toolkit_env`` is set
+    2. ``default_config_yaml`` / ``default_env`` from ``cdf.toml`` (e.g. sandbox)
+    3. ``config.dev.yaml`` then ``config.sandbox.yaml`` if present
     """
     options = options or ToolkitReadOptions()
     hints = hints if hints is not None else parse_cdf_toml_hints(project_root)
@@ -247,17 +324,18 @@ def resolve_toolkit_config_paths(
     if default_config := _first_existing(search_roots, "default.config.yaml"):
         paths.append(default_config)
 
-    env = options.env
-    if env is None and _first_existing(search_roots, "config.dev.yaml"):
-        env = "dev"
-    if env is None:
-        env = hints.get("default_env")
-
     overlay = options.config
-    if overlay is None and env:
-        overlay = _first_existing(search_roots, f"config.{env}.yaml")
+    if overlay is None and options.env:
+        overlay = _first_existing(search_roots, f"config.{options.env}.yaml")
     if overlay is None and hints.get("default_config_yaml"):
         overlay = _first_existing(search_roots, hints["default_config_yaml"])
+    if overlay is None and hints.get("default_env"):
+        overlay = _first_existing(search_roots, f"config.{hints['default_env']}.yaml")
+    if overlay is None:
+        for heuristic in ("config.dev.yaml", "config.sandbox.yaml"):
+            overlay = _first_existing(search_roots, heuristic)
+            if overlay is not None:
+                break
 
     if overlay is not None and overlay.exists() and overlay.resolve() not in {path.resolve() for path in paths}:
         paths.append(overlay)
@@ -267,6 +345,20 @@ def resolve_toolkit_config_paths(
 # ---------------------------------------------------------------------------
 # Variable flattening and substitution
 # ---------------------------------------------------------------------------
+
+
+def variables_mapping_from_config(raw: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the ``variables:`` mapping, or a flat module ``default.config.yaml`` map."""
+    if not isinstance(raw, dict):
+        return {}
+    nested = raw.get("variables")
+    if isinstance(nested, dict):
+        return nested
+    return {
+        key: value
+        for key, value in raw.items()
+        if value is not None and not isinstance(value, dict | list) and not str(key).startswith("#")
+    }
 
 
 def deep_merge_dict(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:

--- a/cognite/neat/_data_model/importers/_toolkit_variables.py
+++ b/cognite/neat/_data_model/importers/_toolkit_variables.py
@@ -18,6 +18,37 @@ else:
 _PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*(\w+)\s*\}\}")
 _CDF_HINT_KEYS = ("default_config_yaml", "default_env", "default_organization_dir")
 
+TOOLKIT_READ_ARGS_DOC = """\
+        toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
+        toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
+        toolkit_version (str | None): Override ``version`` / ``viewVersion`` template variables."""
+
+
+@dataclass(frozen=True)
+class ToolkitReadOptions:
+    """Caller options for Toolkit template variable resolution."""
+
+    env: str | None = None
+    config: Path | None = None
+    version: str | None = None
+    substitute: bool = True
+
+    @classmethod
+    def from_args(
+        cls,
+        toolkit_env: str | None = None,
+        toolkit_config: Path | str | None = None,
+        toolkit_version: str | None = None,
+        *,
+        substitute_toolkit_variables: bool = True,
+    ) -> ToolkitReadOptions:
+        return cls(
+            env=toolkit_env,
+            config=Path(toolkit_config) if toolkit_config is not None else None,
+            version=toolkit_version,
+            substitute=substitute_toolkit_variables,
+        )
+
 
 @dataclass(frozen=True)
 class ToolkitProjectContext:
@@ -29,26 +60,16 @@ class ToolkitProjectContext:
     merged_variables: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def load(
-        cls,
-        data_model_dir: Path,
-        *,
-        toolkit_env: str | None = None,
-        toolkit_config: Path | str | None = None,
-    ) -> ToolkitProjectContext:
+    def load(cls, data_model_dir: Path, options: ToolkitReadOptions | None = None) -> ToolkitProjectContext:
+        options = options or ToolkitReadOptions()
         project_root = find_toolkit_project_root(data_model_dir)
         if project_root is None:
             return cls(project_root=None)
 
         hints = parse_cdf_toml_hints(project_root)
-        config_paths = resolve_toolkit_config_paths(
-            project_root,
-            hints=hints,
-            toolkit_env=toolkit_env,
-            toolkit_config=toolkit_config,
-        )
-        if not config_paths and toolkit_config is not None:
-            config_paths = [Path(toolkit_config)]
+        config_paths = resolve_toolkit_config_paths(project_root, hints=hints, options=options)
+        if not config_paths and options.config is not None:
+            config_paths = [options.config]
 
         merged_variables: dict[str, Any] = {}
         for config_path in config_paths:
@@ -64,12 +85,26 @@ class ToolkitProjectContext:
             merged_variables=merged_variables,
         )
 
-    def variables_for(self, data_model_dir: Path, toolkit_version: str | None = None) -> dict[str, str]:
+    def variables_for(self, data_model_dir: Path, version: str | None = None) -> dict[str, str]:
         if self.project_root is None:
-            return apply_version_overrides({}, toolkit_version)
+            return apply_version_overrides({}, version)
         module_path = module_path_under_toolkit(data_model_dir, self.project_root, self.hints)
         flat = flatten_variables_for_module(self.merged_variables, module_path)
-        return apply_version_overrides(flat, toolkit_version)
+        return apply_version_overrides(flat, version)
+
+
+def _organization_dir(hints: dict[str, str] | None, project_root: Path | None = None) -> str | None:
+    if hints is None and project_root is not None:
+        hints = parse_cdf_toml_hints(project_root)
+    return (hints or {}).get("default_organization_dir")
+
+
+def _first_existing(roots: list[Path], relative: str) -> Path | None:
+    for root in roots:
+        candidate = root / relative
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def _path_under_toolkit_modules(start: Path, project_root: Path, hints: dict[str, str] | None = None) -> bool:
@@ -83,7 +118,7 @@ def _path_under_toolkit_modules(start: Path, project_root: Path, hints: dict[str
     if parts and parts[0] == "modules":
         return True
 
-    org_dir = (hints if hints is not None else parse_cdf_toml_hints(project_root)).get("default_organization_dir")
+    org_dir = _organization_dir(hints, project_root)
     return bool(org_dir and len(parts) > 1 and parts[0] == org_dir and parts[1] == "modules")
 
 
@@ -123,7 +158,7 @@ def parse_cdf_toml_hints(start_dir: Path) -> dict[str, str]:
 
 def toolkit_config_search_roots(project_root: Path, hints: dict[str, str] | None = None) -> list[Path]:
     """Return Toolkit config directories, preferring the organization directory from ``cdf.toml``."""
-    org_dir = (hints if hints is not None else parse_cdf_toml_hints(project_root)).get("default_organization_dir")
+    org_dir = _organization_dir(hints, project_root)
     if org_dir:
         org_root = project_root / org_dir
         if org_root.is_dir():
@@ -135,49 +170,31 @@ def resolve_toolkit_config_paths(
     project_root: Path,
     *,
     hints: dict[str, str] | None = None,
-    toolkit_env: str | None = None,
-    toolkit_config: Path | str | None = None,
+    options: ToolkitReadOptions | None = None,
 ) -> list[Path]:
     """Resolve the ordered Toolkit config chain: base + environment overlay."""
-    if toolkit_config is not None:
-        toolkit_config = Path(toolkit_config)
+    options = options or ToolkitReadOptions()
     hints = hints if hints is not None else parse_cdf_toml_hints(project_root)
-    paths: list[Path] = []
     search_roots = toolkit_config_search_roots(project_root, hints)
 
-    for root in search_roots:
-        default_config = root / "default.config.yaml"
-        if default_config.exists():
-            paths.append(default_config)
-            break
+    paths: list[Path] = []
+    if default_config := _first_existing(search_roots, "default.config.yaml"):
+        paths.append(default_config)
 
-    env = toolkit_env
+    env = options.env
+    if env is None and _first_existing(search_roots, "config.dev.yaml"):
+        env = "dev"
     if env is None:
-        for root in search_roots:
-            if (root / "config.dev.yaml").exists():
-                env = "dev"
-                break
-    if env is None and hints.get("default_env"):
-        env = hints["default_env"]
+        env = hints.get("default_env")
 
-    overlay = toolkit_config
+    overlay = options.config
     if overlay is None and env:
-        for root in search_roots:
-            candidate = root / f"config.{env}.yaml"
-            if candidate.exists():
-                overlay = candidate
-                break
+        overlay = _first_existing(search_roots, f"config.{env}.yaml")
     if overlay is None and hints.get("default_config_yaml"):
-        for root in search_roots:
-            candidate = root / hints["default_config_yaml"]
-            if candidate.exists():
-                overlay = candidate
-                break
+        overlay = _first_existing(search_roots, hints["default_config_yaml"])
 
-    if overlay is not None:
-        overlay = Path(overlay)
-        if overlay.exists() and overlay.resolve() not in {path.resolve() for path in paths}:
-            paths.append(overlay)
+    if overlay is not None and overlay.exists() and overlay.resolve() not in {path.resolve() for path in paths}:
+        paths.append(overlay)
     return paths
 
 
@@ -204,7 +221,7 @@ def module_path_under_toolkit(
         return None
 
     parts = list(relative.parts)
-    org_dir = (hints if hints is not None else parse_cdf_toml_hints(project_root)).get("default_organization_dir")
+    org_dir = _organization_dir(hints, project_root)
     if org_dir and parts and parts[0] == org_dir:
         parts = parts[1:]
 
@@ -263,19 +280,10 @@ def apply_version_overrides(variables: dict[str, str], toolkit_version: str | No
     return result
 
 
-def load_toolkit_variables(
-    data_model_dir: Path,
-    *,
-    toolkit_env: str | None = None,
-    toolkit_config: Path | str | None = None,
-    toolkit_version: str | None = None,
-) -> dict[str, str]:
+def load_toolkit_variables(data_model_dir: Path, options: ToolkitReadOptions | None = None) -> dict[str, str]:
     """Load and flatten Toolkit template variables for a data model directory."""
-    return ToolkitProjectContext.load(
-        data_model_dir,
-        toolkit_env=toolkit_env,
-        toolkit_config=toolkit_config,
-    ).variables_for(data_model_dir, toolkit_version)
+    options = options or ToolkitReadOptions()
+    return ToolkitProjectContext.load(data_model_dir, options).variables_for(data_model_dir, options.version)
 
 
 def substitute_toolkit_variables(content: str, variables: dict[str, str], *, source: str) -> str:
@@ -306,20 +314,13 @@ def prepare_toolkit_yaml_content(
     source: Path,
     data_model_dir: Path | None = None,
     variables: dict[str, str] | None = None,
-    toolkit_env: str | None = None,
-    toolkit_config: Path | str | None = None,
-    toolkit_version: str | None = None,
-    enabled: bool = True,
+    options: ToolkitReadOptions | None = None,
 ) -> str:
     """Substitute Toolkit template variables in YAML source before parsing."""
-    if not enabled or "{{" not in content:
+    options = options or ToolkitReadOptions()
+    if not options.substitute or "{{" not in content:
         return content
 
     if variables is None:
-        variables = load_toolkit_variables(
-            data_model_dir or source.parent,
-            toolkit_env=toolkit_env,
-            toolkit_config=toolkit_config,
-            toolkit_version=toolkit_version,
-        )
+        variables = load_toolkit_variables(data_model_dir or source.parent, options)
     return substitute_toolkit_variables(content, variables, source=str(source))

--- a/cognite/neat/_data_model/importers/_toolkit_variables.py
+++ b/cognite/neat/_data_model/importers/_toolkit_variables.py
@@ -1,3 +1,40 @@
+"""Toolkit template-variable resolution for NEAT YAML imports.
+
+NEAT cannot hard-depend on ``cognite-toolkit``, but Toolkit module YAML uses
+``{{ variable }}`` placeholders. This module reimplements the subset of Toolkit
+config resolution needed so ``format="toolkit"`` reads work without running
+``cdf build``.
+
+Strategy (pipeline)
+-------------------
+1. **Locate project** — Walk up from the data-model directory to find a Toolkit
+   project root (``default.config.yaml`` and/or ``cdf.toml`` above a ``modules/``
+   tree). Guard against unrelated repo-root ``cdf.toml`` files that are not
+   Toolkit projects for the path being read.
+
+2. **Resolve config chain** — Merge configs in Toolkit order:
+   ``default.config.yaml`` (base) then an environment overlay
+   (``config.<env>.yaml``, explicit ``toolkit_config``, or ``cdf.toml`` hints).
+   Prefer the organization directory from ``cdf.toml`` when present
+   (e.g. ``beyond-the-plant/config.dev.yaml``).
+
+3. **Flatten variables** — Build a flat ``name -> value`` map from the merged
+   ``variables:`` tree. Collect scalars at the root, at ``variables.modules``
+   (project-wide globals — common in ADA20/BTP-style configs), then walk the
+   module path for nested overrides (later wins).
+
+4. **Version aliases** — Ensure both ``version`` and ``viewVersion`` exist
+   (Toolkit YAML uses either). Explicit ``toolkit_version`` overrides both.
+
+5. **Substitute** — Replace ``{{ name }}`` in YAML text *before* parsing.
+   Unresolved names raise ``FileReadException`` with available variables listed.
+
+Performance note
+----------------
+Load config once per directory import via :class:`ToolkitProjectContext`, then
+reuse the flattened map for every YAML file under that directory.
+"""
+
 from __future__ import annotations
 
 import re
@@ -18,6 +55,7 @@ else:
 _PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*(\w+)\s*\}\}")
 _CDF_HINT_KEYS = ("default_config_yaml", "default_env", "default_organization_dir")
 
+# Shared Args snippet for session ``read.yaml`` docstrings (keep public kwargs as three fields).
 TOOLKIT_READ_ARGS_DOC = """\
         toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
         toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
@@ -26,7 +64,11 @@ TOOLKIT_READ_ARGS_DOC = """\
 
 @dataclass(frozen=True)
 class ToolkitReadOptions:
-    """Caller options for Toolkit template variable resolution."""
+    """Caller options for Toolkit template variable resolution.
+
+    Public session APIs expose ``toolkit_env`` / ``toolkit_config`` / ``toolkit_version``;
+    pack them once with :meth:`from_args` and thread this object through importers.
+    """
 
     env: str | None = None
     config: Path | None = None
@@ -52,7 +94,11 @@ class ToolkitReadOptions:
 
 @dataclass(frozen=True)
 class ToolkitProjectContext:
-    """Resolved Toolkit project config, loaded once per directory import."""
+    """Resolved Toolkit project config, loaded once per directory import.
+
+    Holds the merged ``variables:`` tree (still nested). Call :meth:`variables_for`
+    to flatten for a specific module path and apply version overrides.
+    """
 
     project_root: Path | None
     hints: dict[str, str] = field(default_factory=dict)
@@ -71,6 +117,7 @@ class ToolkitProjectContext:
         if not config_paths and options.config is not None:
             config_paths = [options.config]
 
+        # Deep-merge in chain order so env overlays win over default.config.yaml.
         merged_variables: dict[str, Any] = {}
         for config_path in config_paths:
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
@@ -93,6 +140,11 @@ class ToolkitProjectContext:
         return apply_version_overrides(flat, version)
 
 
+# ---------------------------------------------------------------------------
+# Project / config discovery
+# ---------------------------------------------------------------------------
+
+
 def _organization_dir(hints: dict[str, str] | None, project_root: Path | None = None) -> str | None:
     if hints is None and project_root is not None:
         hints = parse_cdf_toml_hints(project_root)
@@ -108,7 +160,11 @@ def _first_existing(roots: list[Path], relative: str) -> Path | None:
 
 
 def _path_under_toolkit_modules(start: Path, project_root: Path, hints: dict[str, str] | None = None) -> bool:
-    """Return True when *start* sits under a Toolkit ``modules/`` tree for *project_root*."""
+    """Return True when *start* sits under a Toolkit ``modules/`` tree for *project_root*.
+
+    Used so a repo-root ``cdf.toml`` alone does not claim unrelated paths (e.g. test
+    fixtures outside ``modules/``) as Toolkit projects.
+    """
     try:
         relative = start.resolve().relative_to(project_root.resolve())
     except ValueError:
@@ -130,13 +186,17 @@ def find_toolkit_project_root(start: Path) -> Path | None:
     for candidate in [current, *current.parents]:
         if (candidate / "default.config.yaml").exists():
             return candidate
+        # cdf.toml only counts when start is under that project's modules tree.
         if (candidate / "cdf.toml").exists() and _path_under_toolkit_modules(current, candidate):
             return candidate
     return None
 
 
 def parse_cdf_toml_hints(start_dir: Path) -> dict[str, str]:
-    """Read Toolkit project hints from the nearest ``cdf.toml`` upward."""
+    """Read Toolkit project hints from the nearest ``cdf.toml`` upward.
+
+    Only the ``[cdf]`` keys that affect config path / env selection are kept.
+    """
     for ancestor in [Path(start_dir), *list(Path(start_dir).parents)[:8]]:
         cdf_toml = ancestor / "cdf.toml"
         if not cdf_toml.exists():
@@ -172,7 +232,13 @@ def resolve_toolkit_config_paths(
     hints: dict[str, str] | None = None,
     options: ToolkitReadOptions | None = None,
 ) -> list[Path]:
-    """Resolve the ordered Toolkit config chain: base + environment overlay."""
+    """Resolve the ordered Toolkit config chain: base + environment overlay.
+
+    Selection order for the overlay when not passed explicitly:
+    1. ``config.<toolkit_env>.yaml``
+    2. ``config.dev.yaml`` if present (default env heuristic)
+    3. ``default_env`` / ``default_config_yaml`` from ``cdf.toml``
+    """
     options = options or ToolkitReadOptions()
     hints = hints if hints is not None else parse_cdf_toml_hints(project_root)
     search_roots = toolkit_config_search_roots(project_root, hints)
@@ -198,6 +264,11 @@ def resolve_toolkit_config_paths(
     return paths
 
 
+# ---------------------------------------------------------------------------
+# Variable flattening and substitution
+# ---------------------------------------------------------------------------
+
+
 def deep_merge_dict(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
     """Recursively merge *override* into *base* (override wins on conflicts)."""
     merged = dict(base)
@@ -214,7 +285,11 @@ def module_path_under_toolkit(
     project_root: Path,
     hints: dict[str, str] | None = None,
 ) -> Path | None:
-    """Return the path under ``modules/`` for module-scoped variable resolution."""
+    """Return the path under ``modules/`` for module-scoped variable resolution.
+
+    Example: ``modules/btp/data_modeling/dm`` → ``btp/data_modeling/dm``, used to
+    walk ``variables.modules.btp...`` for nested overrides.
+    """
     try:
         relative = data_model_dir.resolve().relative_to(project_root.resolve())
     except ValueError:
@@ -240,7 +315,13 @@ def _collect_scalar_variables(node: dict[str, Any], flat: dict[str, str]) -> Non
 
 
 def flatten_variables_for_module(variables_root: dict[str, Any], module_path: Path | None) -> dict[str, str]:
-    """Flatten Toolkit variables, applying module-specific overrides when available."""
+    """Flatten Toolkit variables, applying module-specific overrides when available.
+
+    Layering (later overwrites earlier):
+    1. Scalars under ``variables:``
+    2. Scalars under ``variables.modules:`` (project globals next to nested module dicts)
+    3. Scalars along the module path under ``variables.modules.<...>``
+    """
     flat: dict[str, str] = {}
     _collect_scalar_variables(variables_root, flat)
 
@@ -248,8 +329,7 @@ def flatten_variables_for_module(variables_root: dict[str, Any], module_path: Pa
     if not isinstance(modules, dict):
         return flat
 
-    # Toolkit stores project-wide variables directly under ``variables.modules``,
-    # alongside per-module nested dicts (e.g. ``variables.modules.pidm``).
+    # Project-wide globals often live directly under variables.modules (ADA20/BTP).
     _collect_scalar_variables(modules, flat)
 
     if module_path is None:
@@ -316,7 +396,11 @@ def prepare_toolkit_yaml_content(
     variables: dict[str, str] | None = None,
     options: ToolkitReadOptions | None = None,
 ) -> str:
-    """Substitute Toolkit template variables in YAML source before parsing."""
+    """Substitute Toolkit template variables in YAML source before parsing.
+
+    Prefer passing a precomputed *variables* map when reading many files in one
+    directory so config is not reloaded per file.
+    """
     options = options or ToolkitReadOptions()
     if not options.substitute or "{{" not in content:
         return content

--- a/cognite/neat/_data_model/importers/_toolkit_variables.py
+++ b/cognite/neat/_data_model/importers/_toolkit_variables.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from cognite.neat._exceptions import FileReadException
+
+if sys.version_info >= (3, 11):
+    import tomllib as tomli
+else:
+    import tomli  # type: ignore
+
+_PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+_CDF_HINT_KEYS = ("default_config_yaml", "default_env", "default_organization_dir")
+
+
+@dataclass(frozen=True)
+class ToolkitProjectContext:
+    """Resolved Toolkit project config, loaded once per directory import."""
+
+    project_root: Path | None
+    hints: dict[str, str] = field(default_factory=dict)
+    config_paths: tuple[Path, ...] = ()
+    merged_variables: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def load(
+        cls,
+        data_model_dir: Path,
+        *,
+        toolkit_env: str | None = None,
+        toolkit_config: Path | str | None = None,
+    ) -> ToolkitProjectContext:
+        project_root = find_toolkit_project_root(data_model_dir)
+        if project_root is None:
+            return cls(project_root=None)
+
+        hints = parse_cdf_toml_hints(project_root)
+        config_paths = resolve_toolkit_config_paths(
+            project_root,
+            hints=hints,
+            toolkit_env=toolkit_env,
+            toolkit_config=toolkit_config,
+        )
+        if not config_paths and toolkit_config is not None:
+            config_paths = [Path(toolkit_config)]
+
+        merged_variables: dict[str, Any] = {}
+        for config_path in config_paths:
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            variable_source = raw.get("variables") or {}
+            if isinstance(variable_source, dict):
+                merged_variables = deep_merge_dict(merged_variables, variable_source)
+
+        return cls(
+            project_root=project_root,
+            hints=hints,
+            config_paths=tuple(config_paths),
+            merged_variables=merged_variables,
+        )
+
+    def variables_for(self, data_model_dir: Path, toolkit_version: str | None = None) -> dict[str, str]:
+        if self.project_root is None:
+            return apply_version_overrides({}, toolkit_version)
+        module_path = module_path_under_toolkit(data_model_dir, self.project_root, self.hints)
+        flat = flatten_variables_for_module(self.merged_variables, module_path)
+        return apply_version_overrides(flat, toolkit_version)
+
+
+def _path_under_toolkit_modules(start: Path, project_root: Path, hints: dict[str, str] | None = None) -> bool:
+    """Return True when *start* sits under a Toolkit ``modules/`` tree for *project_root*."""
+    try:
+        relative = start.resolve().relative_to(project_root.resolve())
+    except ValueError:
+        return False
+
+    parts = relative.parts
+    if parts and parts[0] == "modules":
+        return True
+
+    org_dir = (hints if hints is not None else parse_cdf_toml_hints(project_root)).get("default_organization_dir")
+    return bool(org_dir and len(parts) > 1 and parts[0] == org_dir and parts[1] == "modules")
+
+
+def find_toolkit_project_root(start: Path) -> Path | None:
+    """Find the nearest Toolkit project root by walking up from *start*."""
+    current = Path(start)
+    if current.is_file():
+        current = current.parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "default.config.yaml").exists():
+            return candidate
+        if (candidate / "cdf.toml").exists() and _path_under_toolkit_modules(current, candidate):
+            return candidate
+    return None
+
+
+def parse_cdf_toml_hints(start_dir: Path) -> dict[str, str]:
+    """Read Toolkit project hints from the nearest ``cdf.toml`` upward."""
+    for ancestor in [Path(start_dir), *list(Path(start_dir).parents)[:8]]:
+        cdf_toml = ancestor / "cdf.toml"
+        if not cdf_toml.exists():
+            continue
+        try:
+            with cdf_toml.open("rb") as file_handle:
+                data = tomli.load(file_handle)
+        except Exception:
+            return {}
+        cdf = data.get("cdf", {}) or {}
+        hints: dict[str, str] = {}
+        for key in _CDF_HINT_KEYS:
+            value = cdf.get(key) or cdf.get(key.replace("_", "-"))
+            if value:
+                hints[key] = str(value)
+        return hints
+    return {}
+
+
+def toolkit_config_search_roots(project_root: Path, hints: dict[str, str] | None = None) -> list[Path]:
+    """Return Toolkit config directories, preferring the organization directory from ``cdf.toml``."""
+    org_dir = (hints if hints is not None else parse_cdf_toml_hints(project_root)).get("default_organization_dir")
+    if org_dir:
+        org_root = project_root / org_dir
+        if org_root.is_dir():
+            return [org_root, project_root]
+    return [project_root]
+
+
+def resolve_toolkit_config_paths(
+    project_root: Path,
+    *,
+    hints: dict[str, str] | None = None,
+    toolkit_env: str | None = None,
+    toolkit_config: Path | str | None = None,
+) -> list[Path]:
+    """Resolve the ordered Toolkit config chain: base + environment overlay."""
+    if toolkit_config is not None:
+        toolkit_config = Path(toolkit_config)
+    hints = hints if hints is not None else parse_cdf_toml_hints(project_root)
+    paths: list[Path] = []
+    search_roots = toolkit_config_search_roots(project_root, hints)
+
+    for root in search_roots:
+        default_config = root / "default.config.yaml"
+        if default_config.exists():
+            paths.append(default_config)
+            break
+
+    env = toolkit_env
+    if env is None:
+        for root in search_roots:
+            if (root / "config.dev.yaml").exists():
+                env = "dev"
+                break
+    if env is None and hints.get("default_env"):
+        env = hints["default_env"]
+
+    overlay = toolkit_config
+    if overlay is None and env:
+        for root in search_roots:
+            candidate = root / f"config.{env}.yaml"
+            if candidate.exists():
+                overlay = candidate
+                break
+    if overlay is None and hints.get("default_config_yaml"):
+        for root in search_roots:
+            candidate = root / hints["default_config_yaml"]
+            if candidate.exists():
+                overlay = candidate
+                break
+
+    if overlay is not None:
+        overlay = Path(overlay)
+        if overlay.exists() and overlay.resolve() not in {path.resolve() for path in paths}:
+            paths.append(overlay)
+    return paths
+
+
+def deep_merge_dict(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge *override* into *base* (override wins on conflicts)."""
+    merged = dict(base)
+    for key, value in override.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = deep_merge_dict(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def module_path_under_toolkit(
+    data_model_dir: Path,
+    project_root: Path,
+    hints: dict[str, str] | None = None,
+) -> Path | None:
+    """Return the path under ``modules/`` for module-scoped variable resolution."""
+    try:
+        relative = data_model_dir.resolve().relative_to(project_root.resolve())
+    except ValueError:
+        return None
+
+    parts = list(relative.parts)
+    org_dir = (hints if hints is not None else parse_cdf_toml_hints(project_root)).get("default_organization_dir")
+    if org_dir and parts and parts[0] == org_dir:
+        parts = parts[1:]
+
+    if not parts or parts[0] != "modules":
+        return None
+    return Path(*parts[1:])
+
+
+def _collect_scalar_variables(node: dict[str, Any], flat: dict[str, str]) -> None:
+    """Collect scalar Toolkit variables from a config node, skipping nested module dicts."""
+    for key, value in node.items():
+        if key == "modules" or isinstance(value, dict | list):
+            continue
+        if value is not None:
+            flat[str(key)] = str(value)
+
+
+def flatten_variables_for_module(variables_root: dict[str, Any], module_path: Path | None) -> dict[str, str]:
+    """Flatten Toolkit variables, applying module-specific overrides when available."""
+    flat: dict[str, str] = {}
+    _collect_scalar_variables(variables_root, flat)
+
+    modules = variables_root.get("modules")
+    if not isinstance(modules, dict):
+        return flat
+
+    # Toolkit stores project-wide variables directly under ``variables.modules``,
+    # alongside per-module nested dicts (e.g. ``variables.modules.pidm``).
+    _collect_scalar_variables(modules, flat)
+
+    if module_path is None:
+        return flat
+
+    node: dict[str, Any] = modules
+    for part in module_path.parts:
+        child = node.get(part)
+        if not isinstance(child, dict):
+            break
+        node = child
+        _collect_scalar_variables(node, flat)
+    return flat
+
+
+def apply_version_overrides(variables: dict[str, str], toolkit_version: str | None) -> dict[str, str]:
+    """Ensure ``version`` and ``viewVersion`` are available for template substitution."""
+    result = dict(variables)
+    resolved_version = toolkit_version or result.get("viewVersion") or result.get("version")
+    if resolved_version is None:
+        return result
+    if toolkit_version is not None:
+        result["version"] = toolkit_version
+        result["viewVersion"] = toolkit_version
+    else:
+        result.setdefault("version", resolved_version)
+        result.setdefault("viewVersion", resolved_version)
+    return result
+
+
+def load_toolkit_variables(
+    data_model_dir: Path,
+    *,
+    toolkit_env: str | None = None,
+    toolkit_config: Path | str | None = None,
+    toolkit_version: str | None = None,
+) -> dict[str, str]:
+    """Load and flatten Toolkit template variables for a data model directory."""
+    return ToolkitProjectContext.load(
+        data_model_dir,
+        toolkit_env=toolkit_env,
+        toolkit_config=toolkit_config,
+    ).variables_for(data_model_dir, toolkit_version)
+
+
+def substitute_toolkit_variables(content: str, variables: dict[str, str], *, source: str) -> str:
+    """Replace ``{{ variable }}`` placeholders in Toolkit YAML source text."""
+    if "{{" not in content:
+        return content
+
+    def replace_match(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in variables:
+            available = ", ".join(sorted(variables)) if variables else "none"
+            raise FileReadException(
+                source,
+                f"Unresolved toolkit variable '{{{{ {name} }}}}'. "
+                f"Available variables: {available}. "
+                "Ensure Toolkit config files (for example default.config.yaml or config.<env>.yaml "
+                "referenced from cdf.toml) are present, "
+                "or pass toolkit_env / toolkit_config to read.yaml().",
+            )
+        return variables[name]
+
+    return _PLACEHOLDER_PATTERN.sub(replace_match, content)
+
+
+def prepare_toolkit_yaml_content(
+    content: str,
+    *,
+    source: Path,
+    data_model_dir: Path | None = None,
+    variables: dict[str, str] | None = None,
+    toolkit_env: str | None = None,
+    toolkit_config: Path | str | None = None,
+    toolkit_version: str | None = None,
+    enabled: bool = True,
+) -> str:
+    """Substitute Toolkit template variables in YAML source before parsing."""
+    if not enabled or "{{" not in content:
+        return content
+
+    if variables is None:
+        variables = load_toolkit_variables(
+            data_model_dir or source.parent,
+            toolkit_env=toolkit_env,
+            toolkit_config=toolkit_config,
+            toolkit_version=toolkit_version,
+        )
+    return substitute_toolkit_variables(content, variables, source=str(source))

--- a/cognite/neat/_session/_physical.py
+++ b/cognite/neat/_session/_physical.py
@@ -491,12 +491,12 @@ def yaml(
 ) -> None:
     """Read physical data model from YAML file(s)
 
-    Args:
-        io (Any): The file or directory path or buffer to read from.
-        format (Literal["neat", "toolkit"]): The format of the input file(s).
-            - "neat": Neat's DMS table format.
-            - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
-<<TOOLKIT_ARGS>>
+        Args:
+            io (Any): The file or directory path or buffer to read from.
+            format (Literal["neat", "toolkit"]): The format of the input file(s).
+                - "neat": Neat's DMS table format.
+                - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
+    <<TOOLKIT_ARGS>>
 
     """
     self._yaml(
@@ -519,13 +519,13 @@ def read_yaml_alpha_fix(
 ) -> None:
     """Read physical data model from YAML file(s)
 
-    Args:
-        io (Any): The file or directory path or buffer to read from.
-        format (Literal["neat", "toolkit"]): The format of the input file(s).
-            - "neat": Neat's DMS table format.
-            - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
-        fix (bool): If True, automatically apply fixes for fixable issues.
-<<TOOLKIT_ARGS>>
+        Args:
+            io (Any): The file or directory path or buffer to read from.
+            format (Literal["neat", "toolkit"]): The format of the input file(s).
+                - "neat": Neat's DMS table format.
+                - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
+            fix (bool): If True, automatically apply fixes for fixable issues.
+    <<TOOLKIT_ARGS>>
 
     """
     self._yaml(
@@ -547,15 +547,15 @@ def read_yaml_alpha_data_model_file(
 ) -> None:
     """Read physical data model from YAML file(s)
 
-    Args:
-        io (Any): The file or directory path or buffer to read from.
-        format (Literal["neat", "toolkit"]): The format of the input file(s).
-            - "neat": Neat's DMS table format.
-            - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
-        data_model_file (str | Path | None): Optional specific data model file to read. This is only applicable when
-            format is set to "toolkit", and when io contains multiple data model YAML files.
-            A file name or full path may be given; only the file name is used for matching.
-<<TOOLKIT_ARGS>>
+        Args:
+            io (Any): The file or directory path or buffer to read from.
+            format (Literal["neat", "toolkit"]): The format of the input file(s).
+                - "neat": Neat's DMS table format.
+                - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
+            data_model_file (str | Path | None): Optional specific data model file to read. This is only applicable when
+                format is set to "toolkit", and when io contains multiple data model YAML files.
+                A file name or full path may be given; only the file name is used for matching.
+    <<TOOLKIT_ARGS>>
 
     """
     self._yaml(

--- a/cognite/neat/_session/_physical.py
+++ b/cognite/neat/_session/_physical.py
@@ -29,6 +29,25 @@ from cognite.neat._utils._reader import NeatReader
 
 from ._wrappers import session_wrapper
 
+_TOOLKIT_YAML_READ_NOTES = """
+    !!! note "Toolkit YAML import"
+        When ``format`` is ``\"toolkit\"``, ``{{ variable }}`` placeholders in module YAML are resolved
+        from Toolkit config (``default.config.yaml``, environment overlays such as ``config.dev.yaml``,
+        and module overrides). Use ``toolkit_env``, ``toolkit_config``, and ``toolkit_version`` to control
+        resolution.
+"""
+
+
+def _toolkit_read_kwargs(
+    toolkit_env: str | None = None,
+    toolkit_config: Path | str | None = None,
+    toolkit_version: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "toolkit_env": toolkit_env,
+        "toolkit_config": Path(toolkit_config) if toolkit_config is not None else None,
+        "toolkit_version": toolkit_version,
+    }
 
 @session_wrapper
 class PhysicalDataModel:
@@ -136,8 +155,11 @@ class ReadPhysicalDataModel:
         self,
         io: Any,
         format: Literal["neat", "toolkit"] = "neat",
-        data_model_file: Path | None = None,
+        data_model_file: Path | str | None = None,
         fix: bool = False,
+        toolkit_env: str | None = None,
+        toolkit_config: Path | str | None = None,
+        toolkit_version: str | None = None,
     ) -> None:
         """Read physical data model from YAML file(s)
 
@@ -146,15 +168,28 @@ class ReadPhysicalDataModel:
             format (Literal["neat", "toolkit"]): The format of the input file(s).
                 - "neat": Neat's DMS table format.
                 - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
+            data_model_file (str | Path | None): Optional data model YAML file name or path when reading a toolkit
+                directory. Only the file name is used for matching.
+            fix (bool): If True, automatically apply fixes for fixable issues.
+            toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
+            toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
+            toolkit_version (str | None): Override ``version`` / ``viewVersion`` template variables.
         """
 
         path = NeatReader.create(io).materialize_path()
+        if data_model_file is not None:
+            data_model_file = Path(data_model_file)
+        toolkit_options = _toolkit_read_kwargs(toolkit_env, toolkit_config, toolkit_version)
 
         reader: DMSImporter
         if format == "neat":
             reader = DMSTableImporter.from_yaml(path)
         elif format == "toolkit":
-            reader = DMSAPIImporter.from_yaml(path, data_model_file=data_model_file)
+            reader = DMSAPIImporter.from_yaml(
+                path,
+                data_model_file=data_model_file,
+                **toolkit_options,
+            )
         else:
             raise UserInputError(f"Unsupported format: {format}. Supported formats are 'neat' and 'toolkit'.")
 
@@ -322,7 +357,9 @@ class WritePhysicalDataModel:
 
         Args:
             io (Any): The file path or buffer to write to.
-            skip_other_spaces (bool): If true, only properties in the same space as the data model will be written.
+            skip_other_spaces (bool): If ``True`` (default), only view properties in the same space as the
+                data model are written to the Properties sheet. Set to ``False`` when exporting multi-space
+                toolkit modules where views and containers live in spaces other than the data model space.
 
         """
 
@@ -466,6 +503,9 @@ def yaml(
     self: ReadPhysicalDataModel,
     io: Any,
     format: Literal["neat", "toolkit"] = "neat",
+    toolkit_env: str | None = None,
+    toolkit_config: Path | str | None = None,
+    toolkit_version: str | None = None,
 ) -> None:
     """Read physical data model from YAML file(s)
 
@@ -474,9 +514,18 @@ def yaml(
         format (Literal["neat", "toolkit"]): The format of the input file(s).
             - "neat": Neat's DMS table format.
             - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
+        toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
+        toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
+        toolkit_version (str | None): Override ``version`` / ``viewVersion`` template variables.
 
     """
-    self._yaml(io=io, format=format, data_model_file=None, fix=False)
+    self._yaml(
+        io=io,
+        format=format,
+        data_model_file=None,
+        fix=False,
+        **_toolkit_read_kwargs(toolkit_env, toolkit_config, toolkit_version),
+    )
 
 
 def read_yaml_alpha_fix(
@@ -484,6 +533,9 @@ def read_yaml_alpha_fix(
     io: Any,
     format: Literal["neat", "toolkit"] = "neat",
     fix: bool = False,
+    toolkit_env: str | None = None,
+    toolkit_config: Path | str | None = None,
+    toolkit_version: str | None = None,
 ) -> None:
     """Read physical data model from YAML file(s)
 
@@ -493,16 +545,27 @@ def read_yaml_alpha_fix(
             - "neat": Neat's DMS table format.
             - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
         fix (bool): If True, automatically apply fixes for fixable issues.
+        toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
+        toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
+        toolkit_version (str | None): Override ``version`` / ``viewVersion`` template variables.
 
     """
-    self._yaml(io=io, format=format, fix=fix)
+    self._yaml(
+        io=io,
+        format=format,
+        fix=fix,
+        **_toolkit_read_kwargs(toolkit_env, toolkit_config, toolkit_version),
+    )
 
 
 def read_yaml_alpha_data_model_file(
     self: ReadPhysicalDataModel,
     io: Any,
     format: Literal["neat", "toolkit"] = "neat",
-    data_model_file: Path | None = None,
+    data_model_file: Path | str | None = None,
+    toolkit_env: str | None = None,
+    toolkit_config: Path | str | None = None,
+    toolkit_version: str | None = None,
 ) -> None:
     """Read physical data model from YAML file(s)
 
@@ -511,12 +574,21 @@ def read_yaml_alpha_data_model_file(
         format (Literal["neat", "toolkit"]): The format of the input file(s).
             - "neat": Neat's DMS table format.
             - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
-        data_model_file (str | None): Optional specific data model file to read. This is only applicable when format
-            is set to "toolkit", and when io contains multiple data model YAML files.
-            The value should match the file name of the data model YAML file to read.
+        data_model_file (str | Path | None): Optional specific data model file to read. This is only applicable when
+            format is set to "toolkit", and when io contains multiple data model YAML files.
+            A file name or full path may be given; only the file name is used for matching.
+        toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
+        toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
+        toolkit_version (str | None): Override ``version`` / ``viewVersion`` template variables.
 
     """
-    self._yaml(io=io, format=format, data_model_file=data_model_file, fix=False)
+    self._yaml(
+        io=io,
+        format=format,
+        data_model_file=data_model_file,
+        fix=False,
+        **_toolkit_read_kwargs(toolkit_env, toolkit_config, toolkit_version),
+    )
 
 
 def json(
@@ -564,3 +636,11 @@ def cdf(
 
     """
     self._cdf(space=space, external_id=external_id, version=version, fix=False)
+
+
+for _yaml_reader in (yaml, read_yaml_alpha_fix, read_yaml_alpha_data_model_file):
+    if _yaml_reader.__doc__:
+        _yaml_reader.__doc__ += _TOOLKIT_YAML_READ_NOTES
+
+if ReadPhysicalDataModel._yaml.__doc__:
+    ReadPhysicalDataModel._yaml.__doc__ += _TOOLKIT_YAML_READ_NOTES

--- a/cognite/neat/_session/_physical.py
+++ b/cognite/neat/_session/_physical.py
@@ -18,6 +18,7 @@ from cognite.neat._data_model.exporters import (
 )
 from cognite.neat._data_model.exporters._table_exporter.workbook import WorkbookOptions
 from cognite.neat._data_model.importers import DMSAPICreator, DMSAPIImporter, DMSImporter, DMSTableImporter
+from cognite.neat._data_model.importers._toolkit_variables import TOOLKIT_READ_ARGS_DOC, ToolkitReadOptions
 from cognite.neat._data_model.models.dms import DataModelReference
 from cognite.neat._data_model.rules.dms import DmsDataModelRulesOrchestrator
 from cognite.neat._exceptions import UserInputError
@@ -37,17 +38,6 @@ _TOOLKIT_YAML_READ_NOTES = """
         resolution.
 """
 
-
-def _toolkit_read_kwargs(
-    toolkit_env: str | None = None,
-    toolkit_config: Path | str | None = None,
-    toolkit_version: str | None = None,
-) -> dict[str, Any]:
-    return {
-        "toolkit_env": toolkit_env,
-        "toolkit_config": Path(toolkit_config) if toolkit_config is not None else None,
-        "toolkit_version": toolkit_version,
-    }
 
 @session_wrapper
 class PhysicalDataModel:
@@ -157,9 +147,7 @@ class ReadPhysicalDataModel:
         format: Literal["neat", "toolkit"] = "neat",
         data_model_file: Path | str | None = None,
         fix: bool = False,
-        toolkit_env: str | None = None,
-        toolkit_config: Path | str | None = None,
-        toolkit_version: str | None = None,
+        options: ToolkitReadOptions | None = None,
     ) -> None:
         """Read physical data model from YAML file(s)
 
@@ -171,25 +159,19 @@ class ReadPhysicalDataModel:
             data_model_file (str | Path | None): Optional data model YAML file name or path when reading a toolkit
                 directory. Only the file name is used for matching.
             fix (bool): If True, automatically apply fixes for fixable issues.
-            toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
-            toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
-            toolkit_version (str | None): Override ``version`` / ``viewVersion`` template variables.
+            options (ToolkitReadOptions | None): Toolkit variable resolution options.
         """
 
         path = NeatReader.create(io).materialize_path()
         if data_model_file is not None:
             data_model_file = Path(data_model_file)
-        toolkit_options = _toolkit_read_kwargs(toolkit_env, toolkit_config, toolkit_version)
+        options = options or ToolkitReadOptions()
 
         reader: DMSImporter
         if format == "neat":
             reader = DMSTableImporter.from_yaml(path)
         elif format == "toolkit":
-            reader = DMSAPIImporter.from_yaml(
-                path,
-                data_model_file=data_model_file,
-                **toolkit_options,
-            )
+            reader = DMSAPIImporter.from_yaml(path, data_model_file=data_model_file, options=options)
         else:
             raise UserInputError(f"Unsupported format: {format}. Supported formats are 'neat' and 'toolkit'.")
 
@@ -514,9 +496,7 @@ def yaml(
         format (Literal["neat", "toolkit"]): The format of the input file(s).
             - "neat": Neat's DMS table format.
             - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
-        toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
-        toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
-        toolkit_version (str | None): Override ``version`` / ``viewVersion`` template variables.
+<<TOOLKIT_ARGS>>
 
     """
     self._yaml(
@@ -524,7 +504,7 @@ def yaml(
         format=format,
         data_model_file=None,
         fix=False,
-        **_toolkit_read_kwargs(toolkit_env, toolkit_config, toolkit_version),
+        options=ToolkitReadOptions.from_args(toolkit_env, toolkit_config, toolkit_version),
     )
 
 
@@ -545,16 +525,14 @@ def read_yaml_alpha_fix(
             - "neat": Neat's DMS table format.
             - "toolkit": Cognite DMS API format which is the format used by Cognite Toolkit.
         fix (bool): If True, automatically apply fixes for fixable issues.
-        toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
-        toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
-        toolkit_version (str | None): Override ``version`` / ``viewVersion`` template variables.
+<<TOOLKIT_ARGS>>
 
     """
     self._yaml(
         io=io,
         format=format,
         fix=fix,
-        **_toolkit_read_kwargs(toolkit_env, toolkit_config, toolkit_version),
+        options=ToolkitReadOptions.from_args(toolkit_env, toolkit_config, toolkit_version),
     )
 
 
@@ -577,9 +555,7 @@ def read_yaml_alpha_data_model_file(
         data_model_file (str | Path | None): Optional specific data model file to read. This is only applicable when
             format is set to "toolkit", and when io contains multiple data model YAML files.
             A file name or full path may be given; only the file name is used for matching.
-        toolkit_env (str | None): Toolkit environment name (e.g. ``dev``) for config overlay resolution.
-        toolkit_config (str | Path | None): Explicit Toolkit config YAML to merge on top of ``default.config.yaml``.
-        toolkit_version (str | None): Override ``version`` / ``viewVersion`` template variables.
+<<TOOLKIT_ARGS>>
 
     """
     self._yaml(
@@ -587,7 +563,7 @@ def read_yaml_alpha_data_model_file(
         format=format,
         data_model_file=data_model_file,
         fix=False,
-        **_toolkit_read_kwargs(toolkit_env, toolkit_config, toolkit_version),
+        options=ToolkitReadOptions.from_args(toolkit_env, toolkit_config, toolkit_version),
     )
 
 
@@ -640,6 +616,7 @@ def cdf(
 
 for _yaml_reader in (yaml, read_yaml_alpha_fix, read_yaml_alpha_data_model_file):
     if _yaml_reader.__doc__:
+        _yaml_reader.__doc__ = _yaml_reader.__doc__.replace("<<TOOLKIT_ARGS>>", TOOLKIT_READ_ARGS_DOC)
         _yaml_reader.__doc__ += _TOOLKIT_YAML_READ_NOTES
 
 if ReadPhysicalDataModel._yaml.__doc__:

--- a/docs/data_modeling/toolkit_yaml.md
+++ b/docs/data_modeling/toolkit_yaml.md
@@ -1,0 +1,26 @@
+# Reading Toolkit YAML
+
+NEAT can read Cognite Toolkit module YAML directly via `neat.physical_data_model.read.yaml()` with `format="toolkit"`.
+
+```python
+neat.physical_data_model.read.yaml(
+    "path/to/modules/my_module/data_modeling/my_model",
+    format="toolkit",
+)
+```
+
+## Template variables
+
+Toolkit modules use `{{ variable }}` placeholders in YAML files. When `format="toolkit"`, NEAT resolves these from Toolkit config before import:
+
+- `default.config.yaml` at the toolkit project root
+- Environment overlays such as `config.dev.yaml` (selected via `toolkit_env`, or from `cdf.toml` when present)
+- Module-level overrides under `variables.modules`
+
+Optional parameters on `read.yaml()`:
+
+| Parameter | Purpose |
+|-----------|---------|
+| `toolkit_env` | Select a config overlay (e.g. `"dev"`, `"prod"`) |
+| `toolkit_config` | Merge an explicit config YAML on top of defaults |
+| `toolkit_version` | Override `version` and `viewVersion` template variables |

--- a/docs/data_modeling/toolkit_yaml.md
+++ b/docs/data_modeling/toolkit_yaml.md
@@ -11,7 +11,9 @@ neat.physical_data_model.read.yaml(
 
 Pass the **module** (or `data_modeling`) directory, not a parent folder of the Toolkit project. `cdf.toml` `default_config_yaml` (often `config.sandbox.yaml`) is used as the environment overlay unless you pass `toolkit_env`. Optional `toolkit_env="sandbox"` selects `config.sandbox.yaml` explicitly.
 
-Non-schema YAML (`config.*.yaml`, `build_info.*.yaml`, …) is ignored during directory reads.
+Non-schema YAML (`config.*.yaml`, `build_info.*.yaml`, Yamale files under `validation/schemas/`, …) is ignored during directory reads. Only files named like Toolkit resources (`*.Container.yaml`, `*.View.yaml`, …) are imported.
+
+When reading a `modules/` tree, template variables are resolved from each file's module path so nested `variables.modules.<module>.*` keys apply correctly.
 
 ## Template variables
 

--- a/docs/data_modeling/toolkit_yaml.md
+++ b/docs/data_modeling/toolkit_yaml.md
@@ -9,6 +9,10 @@ neat.physical_data_model.read.yaml(
 )
 ```
 
+Pass the **module** (or `data_modeling`) directory, not a parent folder of the Toolkit project. `cdf.toml` `default_config_yaml` (often `config.sandbox.yaml`) is used as the environment overlay unless you pass `toolkit_env`. Optional `toolkit_env="sandbox"` selects `config.sandbox.yaml` explicitly.
+
+Non-schema YAML (`config.*.yaml`, `build_info.*.yaml`, …) is ignored during directory reads.
+
 ## Template variables
 
 Toolkit modules use `{{ variable }}` placeholders in YAML files. When `format="toolkit"`, NEAT resolves these from Toolkit config before import:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
   - Data Modeling:
       - Principles: data_modeling/principles.md
       - Modes: data_modeling/modes.md
+      - Toolkit YAML: data_modeling/toolkit_yaml.md
       - Data Modeling in Excel:
         - Overview: data_modeling/excel/data_model.md
         - Physical Data Model:

--- a/tests/data/toolkit_substitution/config.dev.yaml
+++ b/tests/data/toolkit_substitution/config.dev.yaml
@@ -1,0 +1,2 @@
+variables:
+  schemaSpace: dev_space

--- a/tests/data/toolkit_substitution/default.config.yaml
+++ b/tests/data/toolkit_substitution/default.config.yaml
@@ -1,0 +1,7 @@
+variables:
+  version: "1"
+  viewVersion: "1"
+  schemaSpace: global_space
+  modules:
+    test:
+      schemaSpace: module_space

--- a/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/MyContainer.container.yaml
+++ b/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/MyContainer.container.yaml
@@ -1,0 +1,6 @@
+space: {{ schemaSpace }}
+externalId: MyContainer
+properties:
+  name:
+    type:
+      type: text

--- a/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/MyModel.datamodel.yaml
+++ b/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/MyModel.datamodel.yaml
@@ -1,0 +1,7 @@
+space: {{ schemaSpace }}
+externalId: MyModel
+version: {{ viewVersion }}
+views:
+  - space: {{ schemaSpace }}
+    externalId: MyView
+    version: {{ viewVersion }}

--- a/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/MyView.view.yaml
+++ b/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/MyView.view.yaml
@@ -1,0 +1,9 @@
+space: {{ schemaSpace }}
+externalId: MyView
+version: {{ viewVersion }}
+properties:
+  name:
+    container:
+      space: {{ schemaSpace }}
+      externalId: MyContainer
+    containerPropertyIdentifier: name

--- a/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
+++ b/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
@@ -191,6 +191,58 @@ class TestToolkitYamlImport:
         assert schema.data_model.space == "sandbox_space"
         assert schema.data_model.version == "v1"
 
+    def test_modules_tree_resolves_nested_variables_per_file(self, tmp_path: Path) -> None:
+        """Reading modules/ must use each file's module path for nested Toolkit variables.
+
+        Selecting the solution DataModel still imports a mapped container from another
+        module, and must not fail on a sibling DataModel whose version is only defined
+        under that sibling module.
+        """
+        project = tmp_path / "project"
+        e360 = project / "modules" / "emergency360" / "data_modeling" / "dm_sol"
+        lci = project / "modules" / "lci" / "data_modeling" / "dm_ent"
+        valve = project / "modules" / "valve_track" / "data_modeling" / "dm_ent"
+        e360.mkdir(parents=True)
+        lci.mkdir(parents=True)
+        valve.mkdir(parents=True)
+        (project / "cdf.toml").write_text(
+            '[cdf]\ndefault_config_yaml = "config.sandbox.yaml"\n',
+            encoding="utf-8",
+        )
+        (project / "config.sandbox.yaml").write_text(
+            "variables:\n  modules:\n    sp_id_prefix: sp\n    LCI_PREFIX: LCI\n"
+            "    emergency360:\n      E360_SOL_DM_VERSION: 1.0.0\n"
+            "    valve_track:\n      VALVE_MANAGEMENT_ENT_DM_VERSION: 1.18.0\n",
+            encoding="utf-8",
+        )
+        _write(
+            e360 / "Sol.DataModel.yaml",
+            "space: {{ sp_id_prefix }}_sol\nexternalId: dm_sol\nversion: {{ E360_SOL_DM_VERSION }}\n"
+            "views:\n  - space: {{ sp_id_prefix }}_sol\n    externalId: Tag\n"
+            "    version: {{ E360_SOL_DM_VERSION }}\n",
+        )
+        _write(
+            e360 / "Tag.View.yaml",
+            "space: {{ sp_id_prefix }}_sol\nexternalId: Tag\nversion: {{ E360_SOL_DM_VERSION }}\n"
+            "properties:\n  tagName:\n    container:\n      space: {{ sp_id_prefix }}_ent\n"
+            "      externalId: {{ LCI_PREFIX }}Tag\n      type: container\n"
+            "    containerPropertyIdentifier: name\n",
+        )
+        _write(
+            lci / "Tag.Container.yaml",
+            "space: {{ sp_id_prefix }}_ent\nexternalId: {{ LCI_PREFIX }}Tag\n"
+            "properties:\n  name:\n    type:\n      type: text\n",
+        )
+        _write(
+            valve / "Valve.DataModel.yaml",
+            "space: {{ sp_id_prefix }}_ent\nexternalId: dm_valve\n"
+            "version: {{ VALVE_MANAGEMENT_ENT_DM_VERSION }}\nviews: []\n",
+        )
+
+        schema = _import_schema(project / "modules", data_model_file="Sol.DataModel.yaml")
+        assert schema.data_model.version == "1.0.0"
+        assert {container.external_id for container in schema.containers} == {"LCITag"}
+
     def test_yamale_schema_files_are_not_treated_as_dms_resources(self, tmp_path: Path) -> None:
         assert DMSAPIImporter._is_toolkit_schema_yaml(tmp_path / "data_model_container.yaml") is False
         assert DMSAPIImporter._is_toolkit_schema_yaml(tmp_path / "Tag.Container.yaml") is True

--- a/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
+++ b/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
@@ -191,6 +191,10 @@ class TestToolkitYamlImport:
         assert schema.data_model.space == "sandbox_space"
         assert schema.data_model.version == "v1"
 
+    def test_yamale_schema_files_are_not_treated_as_dms_resources(self, tmp_path: Path) -> None:
+        assert DMSAPIImporter._is_toolkit_schema_yaml(tmp_path / "data_model_container.yaml") is False
+        assert DMSAPIImporter._is_toolkit_schema_yaml(tmp_path / "Tag.Container.yaml") is True
+
     def test_repo_cdf_toml_does_not_hijack_unrelated_paths(self) -> None:
         assert find_toolkit_project_root(CYCLIC_REVERSE_ONLY) is None
 

--- a/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
+++ b/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cognite.neat._data_model.importers import DMSAPIImporter
+from cognite.neat._data_model.importers._toolkit_variables import (
+    find_toolkit_project_root,
+    substitute_toolkit_variables,
+)
+from cognite.neat._data_model.models.dms import RequestSchema
+from cognite.neat._exceptions import FileReadException
+
+TOOLKIT_FIXTURE = Path(__file__).resolve().parents[3] / "data" / "toolkit_substitution"
+DATA_MODEL_DIR = TOOLKIT_FIXTURE / "modules" / "test" / "data_modeling" / "my_model"
+CYCLIC_REVERSE_ONLY = Path(__file__).resolve().parents[3] / "data" / "snapshots" / "local" / "cyclic_reverse_only"
+
+
+def _import_schema(model_dir: Path, **kwargs: Any) -> RequestSchema:
+    return DMSAPIImporter.from_yaml(model_dir, **kwargs).to_data_model()
+
+
+class TestToolkitYamlImport:
+    def test_import_resolves_variables(self) -> None:
+        assert find_toolkit_project_root(DATA_MODEL_DIR) == TOOLKIT_FIXTURE
+
+        schema = _import_schema(DATA_MODEL_DIR)
+
+        assert schema.data_model.space == "module_space"
+        assert schema.data_model.external_id == "MyModel"
+        assert schema.data_model.version == "1"
+
+    @pytest.mark.parametrize(
+        ("kwargs", "assertions"),
+        [
+            pytest.param(
+                {"data_model_file": "MyModel.datamodel.yaml"},
+                lambda schema: schema.data_model.external_id == "MyModel",
+                id="explicit-data-model-file",
+            ),
+            pytest.param(
+                {"toolkit_version": "9"},
+                lambda schema: schema.data_model.version == "9" and all(view.version == "9" for view in schema.views),
+                id="toolkit-version-override",
+            ),
+        ],
+    )
+    def test_import_options(self, kwargs: dict[str, Any], assertions: Any) -> None:
+        schema = _import_schema(DATA_MODEL_DIR, **kwargs)
+        assert assertions(schema)
+
+    @pytest.mark.parametrize(
+        "layout",
+        [
+            pytest.param("prod-overlay", id="prod-overlay"),
+            pytest.param("cdf-toml-org", id="cdf-toml-org"),
+        ],
+    )
+    def test_import_alternate_toolkit_config_layouts(self, tmp_path: Path, layout: str) -> None:
+        project = tmp_path / "project"
+
+        if layout == "prod-overlay":
+            model_dir = project / "modules" / "mod" / "data_modeling" / "dm"
+            model_dir.mkdir(parents=True)
+            (project / "default.config.yaml").write_text(
+                "variables:\n  schemaSpace: base_space\n  viewVersion: v1\n",
+                encoding="utf-8",
+            )
+            (project / "config.prod.yaml").write_text(
+                "variables:\n  schemaSpace: prod_space\n",
+                encoding="utf-8",
+            )
+            (model_dir / "Model.datamodel.yaml").write_text(
+                "space: {{ schemaSpace }}\nexternalId: Model\nversion: {{ viewVersion }}\nviews: []\n",
+                encoding="utf-8",
+            )
+            schema = _import_schema(model_dir, toolkit_env="prod")
+            assert schema.data_model.space == "prod_space"
+            assert schema.data_model.version == "v1"
+            return
+
+        org = project / "beyond-the-plant"
+        model_dir = org / "modules" / "btp" / "data_modeling" / "dm"
+        model_dir.mkdir(parents=True)
+        (project / "cdf.toml").write_text(
+            '[cdf]\ndefault_organization_dir = "beyond-the-plant"\ndefault_env = "dev"\n',
+            encoding="utf-8",
+        )
+        (org / "config.dev.yaml").write_text(
+            "variables:\n  version: v1.5.0\n  viewVersion: v1.5.0\n  isaSchemaSpace: sp_test\n",
+            encoding="utf-8",
+        )
+        (model_dir / "Model.datamodel.yaml").write_text(
+            "space: {{ isaSchemaSpace }}\nexternalId: Model\nversion: {{ version }}\nviews: []\n",
+            encoding="utf-8",
+        )
+        schema = _import_schema(model_dir)
+        assert schema.data_model.space == "sp_test"
+        assert schema.data_model.version == "v1.5.0"
+
+    def test_load_globals_from_modules_level_without_default_config(self, tmp_path: Path) -> None:
+        """Match Toolkit projects that only ship config.<env>.yaml with globals under variables.modules."""
+        project = tmp_path / "project"
+        model_dir = project / "modules" / "pidm" / "data_models"
+        model_dir.mkdir(parents=True)
+        (project / "cdf.toml").write_text(
+            '[cdf]\ndefault_config_yaml = "config.dev.yaml"\n',
+            encoding="utf-8",
+        )
+        (project / "config.dev.yaml").write_text(
+            "variables:\n  modules:\n    dm_sol_pidm_version: v0.1.15\n",
+            encoding="utf-8",
+        )
+        (model_dir / "Model.datamodel.yaml").write_text(
+            "space: sp_pidm\nexternalId: Model\nversion: {{ dm_sol_pidm_version }}\nviews: []\n",
+            encoding="utf-8",
+        )
+
+        schema = _import_schema(model_dir)
+        assert schema.data_model.version == "v0.1.15"
+
+    def test_repo_cdf_toml_does_not_hijack_unrelated_paths(self) -> None:
+        assert find_toolkit_project_root(CYCLIC_REVERSE_ONLY) is None
+
+    def test_substitute_unresolved_raises(self) -> None:
+        with pytest.raises(FileReadException, match="Unresolved toolkit variable"):
+            substitute_toolkit_variables("space: {{ missingVar }}", {}, source="test.yaml")

--- a/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
+++ b/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
@@ -119,6 +119,78 @@ class TestToolkitYamlImport:
         schema = _import_schema(model_dir)
         assert schema.data_model.version == "v0.1.15"
 
+    def test_sandbox_overlay_wins_over_dev_and_module_default(self, tmp_path: Path) -> None:
+        """cdf.toml default_config_yaml=sandbox must win even when config.dev.yaml exists.
+
+        Module-local default.config.yaml must not become the project root.
+        """
+        project = tmp_path / "digital-twin-dev"
+        module = project / "modules" / "emergency360"
+        model_dir = module / "data_modeling" / "dm"
+        model_dir.mkdir(parents=True)
+        (project / "cdf.toml").write_text(
+            '[cdf]\ndefault_config_yaml = "config.sandbox.yaml"\n',
+            encoding="utf-8",
+        )
+        (project / "config.dev.yaml").write_text(
+            "variables:\n  modules:\n    viewVersion: v-dev\n    YGGDRASIL_INSTANCE_SPACE: ygg-dev\n",
+            encoding="utf-8",
+        )
+        (project / "config.sandbox.yaml").write_text(
+            "variables:\n  modules:\n    viewVersion: v-sbx\n    YGGDRASIL_INSTANCE_SPACE: ygg\n",
+            encoding="utf-8",
+        )
+        (module / "default.config.yaml").write_text(
+            "E360_PREFIX: E360\nYGGDRASIL_INSTANCE_SPACE: ygg-module\n",
+            encoding="utf-8",
+        )
+        (model_dir / "Model.datamodel.yaml").write_text(
+            "space: {{ YGGDRASIL_INSTANCE_SPACE }}\nexternalId: {{ E360_PREFIX }}\n"
+            "version: {{ viewVersion }}\nviews: []\n",
+            encoding="utf-8",
+        )
+
+        assert find_toolkit_project_root(model_dir) == project
+        schema = _import_schema(model_dir)
+        assert schema.data_model.space == "ygg"
+        assert schema.data_model.external_id == "E360"
+        assert schema.data_model.version == "v-sbx"
+
+        schema_dev = _import_schema(model_dir, toolkit_env="dev")
+        assert schema_dev.data_model.version == "v-dev"
+        assert schema_dev.data_model.space == "ygg-dev"
+
+    def test_project_root_and_parent_folder_resolve_sandbox(self, tmp_path: Path) -> None:
+        """read.yaml(io=project) and io=parent-of-project must find cdf.toml + sandbox overlay."""
+        parent = tmp_path / "ABP-digital-twin"
+        project = parent / "digital-twin-dev"
+        model_dir = project / "modules" / "emergency360" / "data_modeling" / "dm"
+        model_dir.mkdir(parents=True)
+        (project / "cdf.toml").write_text(
+            '[cdf]\ndefault_config_yaml = "config.sandbox.yaml"\n',
+            encoding="utf-8",
+        )
+        (project / "config.sandbox.yaml").write_text(
+            "variables:\n  modules:\n    ep_id_prefix: '[abp-sbx]'\n    viewVersion: v1\n"
+            "    schemaSpace: sandbox_space\n",
+            encoding="utf-8",
+        )
+        (project / "build_info.dev.yaml").write_text(
+            "modules:\n  version: 0.8.103\n  # {{ ep_id_prefix }} must not be substituted in this file\n",
+            encoding="utf-8",
+        )
+        (model_dir / "Model.datamodel.yaml").write_text(
+            "space: {{ schemaSpace }}\nexternalId: Model\nversion: {{ viewVersion }}\nviews: []\n",
+            encoding="utf-8",
+        )
+
+        assert find_toolkit_project_root(project) == project
+        assert find_toolkit_project_root(parent) == project
+
+        schema = _import_schema(parent, data_model_file="Model.datamodel.yaml")
+        assert schema.data_model.space == "sandbox_space"
+        assert schema.data_model.version == "v1"
+
     def test_repo_cdf_toml_does_not_hijack_unrelated_paths(self) -> None:
         assert find_toolkit_project_root(CYCLIC_REVERSE_ONLY) is None
 


### PR DESCRIPTION
﻿# Description

Resolve Toolkit `{{ variable }}` placeholders when reading module YAML with `format="toolkit"`, using Toolkit config (`default.config.yaml`, env overlays, `cdf.toml`, and module overrides). Options are collated in `ToolkitReadOptions` and config is loaded once per directory; strategy is documented in `_toolkit_variables.py`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Added

- Add Toolkit template variable substitution for `format="toolkit"` YAML reads via `toolkit_env`, `toolkit_config`, and `toolkit_version`.
