### PR TITLE
Derive governed spaces for toolkit YAML imports and fix multi-space Excel export

### DIFF
--- a/cognite/neat/_data_model/exporters/_table_exporter/writer.py
+++ b/cognite/neat/_data_model/exporters/_table_exporter/writer.py
@@ -387,27 +387,41 @@ class DMSTableWriter:
         self, view: ViewRequest, prop_id: str, prop: ViewRequestProperty, container: ContainerProperties
     ) -> DMSProperty:
         container_properties: dict[str, Any] = {}
+        has_container_row = False
         if isinstance(prop, ViewCorePropertyRequest):
             identifier = (prop.container, prop.container_property_identifier)
             if identifier in container.properties_by_id:
                 container_properties = container.properties_by_id[identifier]
+                has_container_row = True
+        synthesize_direct = self._needs_synthesized_direct_relation(prop, has_container_row)
         view_properties: dict[str, Any] = dict(
             view=self._create_view_entity(view), view_property=prop_id, name=prop.name, description=prop.description
         )
-        if connection := self._write_view_property_connection(prop):
+        connection = self._write_view_property_connection(prop)
+        if connection is None and synthesize_direct:
+            connection = ParsedEntity("", "direct", properties={})
+        if connection is not None:
             view_properties["connection"] = connection
         if view_value_type := self._write_view_property_value_type(prop):
             view_properties["value_type"] = view_value_type
         view_min_count = self._write_view_property_min_count(prop)
+        if view_min_count is None and synthesize_direct:
+            view_min_count = 0
         if view_min_count is not None:
             view_properties["min_count"] = view_min_count
         view_max_count = self._write_view_property_max_count(prop)
+        if view_max_count == "container" and synthesize_direct:
+            view_max_count = 1
         if view_max_count != "container":
             view_properties["max_count"] = view_max_count
 
         # Overwrite container properties with view properties where relevant.
         args = container_properties | view_properties
         return DMSProperty(**args)
+
+    @staticmethod
+    def _needs_synthesized_direct_relation(prop: ViewRequestProperty, has_container_row: bool) -> bool:
+        return isinstance(prop, ViewCorePropertyRequest) and prop.source is not None and not has_container_row
 
     def _write_view_property_connection(self, prop: ViewRequestProperty) -> ParsedEntity | None:
         if isinstance(prop, ViewCorePropertyRequest):

--- a/cognite/neat/_data_model/importers/_api_importer.py
+++ b/cognite/neat/_data_model/importers/_api_importer.py
@@ -13,6 +13,7 @@ from cognite.neat._data_model.importers._toolkit_variables import (
     ToolkitProjectContext,
     ToolkitReadOptions,
     _is_filesystem_path,
+    populate_toolkit_governed_spaces,
     prepare_toolkit_yaml_content,
 )
 from cognite.neat._data_model.models.dms import (
@@ -41,14 +42,22 @@ class DMSAPIImporter(DMSImporter):
 
     ENCODING = "utf-8"
 
-    def __init__(self, schema: RequestSchema | dict[str, Any]) -> None:
+    def __init__(
+        self,
+        schema: RequestSchema | dict[str, Any],
+        *,
+        derive_governed_spaces: bool = False,
+    ) -> None:
         self._schema = schema
+        self._derive_governed_spaces = derive_governed_spaces
 
     def to_data_model(self) -> RequestSchema:
-        if isinstance(self._schema, RequestSchema):
-            return self._schema
         try:
-            return RequestSchema.model_validate(self._schema)
+            schema = (
+                self._schema
+                if isinstance(self._schema, RequestSchema)
+                else RequestSchema.model_validate(self._schema)
+            )
         except ValidationError as e:
             context = ValidationContext()
             errors = [
@@ -56,6 +65,9 @@ class DMSAPIImporter(DMSImporter):
                 for error in e.errors(include_input=True, include_url=False)
             ]
             raise DataModelImportException(errors) from None
+        if self._derive_governed_spaces:
+            return populate_toolkit_governed_spaces(schema)
+        return schema
 
     @classmethod
     def from_cdf(cls, data_model: DataModelReference, client: NeatClient) -> "DMSAPIImporter":
@@ -144,9 +156,12 @@ class DMSAPIImporter(DMSImporter):
         )
         source = cls._display_name(yaml_file)
         if yaml_file.suffix.lower() in {".yaml", ".yml", ".json"}:
-            return cls(cls._load_toolkit_yaml_file(yaml_file, options))
+            return cls(cls._load_toolkit_yaml_file(yaml_file, options), derive_governed_spaces=True)
         elif yaml_file.is_dir():
-            return cls(cls._read_yaml_files(yaml_file, data_model_file, options=options))
+            return cls(
+                cls._read_yaml_files(yaml_file, data_model_file, options=options),
+                derive_governed_spaces=True,
+            )
         raise FileReadException(source.as_posix(), f"Unsupported file type: {source.suffix}")
 
     @classmethod
