### PR TITLE
Fix ArbitraryTypeWarning printed during pydantic model validation

### DIFF
--- a/cognite/neat/_utils/http_client/_tracker.py
+++ b/cognite/neat/_utils/http_client/_tracker.py
@@ -1,8 +1,6 @@
 import threading
 from dataclasses import dataclass, field
-from typing import Annotated
-
-from pydantic import SkipValidation
+from typing import Any
 
 
 @dataclass
@@ -18,7 +16,10 @@ class ItemsRequestTracker:
     """
 
     max_failures_before_abort: int = -1  # -1 means no early abort
-    lock: Annotated[threading.Lock, SkipValidation] = field(default_factory=threading.Lock, init=False)
+    # Typed as Any so pydantic (which inspects this dataclass's fields when it is embedded in a
+    # pydantic model) does not try to build a schema for threading.Lock, which is actually a
+    # factory function at runtime rather than a real type.
+    lock: Any = field(default_factory=threading.Lock, init=False)
     failed_split_count: int = field(default=0, init=False)
 
     def register_failure(self) -> None:

--- a/cognite/neat/_utils/http_client/_tracker.py
+++ b/cognite/neat/_utils/http_client/_tracker.py
@@ -1,5 +1,8 @@
 import threading
 from dataclasses import dataclass, field
+from typing import Annotated
+
+from pydantic import SkipValidation
 
 
 @dataclass
@@ -15,7 +18,7 @@ class ItemsRequestTracker:
     """
 
     max_failures_before_abort: int = -1  # -1 means no early abort
-    lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+    lock: Annotated[threading.Lock, SkipValidation] = field(default_factory=threading.Lock, init=False)
     failed_split_count: int = field(default=0, init=False)
 
     def register_failure(self) -> None:


### PR DESCRIPTION
# Description

`ItemsRequestTracker.lock` was annotated as `threading.Lock`, but at runtime that's a factory function, not a type. Pydantic inspects the nested dataclass embedded in `ItemsRequest` and warns since it can't resolve a real type for the field. Annotated the field with `SkipValidation` so Pydantic skips schema generation for it.

This fixes a spurious `ArbitraryTypeWarning` showing up during Toolkit validation.
Before:
<img width="951" height="157" alt="Screenshot 2026-08-26 at 09 51 55" src="https://github.com/user-attachments/assets/ffe62f22-4841-4c23-a560-b7598adb7f54" />

After:
<img width="936" height="79" alt="Screenshot 2026-08-26 at 09 52 36" src="https://github.com/user-attachments/assets/020ecb33-6d91-485c-b532-ddf094fd397e" />

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix spurious `ArbitraryTypeWarning` printed to the console when Neat is used with Cognite Toolkit