@@ -215,7 +230,7 @@ class DMSAPIImporter(DMSImporter):
         Template variables are resolved per file from that file's module path, so a read of
         ``modules/`` still sees nested keys such as ``variables.modules.valve_track.*``.
         When ``data_model_file`` selects one model, sibling DataModel/view/node files are
-        not parsed.
+        not parsed; containers from other modules remain available for mapping.
         """
         options = options or ToolkitReadOptions()
         schema_data: dict[str, Any] = {}
@@ -238,18 +253,24 @@ class DMSAPIImporter(DMSImporter):
         if data_model_file_name and len(selected_dm_files) == 1 and _is_filesystem_path(selected_dm_files[0]):
             resource_root = selected_dm_files[0].parent
 
+        view_items: list[tuple[Path | None, dict[str, Any]]] = []
+        container_items: list[tuple[Path | None, dict[str, Any]]] = []
+        space_items: list[tuple[Path | None, dict[str, Any]]] = []
+        node_items: list[tuple[Path | None, dict[str, Any]]] = []
+
         for yaml_file in schema_files:
             stem = yaml_file.stem.casefold()
+            origin = yaml_file if _is_filesystem_path(yaml_file) else None
             if stem.endswith("datamodel") and data_model_file_name and yaml_file.name != data_model_file_name:
                 continue
             if (
                 resource_root is not None
                 and stem.endswith(("view", "node"))
-                and not cls._is_path_under(yaml_file, resource_root)
+                and (origin is None or not cls._is_path_under(origin, resource_root))
             ):
                 continue
             quote_version = stem.endswith("datamodel") or stem.endswith("view")
-            file_dir = yaml_file.parent
+            file_dir = yaml_file.parent if origin is not None else config_dir
             file_variables = context.variables_for(file_dir, options.version) if context is not None else None
             data = cls._load_toolkit_yaml_file(
                 yaml_file,
@@ -271,13 +292,13 @@ class DMSAPIImporter(DMSImporter):
                 data_model = data
 
             elif stem.endswith("container"):
-                schema_data.setdefault("containers", []).extend(list_data)
+                container_items.extend((origin, item) for item in list_data if isinstance(item, dict))
             elif stem.endswith("view"):
-                schema_data.setdefault("views", []).extend(list_data)
+                view_items.extend((origin, item) for item in list_data if isinstance(item, dict))
             elif stem.endswith("space"):
-                schema_data.setdefault("spaces", []).extend(list_data)
+                space_items.extend((origin, item) for item in list_data if isinstance(item, dict))
             elif stem.endswith("node"):
-                schema_data.setdefault("nodeTypes", []).extend(list_data)
+                node_items.extend((origin, item) for item in list_data if isinstance(item, dict))
             # Ignore other files
         if data_model is None:
             raise FileReadException(
@@ -285,7 +306,136 @@ class DMSAPIImporter(DMSImporter):
                 "No data model file found in directory.",
             )
         schema_data["dataModel"] = data_model
+        views, containers, spaces, nodes = cls._select_resources_for_data_model(
+            resource_root,
+            view_items,
+            container_items,
+            space_items,
+            node_items,
+            data_model,
+        )
+        if views:
+            schema_data["views"] = views
+        if containers:
+            schema_data["containers"] = containers
+        if spaces:
+            schema_data["spaces"] = spaces
+        if nodes:
+            schema_data["nodeTypes"] = nodes
         return schema_data
+
+    @classmethod
+    def _select_resources_for_data_model(
+        cls,
+        resource_root: Path | None,
+        view_items: list[tuple[Path | None, dict[str, Any]]],
+        container_items: list[tuple[Path | None, dict[str, Any]]],
+        space_items: list[tuple[Path | None, dict[str, Any]]],
+        node_items: list[tuple[Path | None, dict[str, Any]]],
+        data_model: dict[str, Any],
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+        """Keep the selected model's folder, plus containers those views map to (often enterprise).
+
+        Solution views typically map to enterprise containers in a sibling folder. Restricting
+        to the DataModel directory dropped those containers and broke reverse/direct relations.
+        Sibling *views* (the other data model) stay excluded.
+        """
+        if resource_root is None:
+            return (
+                [item for _, item in view_items],
+                [item for _, item in container_items],
+                [item for _, item in space_items],
+                [item for _, item in node_items],
+            )
+
+        def is_local(origin: Path | None) -> bool:
+            return origin is not None and cls._is_path_under(origin, resource_root)
+
+        views = [item for origin, item in view_items if is_local(origin)]
+        container_by_id: dict[tuple[str, str], dict[str, Any]] = {}
+        needed_containers: set[tuple[str, str]] = {
+            ref for view in views for ref in cls._container_ids_from_view(view)
+        }
+        for origin, item in container_items:
+            key = (str(item.get("space") or ""), str(item.get("externalId") or ""))
+            if not key[0] or not key[1]:
+                continue
+            container_by_id.setdefault(key, item)
+            if is_local(origin):
+                needed_containers.add(key)
+
+        pending = list(needed_containers)
+        while pending:
+            item = container_by_id.get(pending.pop())
+            if item is None:
+                continue
+            for extra in cls._required_container_ids(item):
+                if extra not in needed_containers:
+                    needed_containers.add(extra)
+                    pending.append(extra)
+
+        containers: list[dict[str, Any]] = []
+        seen_containers: set[tuple[str, str]] = set()
+        for _, item in container_items:
+            key = (str(item.get("space") or ""), str(item.get("externalId") or ""))
+            if key not in needed_containers or key in seen_containers:
+                continue
+            seen_containers.add(key)
+            containers.append(item)
+
+        space_ids = {str(data_model["space"])} if data_model.get("space") else set()
+        space_ids.update(str(view["space"]) for view in views if view.get("space"))
+        space_ids.update(str(container["space"]) for container in containers if container.get("space"))
+        spaces: list[dict[str, Any]] = []
+        seen_spaces: set[str] = set()
+        for origin, item in space_items:
+            space_id = str(item.get("space", ""))
+            if not space_id or space_id in seen_spaces:
+                continue
+            if is_local(origin) or space_id in space_ids:
+                seen_spaces.add(space_id)
+                spaces.append(item)
+
+        nodes = [item for origin, item in node_items if is_local(origin)]
+        return views, containers, spaces, nodes
+
+    @staticmethod
+    def _container_ref(node: object) -> tuple[str, str] | None:
+        if not isinstance(node, dict) or node.get("type", "container") != "container":
+            return None
+        space, external_id = node.get("space"), node.get("externalId")
+        if space and external_id:
+            return str(space), str(external_id)
+        return None
+
+    @classmethod
+    def _container_ids_from_view(cls, view: dict[str, Any]) -> set[tuple[str, str]]:
+        refs: set[tuple[str, str]] = set()
+        has_data = (view.get("filter") or {}).get("hasData") or []
+        if isinstance(has_data, dict):
+            has_data = [has_data]
+        for item in has_data:
+            if ref := cls._container_ref(item):
+                refs.add(ref)
+        for prop in (view.get("properties") or {}).values():
+            if not isinstance(prop, dict):
+                continue
+            if ref := cls._container_ref(prop.get("container")):
+                refs.add(ref)
+            through = prop.get("through")
+            if isinstance(through, dict):
+                if ref := cls._container_ref(through.get("source")):
+                    refs.add(ref)
+        return refs
+
+    @classmethod
+    def _required_container_ids(cls, container: dict[str, Any]) -> set[tuple[str, str]]:
+        refs: set[tuple[str, str]] = set()
+        for constraint in (container.get("constraints") or {}).values():
+            if isinstance(constraint, dict):
+                if ref := cls._container_ref(constraint.get("require")):
+                    refs.add(ref)
+        return refs
 
     @staticmethod
     def _is_path_under(path: Path, root: Path) -> bool:

--- a/cognite/neat/_data_model/importers/_toolkit_variables.py
+++ b/cognite/neat/_data_model/importers/_toolkit_variables.py
@@ -31,6 +31,11 @@ Strategy (pipeline)
 5. **Substitute** — Replace ``{{ name }}`` in YAML text *before* parsing.
    Unresolved names raise ``FileReadException`` with available variables listed.
 
+6. **Governed spaces** (toolkit directory imports) — Mark every space found in
+   the imported module as NEAT-governed so multi-space local YAML validates
+   against local containers/views instead of falling back to CDF. Explicit
+   Excel ``governedSpaces`` metadata is never overridden.
+
 Performance note
 ----------------
 Load config once per directory import via :class:`ToolkitProjectContext`, then
@@ -501,6 +506,11 @@ def prepare_toolkit_yaml_content(
     if variables is None:
         variables = load_toolkit_variables(data_model_dir or source.parent, options)
     return substitute_toolkit_variables(content, variables, source=str(source))
+
+
+# ---------------------------------------------------------------------------
+# Multi-space toolkit imports → NEAT governed spaces
+# ---------------------------------------------------------------------------
 
 
 def populate_toolkit_governed_spaces(schema: RequestSchema) -> RequestSchema:

--- a/cognite/neat/_data_model/importers/_toolkit_variables.py
+++ b/cognite/neat/_data_model/importers/_toolkit_variables.py
@@ -47,6 +47,7 @@ from typing import Any
 
 import yaml
 
+from cognite.neat._data_model.models.dms import RequestSchema, SpaceRequest
 from cognite.neat._exceptions import FileReadException
 
 if sys.version_info >= (3, 11):
@@ -500,3 +501,29 @@ def prepare_toolkit_yaml_content(
     if variables is None:
         variables = load_toolkit_variables(data_model_dir or source.parent, options)
     return substitute_toolkit_variables(content, variables, source=str(source))
+
+
+def populate_toolkit_governed_spaces(schema: RequestSchema) -> RequestSchema:
+    """Mark all spaces present in a toolkit module import as NEAT-governed.
+
+    Toolkit modules are multi-space by design (data model space plus domain spaces).
+    Without this, NEAT only governs the data model space and falls back to CDF for
+    views/containers in other spaces — which is surprising when reading local YAML.
+
+    Explicit ``governedSpaces`` from NEAT Excel metadata is left unchanged.
+    """
+    if schema.extra.governed_spaces:
+        return schema
+
+    space_ids = {schema.data_model.space}
+    space_ids.update(space.space for space in schema.spaces)
+    space_ids.update(view.space for view in schema.views)
+    space_ids.update(container.space for container in schema.containers)
+
+    additional = sorted(space_ids - {schema.data_model.space})
+    if not additional:
+        return schema
+
+    updated = schema.model_copy(deep=True)
+    updated.extra.governed_spaces = [SpaceRequest(space=space_id) for space_id in additional]
+    return updated

--- a/cognite/neat/_data_model/rules/dms/_ai_readiness.py
+++ b/cognite/neat/_data_model/rules/dms/_ai_readiness.py
@@ -301,7 +301,7 @@ class EnumerationMissingName(DataModelRule):
         recommendations: list[Recommendation] = []
 
         for container_ref in self.validation_resources.merged.containers:
-            container = self.validation_resources.select_container(container_ref)
+            container = self.validation_resources.select_container(container_ref, source="merged")
 
             if not container:
                 raise RuntimeError(f"{type(self).__name__}: Container {container_ref!s} not found. This is a bug.")
@@ -361,7 +361,7 @@ class EnumerationMissingDescription(DataModelRule):
         recommendations: list[Recommendation] = []
 
         for container_ref in self.validation_resources.merged.containers:
-            container = self.validation_resources.select_container(container_ref)
+            container = self.validation_resources.select_container(container_ref, source="merged")
             if not container:
                 raise RuntimeError(f"{self.__class__.__name__}: Container {container_ref!s} not found. This is a bug.")
 

--- a/cognite/neat/_data_model/rules/dms/_containers.py
+++ b/cognite/neat/_data_model/rules/dms/_containers.py
@@ -167,7 +167,7 @@ class RequiredContainerDoesNotExist(DataModelRule):
         errors: list[ConsistencyError] = []
 
         for container_ref in self.validation_resources.merged.containers:
-            container = self.validation_resources.select_container(container_ref)
+            container = self.validation_resources.select_container(container_ref, source="merged")
 
             if not container:
                 raise RuntimeError(

--- a/cognite/neat/_data_model/rules/dms/_limits.py
+++ b/cognite/neat/_data_model/rules/dms/_limits.py
@@ -253,7 +253,7 @@ class ContainerPropertyCountIsOutOfLimits(DataModelRule):
         recommendations: list[Recommendation] = []
         # Single loop over all containers
         for container_ref in self.validation_resources.merged.containers:
-            container = self.validation_resources.select_container(container_ref)
+            container = self.validation_resources.select_container(container_ref, source="merged")
             limit = self.validation_resources.limits.containers.properties.limit_per_container
 
             if not container:
@@ -317,7 +317,7 @@ class ContainerPropertyListSizeIsOutOfLimits(DataModelRule):
 
         # Single loop over all containers
         for container_ref in self.validation_resources.merged.containers:
-            container = self.validation_resources.select_container(container_ref)
+            container = self.validation_resources.select_container(container_ref, source="merged")
 
             if not container:
                 raise RuntimeError(

--- a/cognite/neat/_data_model/rules/dms/_orchestrator.py
+++ b/cognite/neat/_data_model/rules/dms/_orchestrator.py
@@ -83,7 +83,12 @@ class DmsDataModelRulesOrchestrator(FixProducingOrchestrator):
             local=local,
             limits=self._limits,
             modus_operandi=self._modus_operandi,
-            governed_spaces=request_schema.governed_space_set()
-            if self._alpha_flags and self._alpha_flags.enable_governed_spaces
-            else {request_schema.data_model.space},
+            governed_spaces=self._resolve_governed_spaces(request_schema),
         )
+
+    def _resolve_governed_spaces(self, request_schema: RequestSchema) -> set[str]:
+        if self._alpha_flags and self._alpha_flags.enable_governed_spaces:
+            return request_schema.governed_space_set()
+        if request_schema.extra.governed_spaces:
+            return request_schema.governed_space_set()
+        return {request_schema.data_model.space}

--- a/cognite/neat/_session/_physical.py
+++ b/cognite/neat/_session/_physical.py
@@ -32,10 +32,15 @@ from ._wrappers import session_wrapper
 
 _TOOLKIT_YAML_READ_NOTES = """
     !!! note "Toolkit YAML import"
-        When ``format`` is ``\"toolkit\"``, ``{{ variable }}`` placeholders in module YAML are resolved
-        from Toolkit config (``default.config.yaml``, environment overlays such as ``config.dev.yaml``,
-        and module overrides). Use ``toolkit_env``, ``toolkit_config``, and ``toolkit_version`` to control
-        resolution.
+        When ``format`` is ``\"toolkit\"``:
+
+        - ``{{ variable }}`` placeholders in module YAML are resolved from Toolkit config
+          (``default.config.yaml``, environment overlays such as ``config.dev.yaml``, and module overrides).
+          Use ``toolkit_env``, ``toolkit_config``, and ``toolkit_version`` to control resolution.
+        - Spaces present in the imported module YAML (from ``spaces``, ``views``, and ``containers``) are
+          automatically added to governed spaces metadata. Validators then treat those local module spaces
+          as NEAT-governed without enabling ``enable_governed_spaces`` in ``NeatConfig``. Explicit
+          ``governedSpaces`` from NEAT Excel metadata are not overridden.
 """
 
 

--- a/docs/data_modeling/excel/data_model.md
+++ b/docs/data_modeling/excel/data_model.md
@@ -19,3 +19,5 @@ neat.physical_data_model.read.excel("path/to/excel/file.xlsx")
 # Writing a data model to an Excel file
 neat.physical_data_model.write.excel("path/to/excel/file.xlsx")
 ```
+
+For multi-space toolkit models, pass `skip_other_spaces=False` to include view properties from spaces other than the data model space. See [Toolkit YAML](toolkit_yaml.md) for details.

--- a/docs/data_modeling/toolkit_yaml.md
+++ b/docs/data_modeling/toolkit_yaml.md
@@ -30,3 +30,21 @@ Optional parameters on `read.yaml()`:
 | `toolkit_env` | Select a config overlay (e.g. `"dev"`, `"prod"`) |
 | `toolkit_config` | Merge an explicit config YAML on top of defaults |
 | `toolkit_version` | Override `version` and `viewVersion` template variables |
+
+## Governed spaces
+
+Toolkit modules are often **multi-space**: the data model space plus domain spaces for containers and views.
+
+When reading toolkit YAML, NEAT automatically adds every space found in the imported module (`spaces`, `views`, and `containers`) to governed spaces metadata. Validators then treat those local spaces as NEAT-governed — you do **not** need `enable_governed_spaces=True` in `NeatConfig` for this behavior.
+
+Explicit `governedSpaces` from NEAT Excel metadata are left unchanged.
+
+## Excel export for multi-space models
+
+By default, `write.excel()` only exports view properties in the **data model space** (`skip_other_spaces=True`).
+
+For multi-space toolkit modules, export all spaces with:
+
+```python
+neat.physical_data_model.write.excel("model.xlsx", skip_other_spaces=False)
+```

--- a/docs/data_modeling/toolkit_yaml.md
+++ b/docs/data_modeling/toolkit_yaml.md
@@ -15,6 +15,8 @@ Non-schema YAML (`config.*.yaml`, `build_info.*.yaml`, Yamale files under `valid
 
 When reading a `modules/` tree, template variables are resolved from each file's module path so nested `variables.modules.<module>.*` keys apply correctly.
 
+When `data_model_file` selects one `*.DataModel.yaml` in a module that contains several (for example enterprise + solution), views and other YAML next to that file are imported. Containers those views map to — and containers they `require` — are also imported from sibling folders in the same tree, so solution views that map to enterprise containers still validate (including reverse direct relations). Sibling *views* are not imported and do not appear in `governedSpaces` or Excel.
+
 ## Template variables
 
 Toolkit modules use `{{ variable }}` placeholders in YAML files. When `format="toolkit"`, NEAT resolves these from Toolkit config before import:

--- a/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/Record.container.yaml
+++ b/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/Record.container.yaml
@@ -1,0 +1,8 @@
+space: records_space
+externalId: Record
+properties:
+  status:
+    type:
+      type: enum
+      values:
+        A: {}

--- a/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/Record.view.yaml
+++ b/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/Record.view.yaml
@@ -1,0 +1,10 @@
+space: records_space
+externalId: Record
+version: {{ viewVersion }}
+properties:
+  status:
+    container:
+      space: records_space
+      externalId: Record
+      type: container
+    containerPropertyIdentifier: status

--- a/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/records.Space.yaml
+++ b/tests/data/toolkit_substitution/modules/test/data_modeling/my_model/records.Space.yaml
@@ -1,0 +1,1 @@
+space: records_space

--- a/tests/tests_unit/test_data_model/test_exporters/test_dms_table_exporter.py
+++ b/tests/tests_unit/test_data_model/test_exporters/test_dms_table_exporter.py
@@ -13,6 +13,8 @@ from cognite.neat._data_model.importers._table_importer.data_classes import (
 )
 from cognite.neat._data_model.models.dms import (
     ContainerReference,
+    ContainerRequest,
+    DataModelRequest,
     DirectNodeRelation,
     EqualsFilterData,
     Filter,
@@ -20,7 +22,9 @@ from cognite.neat._data_model.models.dms import (
     InFilterData,
     ListablePropertyTypeDefinition,
     RequestSchema,
+    ViewCorePropertyRequest,
     ViewReference,
+    ViewRequest,
 )
 from cognite.neat._data_model.models.entities import ParsedEntity
 from cognite.neat._utils.useful_types import DataModelTableType
@@ -160,6 +164,36 @@ class TestDMSTableWriter:
     def test_write_view_filter(self, filter: Filter | None, expected: TableViewFilter) -> None:
         writer = DMSTableWriter(self.DEFAULT_SPACE, self.DEFAULT_VERSION, skip_properties_in_other_spaces=True)
         assert writer.write_view_filter(filter) == expected
+
+    def test_write_view_property_with_source_but_no_container_row(self) -> None:
+        schema = RequestSchema(
+            dataModel=DataModelRequest(space="dm_space", externalId="DM", version="v1", views=[]),
+            views=[
+                ViewRequest(
+                    space="dm_space",
+                    externalId="Delivery",
+                    version="v1",
+                    properties={
+                        "destinationCustomerLocation": ViewCorePropertyRequest(
+                            container=ContainerReference(space="dm_space", external_id="Delivery"),
+                            containerPropertyIdentifier="destinationCustomerLocation",
+                            source=ViewReference(space="other_space", external_id="Location", version="v1"),
+                        )
+                    },
+                )
+            ],
+            containers=[
+                ContainerRequest(space="dm_space", externalId="Delivery", properties={}),
+            ],
+        )
+
+        writer = DMSTableWriter("dm_space", "v1", skip_properties_in_other_spaces=False)
+        tables = writer.write_tables(schema)
+
+        exported = next(prop for prop in tables.properties if prop.view_property == "destinationCustomerLocation")
+        assert exported.connection == ParsedEntity("", "direct", properties={})
+        assert exported.min_count == 0
+        assert exported.max_count == 1
 
 
 def test_add_dropdowns_disabled_on_empty_dropdown_sheet() -> None:

--- a/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
+++ b/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
@@ -14,6 +14,7 @@ from cognite.neat._data_model.models.dms import DataModelRequest, RequestSchema,
 from cognite.neat._data_model.models.dms._limits import SchemaLimits
 from cognite.neat._data_model.models.dms._schema import SchemaExtra
 from cognite.neat._data_model.rules.dms._ai_readiness import EnumerationMissingName
+from cognite.neat._data_model.rules.dms._connections import ReverseConnectionContainerMissing
 from cognite.neat._data_model.rules.dms._orchestrator import DmsDataModelRulesOrchestrator
 from cognite.neat._exceptions import FileReadException
 
@@ -24,6 +25,28 @@ CYCLIC_REVERSE_ONLY = Path(__file__).resolve().parents[3] / "data" / "snapshots"
 
 def _import_schema(model_dir: Path, **kwargs: Any) -> RequestSchema:
     return DMSAPIImporter.from_yaml(model_dir, **kwargs).to_data_model()
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _empty_orchestrator() -> DmsDataModelRulesOrchestrator:
+    return DmsDataModelRulesOrchestrator(
+        cdf_snapshot=SchemaSnapshot(data_model={}, views={}, containers={}, spaces={}, node_types={}),
+        limits=SchemaLimits(),
+        modus_operandi="additive",
+    )
+
+
+def _ent_sol_module(tmp_path: Path) -> tuple[Path, Path, Path]:
+    modeling = tmp_path / "project" / "modules" / "emergency360" / "data_modeling"
+    ent, sol = modeling / "dm_ent", modeling / "dm_sol"
+    ent.mkdir(parents=True)
+    sol.mkdir(parents=True)
+    _write(tmp_path / "project" / "default.config.yaml", "variables:\n  viewVersion: v1\n")
+    return modeling, ent, sol
 
 
 class TestToolkitYamlImport:
@@ -258,6 +281,109 @@ class TestToolkitYamlImport:
     def test_yamale_schema_files_are_not_treated_as_dms_resources(self, tmp_path: Path) -> None:
         assert DMSAPIImporter._is_toolkit_schema_yaml(tmp_path / "data_model_container.yaml") is False
         assert DMSAPIImporter._is_toolkit_schema_yaml(tmp_path / "Tag.Container.yaml") is True
+
+    def test_selected_data_model_does_not_import_sibling_model_spaces(self, tmp_path: Path) -> None:
+        """Enterprise + solution YAML in one module: selecting the enterprise DataModel must not
+        pull solution views/spaces into the schema (those showed up in Excel governedSpaces)."""
+        modeling, ent, sol = _ent_sol_module(tmp_path)
+        _write(
+            ent / "Ent.datamodel.yaml",
+            "space: sp_ent\nexternalId: dm_ent\nversion: v1\n"
+            "views:\n  - space: sp_ent\n    externalId: EntView\n    version: v1\n",
+        )
+        _write(ent / "EntView.view.yaml", "space: sp_ent\nexternalId: EntView\nversion: v1\nproperties: {}\n")
+        _write(
+            sol / "Sol.datamodel.yaml",
+            "space: sp_sol\nexternalId: dm_sol\nversion: v1\n"
+            "views:\n  - space: sp_sol\n    externalId: SolView\n    version: v1\n",
+        )
+        _write(sol / "SolView.view.yaml", "space: sp_sol\nexternalId: SolView\nversion: v1\nproperties: {}\n")
+        _write(sol / "sp_sol.Space.yaml", "space: sp_sol\nname: solution\n")
+
+        schema = _import_schema(modeling, data_model_file="Ent.datamodel.yaml")
+        assert schema.data_model.space == "sp_ent"
+        assert {view.space for view in schema.views} == {"sp_ent"}
+        assert {view.external_id for view in schema.views} == {"EntView"}
+        assert all(space.space != "sp_sol" for space in schema.spaces)
+        assert "sp_sol" not in schema.governed_space_set()
+
+    def test_selected_solution_model_imports_referenced_enterprise_containers(self, tmp_path: Path) -> None:
+        """Solution views map to enterprise containers in a sibling folder. Those containers
+        (and containers they require) must be imported so reverse/direct relations validate."""
+        modeling, ent, sol = _ent_sol_module(tmp_path)
+        _write(
+            ent / "Ent.datamodel.yaml",
+            "space: sp_ent\nexternalId: dm_ent\nversion: v1\n"
+            "views:\n  - space: sp_ent\n    externalId: EntView\n    version: v1\n",
+        )
+        _write(ent / "EntView.view.yaml", "space: sp_ent\nexternalId: EntView\nversion: v1\nproperties: {}\n")
+        _write(
+            ent / "EntContainer.container.yaml",
+            "space: sp_ent\nexternalId: EntContainer\n"
+            "constraints:\n  needsBase:\n    require:\n      space: sp_ent\n"
+            "      externalId: EntBase\n      type: container\n    constraintType: requires\n"
+            "properties:\n  personRel:\n    type:\n      type: direct\n",
+        )
+        _write(
+            ent / "EntBase.container.yaml",
+            "space: sp_ent\nexternalId: EntBase\nproperties:\n  name:\n    type:\n      type: text\n",
+        )
+        _write(
+            ent / "EntUnused.container.yaml",
+            "space: sp_ent\nexternalId: EntUnused\nproperties:\n  name:\n    type:\n      type: text\n",
+        )
+        _write(ent / "sp_ent.Space.yaml", "space: sp_ent\nname: enterprise\n")
+        _write(
+            sol / "Sol.datamodel.yaml",
+            "space: sp_sol\nexternalId: dm_sol\nversion: v1\n"
+            "views:\n  - space: sp_sol\n    externalId: PobStay\n    version: v1\n"
+            "  - space: sp_sol\n    externalId: Person\n    version: v1\n",
+        )
+        _write(
+            sol / "PobStay.view.yaml",
+            "space: sp_sol\nexternalId: PobStay\nversion: v1\n"
+            "filter:\n  hasData:\n    - type: container\n      space: sp_ent\n"
+            "      externalId: EntContainer\n"
+            "properties:\n  personRel:\n    container:\n      space: sp_ent\n"
+            "      externalId: EntContainer\n      type: container\n"
+            "    containerPropertyIdentifier: personRel\n"
+            "    source:\n      space: sp_sol\n      externalId: Person\n"
+            "      version: v1\n      type: view\n",
+        )
+        _write(
+            sol / "Person.view.yaml",
+            "space: sp_sol\nexternalId: Person\nversion: v1\n"
+            "properties:\n  pobStays:\n    connectionType: single_reverse_direct_relation\n"
+            "    source:\n      space: sp_sol\n      externalId: PobStay\n"
+            "      version: v1\n      type: view\n"
+            "    through:\n      source:\n        space: sp_sol\n        externalId: PobStay\n"
+            "        version: v1\n        type: view\n      identifier: personRel\n",
+        )
+        _write(sol / "sp_sol.Space.yaml", "space: sp_sol\nname: solution\n")
+
+        schema = _import_schema(modeling, data_model_file="Sol.datamodel.yaml")
+        assert schema.data_model.space == "sp_sol"
+        assert {view.external_id for view in schema.views} == {"PobStay", "Person"}
+        assert {container.external_id for container in schema.containers} == {"EntContainer", "EntBase"}
+        assert {container.space for container in schema.containers} == {"sp_ent"}
+        assert {space.space for space in schema.spaces} == {"sp_sol", "sp_ent"}
+        assert "sp_ent" in schema.governed_space_set()
+
+        orchestrator = _empty_orchestrator()
+        orchestrator.run(schema)
+        assert orchestrator.issues.by_code().get(ReverseConnectionContainerMissing.code, []) == []
+
+    def test_container_ids_from_view_reads_mapping_not_view_sources(self) -> None:
+        view = {
+            "filter": {"hasData": [{"type": "container", "space": "sp_ent", "externalId": "E360PobStay"}]},
+            "properties": {
+                "personRel": {
+                    "container": {"space": "sp_ent", "externalId": "E360PobStay", "type": "container"},
+                    "source": {"space": "sp_sol", "externalId": "Person", "type": "view"},
+                }
+            },
+        }
+        assert DMSAPIImporter._container_ids_from_view(view) == {("sp_ent", "E360PobStay")}
 
     def test_repo_cdf_toml_does_not_hijack_unrelated_paths(self) -> None:
         assert find_toolkit_project_root(CYCLIC_REVERSE_ONLY) is None

--- a/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
+++ b/tests/tests_unit/test_data_model/test_importers/test_toolkit_yaml_import.py
@@ -3,12 +3,18 @@ from typing import Any
 
 import pytest
 
+from cognite.neat._data_model._snapshot import SchemaSnapshot
 from cognite.neat._data_model.importers import DMSAPIImporter
 from cognite.neat._data_model.importers._toolkit_variables import (
     find_toolkit_project_root,
+    populate_toolkit_governed_spaces,
     substitute_toolkit_variables,
 )
-from cognite.neat._data_model.models.dms import RequestSchema
+from cognite.neat._data_model.models.dms import DataModelRequest, RequestSchema, SpaceRequest
+from cognite.neat._data_model.models.dms._limits import SchemaLimits
+from cognite.neat._data_model.models.dms._schema import SchemaExtra
+from cognite.neat._data_model.rules.dms._ai_readiness import EnumerationMissingName
+from cognite.neat._data_model.rules.dms._orchestrator import DmsDataModelRulesOrchestrator
 from cognite.neat._exceptions import FileReadException
 
 TOOLKIT_FIXTURE = Path(__file__).resolve().parents[3] / "data" / "toolkit_substitution"
@@ -21,7 +27,7 @@ def _import_schema(model_dir: Path, **kwargs: Any) -> RequestSchema:
 
 
 class TestToolkitYamlImport:
-    def test_import_resolves_variables(self) -> None:
+    def test_import_resolves_variables_and_derives_governed_spaces(self) -> None:
         assert find_toolkit_project_root(DATA_MODEL_DIR) == TOOLKIT_FIXTURE
 
         schema = _import_schema(DATA_MODEL_DIR)
@@ -29,6 +35,12 @@ class TestToolkitYamlImport:
         assert schema.data_model.space == "module_space"
         assert schema.data_model.external_id == "MyModel"
         assert schema.data_model.version == "1"
+        assert schema.governed_space_set() == {"module_space", "records_space"}
+
+        view_spaces = {view.space for view in schema.views}
+        container_spaces = {container.space for container in schema.containers}
+        assert view_spaces == {"module_space", "records_space"}
+        assert container_spaces == {"module_space", "records_space"}
 
     @pytest.mark.parametrize(
         ("kwargs", "assertions"),
@@ -253,3 +265,30 @@ class TestToolkitYamlImport:
     def test_substitute_unresolved_raises(self) -> None:
         with pytest.raises(FileReadException, match="Unresolved toolkit variable"):
             substitute_toolkit_variables("space: {{ missingVar }}", {}, source="test.yaml")
+
+    def test_populate_toolkit_governed_spaces_respects_explicit_metadata(self) -> None:
+        schema = RequestSchema(
+            dataModel=DataModelRequest(space="dm_space", externalId="Model", version="v1", views=[]),
+            extra=SchemaExtra(governedSpaces=[SpaceRequest(space="explicit_space")]),
+        )
+        updated = populate_toolkit_governed_spaces(schema)
+        assert {space.space for space in updated.extra.governed_spaces} == {"explicit_space"}
+
+    def test_import_validates_containers_in_derived_governed_spaces(self) -> None:
+        schema = _import_schema(DATA_MODEL_DIR)
+        orchestrator = DmsDataModelRulesOrchestrator(
+            cdf_snapshot=SchemaSnapshot(
+                data_model={},
+                views={},
+                containers={},
+                spaces={},
+                node_types={},
+            ),
+            limits=SchemaLimits(),
+            modus_operandi="additive",
+        )
+        orchestrator.run(schema)
+
+        enum_issues = orchestrator.issues.by_code().get(EnumerationMissingName.code, [])
+        assert len(enum_issues) == 1
+        assert "records_space:Record" in enum_issues[0].message


### PR DESCRIPTION
﻿# Description

When reading toolkit YAML, mark all spaces in the imported module as NEAT-governed so multi-space local models validate without `enable_governed_spaces`. Also fix Excel export for view properties that declare a `source` without a matching container property row, and document `skip_other_spaces=False` for multi-space exports. Depends on the Toolkit variable-substitution PR.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Added

- Automatically treat spaces from toolkit YAML imports as governed for validation.
- Support Excel export of view direct relations that lack a matching container property row.

### Improved

- Document multi-space toolkit import and `skip_other_spaces=False` for Excel export.
